### PR TITLE
US-102: reject duplicate POST /links (#82)

### DIFF
--- a/backend/app/routers/links.py
+++ b/backend/app/routers/links.py
@@ -13,7 +13,7 @@ from fastapi.responses import JSONResponse
 from app.dependencies import get_current_user
 from app.schemas.user import UserRead
 from app.services.lab_service import LEGACY_SCHEMA_ERROR
-from app.services.link_service import link_service
+from app.services.link_service import DuplicateLinkError, link_service
 
 
 router = APIRouter(prefix="/api/labs", tags=["links"])
@@ -97,6 +97,16 @@ async def create_link(
             to_endpoint,
             style_override=style_override,
             idempotency_key=idempotency_key,
+        )
+    except DuplicateLinkError as exc:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "code": 409,
+                "status": "fail",
+                "message": "link already exists",
+                "existing_link": exc.existing_link,
+            },
         )
     except KeyError as exc:
         return JSONResponse(

--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -23,6 +23,28 @@ from app.services.ws_hub import ws_hub
 _IDEMPOTENCY_CACHE_MAX = 1024
 
 
+class DuplicateLinkError(Exception):
+    """Raised when a link with the same canonical port pair already exists."""
+
+    def __init__(self, existing_link: dict) -> None:
+        super().__init__("link already exists")
+        self.existing_link = existing_link
+
+
+def _endpoint_key(ep: dict) -> tuple:
+    """Return a hashable key for a normalised endpoint dict."""
+    if "network_id" in ep:
+        return ("network", int(ep["network_id"]))
+    return ("node", int(ep["node_id"]), int(ep.get("interface_index", 0)))
+
+
+def _link_pair_key(ep_a: dict, ep_b: dict) -> tuple:
+    """Return a canonical (order-independent) key for a {from, to} pair."""
+    ka = _endpoint_key(ep_a)
+    kb = _endpoint_key(ep_b)
+    return (min(ka, kb), max(ka, kb))
+
+
 def _refcount(lab_data: dict, network_id: int) -> int:
     """Count link endpoints referencing ``network_id``."""
     return sum(
@@ -227,6 +249,22 @@ class LinkService:
             data = LabService.read_lab_json_static(normalized)
             networks = data.setdefault("networks", {})
             links = data.setdefault("links", [])
+
+            # Duplicate detection (US-102): treat {a,b} and {b,a} as equivalent.
+            target_key = _link_pair_key(endpoint_a, endpoint_b)
+            for existing in links:
+                ex_from = existing.get("from")
+                ex_to = existing.get("to")
+                if isinstance(ex_from, dict) and isinstance(ex_to, dict):
+                    try:
+                        ex_key = _link_pair_key(
+                            _normalize_endpoint(ex_from),
+                            _normalize_endpoint(ex_to),
+                        )
+                    except (ValueError, TypeError):
+                        continue
+                    if ex_key == target_key:
+                        raise DuplicateLinkError(_link_with_state(existing))
 
             link_payload: dict
             network_payload: Optional[dict] = None

--- a/backend/tests/test_links_api.py
+++ b/backend/tests/test_links_api.py
@@ -482,3 +482,112 @@ async def test_create_link_acquires_lock_and_publishes_ws_event(
     assert publish_mock.await_count >= 1
     # Lock file should exist.
     assert (patched_route_settings.LABS_DIR / f"{lab_name}.lock").exists()
+
+
+# ---------------------------------------------------------------------------
+# US-102 — duplicate {from,to} pair detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_link_returns_409(
+    patched_route_settings, auth_override, reset_idempotency, ws_recorder,
+):
+    """Second POST with identical endpoints must return 409 + existing_link."""
+    lab_name = _seed_lab(
+        patched_route_settings.LABS_DIR,
+        nodes={"1": _node(1)},
+        networks={"5": _explicit_network(5, "lan")},
+    )
+    body = {"from": {"node_id": 1, "interface_index": 0}, "to": {"network_id": 5}}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp1 = await c.post(f"/api/labs/{lab_name}/links", json=body)
+        assert resp1.status_code == 201
+        created_id = resp1.json()["link"]["id"]
+
+        resp2 = await c.post(f"/api/labs/{lab_name}/links", json=body)
+
+    assert resp2.status_code == 409
+    body2 = resp2.json()
+    assert body2["code"] == 409
+    assert body2["status"] == "fail"
+    assert body2["message"] == "link already exists"
+    assert body2["existing_link"]["id"] == created_id
+
+    # Lab must still contain only one link.
+    saved = json.loads((patched_route_settings.LABS_DIR / lab_name).read_text())
+    assert len(saved["links"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_link_symmetric_pair_returns_409(
+    patched_route_settings, auth_override, reset_idempotency, ws_recorder,
+):
+    """B→A after A→B is detected as a duplicate (bidirectional dedup)."""
+    lab_name = _seed_lab(
+        patched_route_settings.LABS_DIR,
+        nodes={"1": _node(1)},
+        networks={"5": _explicit_network(5, "lan")},
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp1 = await c.post(
+            f"/api/labs/{lab_name}/links",
+            json={"from": {"node_id": 1, "interface_index": 0}, "to": {"network_id": 5}},
+        )
+        assert resp1.status_code == 201
+        created_id = resp1.json()["link"]["id"]
+
+        # Swap from/to — logically the same port pair.
+        resp2 = await c.post(
+            f"/api/labs/{lab_name}/links",
+            json={"from": {"network_id": 5}, "to": {"node_id": 1, "interface_index": 0}},
+        )
+
+    assert resp2.status_code == 409
+    body2 = resp2.json()
+    assert body2["existing_link"]["id"] == created_id
+
+    saved = json.loads((patched_route_settings.LABS_DIR / lab_name).read_text())
+    assert len(saved["links"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_node_to_node_link_returns_409(
+    patched_route_settings, auth_override, reset_idempotency, ws_recorder,
+):
+    """Duplicate node↔network pair pre-seeded in links[] is rejected with 409."""
+    # Pre-seed a lab with an existing node→network link so the dedup check fires
+    # against links already stored in the file.
+    lab_name = _seed_lab(
+        patched_route_settings.LABS_DIR,
+        nodes={"1": _node(1)},
+        networks={"3": _explicit_network(3, "core")},
+        links=[
+            {
+                "id": "lnk_001",
+                "from": {"node_id": 1, "interface_index": 0},
+                "to": {"network_id": 3},
+                "style_override": None, "label": "", "color": "", "width": "1",
+                "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+            }
+        ],
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Duplicate of the pre-existing link.
+        resp = await c.post(
+            f"/api/labs/{lab_name}/links",
+            json={"from": {"node_id": 1, "interface_index": 0}, "to": {"network_id": 3}},
+        )
+
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["code"] == 409
+    assert body["message"] == "link already exists"
+    assert body["existing_link"]["id"] == "lnk_001"
+
+    # Link count must stay at 1.
+    saved = json.loads((patched_route_settings.LABS_DIR / lab_name).read_text())
+    assert len(saved["links"]) == 1


### PR DESCRIPTION
Closes #82. Part of #80. Unblocks US-103 (#83).

## Summary
- Added `DuplicateLinkError` exception and `_endpoint_key` / `_link_pair_key` helpers to `link_service.py` to compute a canonical, order-independent key for each `{from, to}` port pair
- `create_link` now scans `links[]` before any mutation; if a link with the same canonical key already exists it raises `DuplicateLinkError` (bidirectional: A→B and B→A hash to the same key)
- `POST /labs/{id}/links` router catches `DuplicateLinkError` and returns **HTTP 409** with `{code:409, status:"fail", message:"link already exists", existing_link:{...}}`
- The existing idempotency-key replay path (200) is unchanged — dedup is a separate, earlier check

## Test plan
- [x] `test_duplicate_link_returns_409` — second POST with identical endpoints returns 409 + existing link payload; lab still has exactly one link
- [x] `test_duplicate_link_symmetric_pair_returns_409` — B→A after A→B also returns 409 (bidirectional dedup confirmed)
- [x] `test_duplicate_node_to_node_link_returns_409` — pre-seeded link in lab.json triggers 409 on matching POST
- [x] All 10 pre-existing link tests continue to pass (102/102 suite-wide)