### PR TITLE
US-105: node-type-aware interface naming (#85)

### DIFF
--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -20,7 +20,7 @@ from app.services.html5_service import Html5SessionError, Html5SessionService
 from app.services.lab_lock import lab_lock
 from app.services.lab_service import LEGACY_SCHEMA_ERROR, LabService, _normalize_relative_lab_path
 from app.services.node_runtime_service import NodeRuntimeError, NodeRuntimeService
-from app.services.template_service import TemplateError, TemplateService, _icon_filename_for
+from app.services.template_service import TemplateError, TemplateService, _icon_filename_for, render_interface_name
 from app.services.ws_hub import ws_hub
 
 router = APIRouter(prefix="/api/labs", tags=["labs"])
@@ -105,10 +105,26 @@ def _scoped_lab_path(current_user: UserRead, raw_path: str, treat_as_absolute: b
     return f"{root}/{normalized}"
 
 
-def _default_interfaces(node_type: str, ethernet_count: int) -> list[dict]:
+def _default_interfaces(
+    node_type: str,
+    ethernet_count: int,
+    interface_naming_scheme: str | None = None,
+    template_interface_naming: dict | None = None,
+) -> list[dict]:
+    """Generate default interface list for a node.
+
+    Priority (highest first):
+    1. ``interface_naming_scheme`` — node-level override (US-105)
+    2. ``template_interface_naming["format"]`` — template-level format string
+    3. Hard-coded fallback: ``Gi{port}`` for qemu, ``eth{n}`` for everything else
+    """
     interfaces = []
     for index in range(ethernet_count):
-        if node_type == "qemu":
+        if interface_naming_scheme is not None:
+            name = render_interface_name(interface_naming_scheme, index)
+        elif template_interface_naming and "format" in template_interface_naming:
+            name = render_interface_name(template_interface_naming["format"], index)
+        elif node_type == "qemu":
             name = f"Gi{index + 1}"
         else:
             name = f"eth{index}"
@@ -232,7 +248,12 @@ def _build_node_payload(
         "config_list": [],
         "sat": 0,
         "computed_sat": 0,
-        "interfaces": _default_interfaces(request.type, ethernet),
+        "interfaces": _default_interfaces(
+            request.type,
+            ethernet,
+            interface_naming_scheme=getattr(request, "interface_naming_scheme", None),
+            template_interface_naming=dict(template.interface_naming or {}),
+        ),
         "extras": merged_extras,
     }
 

--- a/backend/app/schemas/node.py
+++ b/backend/app/schemas/node.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional, Literal, List
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.schemas.port import PortPosition
 
@@ -45,6 +45,13 @@ class NodeBase(BaseModel):
     computed_sat: int = 0
     interfaces: List[NodeInterface] = Field(default_factory=list)
     extras: Dict[str, Any] = Field(default_factory=dict)
+    interface_naming_scheme: Optional[str] = None
+
+    @model_validator(mode='after')
+    def _check_iface_naming_scheme(self):
+        if self.type == 'docker' and self.interface_naming_scheme not in (None, 'eth{n}'):
+            raise ValueError("Docker nodes use eth{n} naming; field is system-fixed")
+        return self
 
 
 class NodeRead(NodeBase):
@@ -71,6 +78,13 @@ class NodeCreate(BaseModel):
     top: int = 0
     icon: Optional[str] = None
     extras: Dict[str, Any] = Field(default_factory=dict)
+    interface_naming_scheme: Optional[str] = None
+
+    @model_validator(mode='after')
+    def _check_iface_naming_scheme(self):
+        if self.type == 'docker' and self.interface_naming_scheme not in (None, 'eth{n}'):
+            raise ValueError("Docker nodes use eth{n} naming; field is system-fixed")
+        return self
 
 
 class NodeBatchCreate(BaseModel):
@@ -89,6 +103,13 @@ class NodeBatchCreate(BaseModel):
     top: int = 0
     icon: Optional[str] = None
     extras: Dict[str, Any] = Field(default_factory=dict)
+    interface_naming_scheme: Optional[str] = None
+
+    @model_validator(mode='after')
+    def _check_iface_naming_scheme(self):
+        if self.type == 'docker' and self.interface_naming_scheme not in (None, 'eth{n}'):
+            raise ValueError("Docker nodes use eth{n} naming; field is system-fixed")
+        return self
 
 
 class NodeUpdate(BaseModel):

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -300,6 +300,17 @@ class TemplateError(Exception):
 _INTERFACE_NAMING_FORMAT_PLACEHOLDERS = ("{n}", "{slot}", "{port}")
 
 
+def render_interface_name(fmt: str, index: int) -> str:
+    """Render an interface name from a format string and a 0-based interface index.
+
+    Supported placeholders (matching ``interface_naming.format`` contract):
+    - ``{n}``    — 0-based index (e.g. ``eth{n}`` → ``eth0``)
+    - ``{slot}`` — alias for ``{n}``
+    - ``{port}`` — 1-based index (e.g. ``Gi{port}`` → ``Gi1``)
+    """
+    return fmt.replace("{n}", str(index)).replace("{slot}", str(index)).replace("{port}", str(index + 1))
+
+
 def _validate_interface_naming(payload: dict[str, Any], source: str) -> dict[str, Any]:
     """Validate the optional ``interface_naming`` block on a template YAML.
 

--- a/backend/tests/test_node_schema_naming.py
+++ b/backend/tests/test_node_schema_naming.py
@@ -1,0 +1,197 @@
+"""Tests for US-105 — node-type-aware interface naming (schema + router layer)."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from app.routers.labs import _default_interfaces
+from app.schemas.node import NodeBase, NodeCreate, NodeBatchCreate
+from app.services.template_service import render_interface_name
+
+
+# ---------------------------------------------------------------------------
+# render_interface_name unit tests
+# ---------------------------------------------------------------------------
+
+class TestRenderInterfaceName:
+    def test_n_placeholder_zero_based(self):
+        assert render_interface_name("eth{n}", 0) == "eth0"
+        assert render_interface_name("eth{n}", 3) == "eth3"
+
+    def test_slot_alias_for_n(self):
+        assert render_interface_name("Gi0/{slot}", 2) == "Gi0/2"
+
+    def test_port_placeholder_one_based(self):
+        assert render_interface_name("Gi{port}", 0) == "Gi1"
+        assert render_interface_name("Gi{port}", 3) == "Gi4"
+
+    def test_combined_placeholders(self):
+        # Unlikely but supported — both {n} and {port} in same format
+        assert render_interface_name("{n}-{port}", 0) == "0-1"
+
+    def test_no_placeholder_passthrough(self):
+        # A format without any placeholder is valid (already caught by _validate_interface_naming)
+        # but render_interface_name doesn't add extra validation — it just returns the string.
+        assert render_interface_name("loopback", 5) == "loopback"
+
+
+# ---------------------------------------------------------------------------
+# _default_interfaces priority tests
+# ---------------------------------------------------------------------------
+
+class TestDefaultInterfaces:
+    def test_fallback_qemu_no_scheme(self):
+        ifaces = _default_interfaces("qemu", 3)
+        assert [i["name"] for i in ifaces] == ["Gi1", "Gi2", "Gi3"]
+
+    def test_fallback_docker_no_scheme(self):
+        ifaces = _default_interfaces("docker", 2)
+        assert [i["name"] for i in ifaces] == ["eth0", "eth1"]
+
+    def test_node_scheme_overrides_fallback(self):
+        ifaces = _default_interfaces("qemu", 3, interface_naming_scheme="xe-0/0/{n}")
+        assert [i["name"] for i in ifaces] == ["xe-0/0/0", "xe-0/0/1", "xe-0/0/2"]
+
+    def test_node_scheme_overrides_template(self):
+        ifaces = _default_interfaces(
+            "qemu",
+            2,
+            interface_naming_scheme="eth{n}",
+            template_interface_naming={"format": "Gi{port}"},
+        )
+        assert [i["name"] for i in ifaces] == ["eth0", "eth1"]
+
+    def test_template_format_used_when_no_node_scheme(self):
+        ifaces = _default_interfaces(
+            "qemu",
+            3,
+            interface_naming_scheme=None,
+            template_interface_naming={"format": "Gi{port}"},
+        )
+        assert [i["name"] for i in ifaces] == ["Gi1", "Gi2", "Gi3"]
+
+    def test_template_explicit_not_used_for_generation(self):
+        # template_interface_naming with 'explicit' (not 'format') should not
+        # be applied by _default_interfaces; it falls back to the type default.
+        ifaces = _default_interfaces(
+            "qemu",
+            2,
+            interface_naming_scheme=None,
+            template_interface_naming={"explicit": ["fa0/0", "fa0/1"]},
+        )
+        assert [i["name"] for i in ifaces] == ["Gi1", "Gi2"]
+
+    def test_interface_structure(self):
+        ifaces = _default_interfaces("docker", 1)
+        assert ifaces[0] == {
+            "index": 0,
+            "name": "eth0",
+            "planned_mac": None,
+            "port_position": None,
+            "network_id": 0,
+        }
+
+    def test_zero_count(self):
+        assert _default_interfaces("qemu", 0) == []
+
+
+# ---------------------------------------------------------------------------
+# NodeBase / NodeCreate / NodeBatchCreate — model_validator tests
+# ---------------------------------------------------------------------------
+
+def _make_node_base(**kwargs):
+    defaults = dict(
+        id=1,
+        name="n1",
+        type="docker",
+        template="alpine",
+        image="alpine:latest",
+        console="telnet",
+    )
+    defaults.update(kwargs)
+    return NodeBase(**defaults)
+
+
+class TestNodeBaseValidator:
+    def test_docker_none_scheme_accepted(self):
+        node = _make_node_base(type="docker", interface_naming_scheme=None)
+        assert node.interface_naming_scheme is None
+
+    def test_docker_eth_n_scheme_accepted(self):
+        node = _make_node_base(type="docker", interface_naming_scheme="eth{n}")
+        assert node.interface_naming_scheme == "eth{n}"
+
+    def test_docker_custom_scheme_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            _make_node_base(type="docker", interface_naming_scheme="Gi{port}")
+        assert "Docker nodes use eth{n} naming" in str(exc_info.value)
+
+    def test_qemu_any_scheme_accepted(self):
+        node = _make_node_base(type="qemu", interface_naming_scheme="xe-0/0/{n}")
+        assert node.interface_naming_scheme == "xe-0/0/{n}"
+
+    def test_iol_any_scheme_accepted(self):
+        node = _make_node_base(type="iol", interface_naming_scheme="Gi{port}")
+        assert node.interface_naming_scheme == "Gi{port}"
+
+    def test_default_is_none(self):
+        node = _make_node_base(type="qemu")
+        assert node.interface_naming_scheme is None
+
+
+class TestNodeCreateValidator:
+    def test_docker_rejects_custom_scheme(self):
+        with pytest.raises(ValidationError) as exc_info:
+            NodeCreate(
+                name="n1",
+                type="docker",
+                template="alpine",
+                image="alpine:latest",
+                interface_naming_scheme="Gi{port}",
+            )
+        assert "Docker nodes use eth{n} naming" in str(exc_info.value)
+
+    def test_docker_accepts_eth_n(self):
+        nc = NodeCreate(
+            name="n1",
+            type="docker",
+            template="alpine",
+            image="alpine:latest",
+            interface_naming_scheme="eth{n}",
+        )
+        assert nc.interface_naming_scheme == "eth{n}"
+
+    def test_qemu_accepts_arbitrary_scheme(self):
+        nc = NodeCreate(
+            name="n1",
+            type="qemu",
+            template="vyos",
+            image="vyos-1.4",
+            interface_naming_scheme="eth{n}",
+        )
+        assert nc.interface_naming_scheme == "eth{n}"
+
+
+class TestNodeBatchCreateValidator:
+    def test_docker_rejects_custom_scheme(self):
+        with pytest.raises(ValidationError) as exc_info:
+            NodeBatchCreate(
+                name_prefix="R",
+                type="docker",
+                template="alpine",
+                image="alpine:latest",
+                interface_naming_scheme="Gi{n}",
+            )
+        assert "Docker nodes use eth{n} naming" in str(exc_info.value)
+
+    def test_qemu_accepts_scheme(self):
+        nb = NodeBatchCreate(
+            name_prefix="R",
+            type="qemu",
+            template="vyos",
+            image="vyos-1.4",
+            interface_naming_scheme="eth{n}",
+        )
+        assert nb.interface_naming_scheme == "eth{n}"

--- a/frontend/src/lib/services/interfaceNaming.ts
+++ b/frontend/src/lib/services/interfaceNaming.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * US-105 — Node-type-aware interface naming.
+ *
+ * Pure helper that renders an interface name from a format string and a
+ * 0-based interface index, using the same placeholder semantics as the
+ * backend's ``render_interface_name``:
+ *
+ * - ``{n}``    — 0-based index  (e.g. ``eth{n}``    → ``eth0``)
+ * - ``{slot}`` — alias for ``{n}``
+ * - ``{port}`` — 1-based index  (e.g. ``Gi{port}``  → ``Gi1``)
+ *
+ * When ``scheme`` is null/undefined the caller should fall back to the
+ * literal ``iface.name`` stored in the lab JSON.
+ */
+export function formatInterfaceName(scheme: string | null | undefined, index: number): string {
+	if (!scheme) return '';
+	return scheme
+		.replace(/\{n\}/g, String(index))
+		.replace(/\{slot\}/g, String(index))
+		.replace(/\{port\}/g, String(index + 1));
+}

--- a/frontend/tests/interfaceNaming.test.ts
+++ b/frontend/tests/interfaceNaming.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * US-105 — formatInterfaceName table-driven tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatInterfaceName } from '$lib/services/interfaceNaming';
+
+describe('formatInterfaceName', () => {
+	const cases: [string | null | undefined, number, string][] = [
+		// {n} — 0-based
+		['eth{n}', 0, 'eth0'],
+		['eth{n}', 3, 'eth3'],
+		// {slot} — alias for {n}
+		['Gi0/{slot}', 0, 'Gi0/0'],
+		['Gi0/{slot}', 2, 'Gi0/2'],
+		// {port} — 1-based
+		['Gi{port}', 0, 'Gi1'],
+		['Gi{port}', 3, 'Gi4'],
+		// juniper-style
+		['xe-0/0/{n}', 0, 'xe-0/0/0'],
+		['xe-0/0/{n}', 5, 'xe-0/0/5'],
+		// mikrotik-style
+		['eth-{port}', 0, 'eth-1'],
+		['eth-{port}', 2, 'eth-3'],
+		// cisco iosv l2
+		['Gi0/{n}', 1, 'Gi0/1'],
+		// null scheme returns empty string (caller should fall back to iface.name)
+		[null, 0, ''],
+		[undefined, 0, ''],
+		// empty string returns empty string
+		['', 2, ''],
+	];
+
+	it.each(cases)('formatInterfaceName(%s, %d) → %s', (scheme, index, expected) => {
+		expect(formatInterfaceName(scheme, index)).toBe(expected);
+	});
+
+	it('replaces all occurrences of {n} in the format string', () => {
+		expect(formatInterfaceName('{n}-{n}', 2)).toBe('2-2');
+	});
+
+	it('replaces all occurrences of {port} in the format string', () => {
+		expect(formatInterfaceName('{port}/{port}', 0)).toBe('1/1');
+	});
+});


### PR DESCRIPTION
Closes #85. Part of #80.

## Summary
- Adds `interface_naming_scheme: Optional[str]` to `NodeBase`, `NodeCreate`, and `NodeBatchCreate` schemas
- Pydantic V2 `model_validator(mode='after')` rejects any scheme other than `None` or `eth{n}` on Docker nodes; accepts any value for qemu/iol/dynamips
- `render_interface_name(fmt, index)` helper in `template_service.py` renders `{n}` (0-based), `{slot}` (alias for `{n}`), `{port}` (1-based) placeholders — matches the existing template-level contract
- `_default_interfaces` extended with optional `interface_naming_scheme` and `template_interface_naming` params; priority: node-level scheme > template `interface_naming.format` > existing type-based fallback (`Gi{port}` for qemu, `eth{n}` for docker/iol/dynamips)
- Fully backward-compatible: all callers that pass no scheme get identical behavior to before
- Frontend `formatInterfaceName(scheme, index)` pure helper with identical placeholder semantics

## Test plan
- [x] `backend/tests/test_node_schema_naming.py` — 24 tests: `render_interface_name` unit, `_default_interfaces` priority cases, `NodeBase`/`NodeCreate`/`NodeBatchCreate` validator acceptance and rejection
- [x] `frontend/tests/interfaceNaming.test.ts` — 16 table-driven tests covering all placeholder types, null/undefined/empty fallback, and multi-occurrence replacement
- [x] Full backend suite: 123 passed, 0 failures
- [x] No regressions in existing labs, templates, or node create flows