### PR TITLE
US-104: node status heartbeat (#84)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,6 +62,9 @@ async def startup():
                 "Database tables not found. Run: cd backend && alembic upgrade head && python -m scripts.seed"
             )
 
+    from app.services.node_runtime_service import NodeRuntimeService
+    NodeRuntimeService.start_heartbeat()
+
 
 @app.on_event("shutdown")
 async def shutdown():

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import logging
 import os
 import shlex
 import shutil
@@ -22,6 +23,10 @@ from app.config import get_settings
 
 
 _DOCKER_RESTART_POLICIES = {"no", "on-failure", "unless-stopped", "always"}
+_HEARTBEAT_INTERVAL_S: float = 5.0
+_TRANSITION_SUPPRESS_S: float = 30.0
+
+_logger = logging.getLogger("nova-ve.heartbeat")
 
 
 def _node_extras(node: dict[str, Any]) -> dict[str, Any]:
@@ -100,6 +105,9 @@ class NodeRuntimeService:
     _registry: dict[str, dict[str, Any]] = {}
     _loaded = False
     _lock = threading.Lock()
+    # Maps (lab_id, node_id) -> monotonic timestamp of last deliberate start/stop.
+    # Heartbeat skips reconciliation for entries younger than _TRANSITION_SUPPRESS_S.
+    _transition_timestamps: dict[tuple[str, int], float] = {}
 
     def __init__(self) -> None:
         self.settings = get_settings()
@@ -115,6 +123,20 @@ class NodeRuntimeService:
         with cls._lock:
             cls._registry.clear()
             cls._loaded = False
+        cls._transition_timestamps.clear()
+
+    @classmethod
+    def _record_transition(cls, lab_id: str, node_id: int) -> None:
+        """Mark that a deliberate start/stop just happened; suppresses heartbeat reconcile."""
+        cls._transition_timestamps[(lab_id, node_id)] = time.monotonic()
+
+    @classmethod
+    def _is_suppressed(cls, lab_id: str, node_id: int) -> bool:
+        """Return True if the node is within the post-transition suppression window."""
+        ts = cls._transition_timestamps.get((lab_id, node_id))
+        if ts is None:
+            return False
+        return (time.monotonic() - ts) < _TRANSITION_SUPPRESS_S
 
     def start_node(self, lab_data: dict[str, Any], node_id: int) -> dict[str, Any]:
         lab_id = self._lab_id(lab_data)
@@ -131,6 +153,7 @@ class NodeRuntimeService:
         else:
             raise NodeRuntimeError(f"Unsupported node type: {node.get('type')}")
 
+        self._record_transition(lab_id, node_id)
         with self._lock:
             self._registry[key] = runtime
         self._persist_runtime(runtime)
@@ -465,6 +488,7 @@ class NodeRuntimeService:
         if not runtime:
             return
 
+        self._record_transition(lab_id, node_id)
         kind = runtime.get("kind")
         if kind == "qemu":
             self._stop_qemu_runtime(runtime)
@@ -568,6 +592,179 @@ class NodeRuntimeService:
                 else:
                     idle_rounds += 1
                     time.sleep(0.2)
+
+    @classmethod
+    def start_heartbeat(cls) -> None:
+        """Schedule _heartbeat_loop as a background asyncio task.
+
+        Safe to call from app.startup — creates a task on the running loop.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        loop.create_task(cls._heartbeat_loop())
+
+    @classmethod
+    async def _heartbeat_loop(cls) -> None:
+        """Periodic reconciliation: polls live runtime state and updates lab.json."""
+        while True:
+            await asyncio.sleep(_HEARTBEAT_INTERVAL_S)
+            try:
+                await cls._run_heartbeat_cycle()
+            except Exception:
+                _logger.exception("heartbeat cycle error")
+
+    @classmethod
+    async def _run_heartbeat_cycle(cls) -> None:
+        """Single heartbeat cycle: reconcile node.status for all known runtimes."""
+        from app.services.lab_service import LabService  # avoid import cycle at module load
+        from app.services.lab_lock import lab_lock
+        from app.services.ws_hub import ws_hub
+
+        settings = get_settings()
+        labs_dir = settings.LABS_DIR
+
+        # Snapshot registry keys under lock; iterate without holding the lock.
+        with cls._lock:
+            registry_snapshot = list(cls._registry.items())
+
+        if not registry_snapshot:
+            return
+
+        # Build lab_id -> relative filename map by scanning LABS_DIR once per cycle.
+        lab_id_to_filename: dict[str, str] = {}
+        if labs_dir.exists():
+            for lab_file in labs_dir.rglob("*.json"):
+                try:
+                    raw = json.loads(lab_file.read_text())
+                except (OSError, json.JSONDecodeError):
+                    continue
+                file_lab_id = str(raw.get("id", "")).strip()
+                if file_lab_id and file_lab_id not in lab_id_to_filename:
+                    try:
+                        relative = lab_file.relative_to(labs_dir).as_posix()
+                    except ValueError:
+                        continue
+                    lab_id_to_filename[file_lab_id] = relative
+
+        for _key, runtime in registry_snapshot:
+            lab_id = str(runtime.get("lab_id", "")).strip()
+            node_id_raw = runtime.get("node_id")
+            if not lab_id or node_id_raw is None:
+                continue
+            try:
+                node_id = int(node_id_raw)
+            except (TypeError, ValueError):
+                continue
+
+            if cls._is_suppressed(lab_id, node_id):
+                continue
+
+            filename = lab_id_to_filename.get(lab_id)
+            if not filename:
+                continue
+
+            kind = runtime.get("kind", "")
+            is_alive = await asyncio.get_running_loop().run_in_executor(
+                None, cls._check_alive_sync, runtime, kind, settings
+            )
+
+            # status: 2 = running, 0 = stopped
+            expected_status = 2 if is_alive else 0
+
+            try:
+                with lab_lock(filename, labs_dir):
+                    data = LabService.read_lab_json_static(filename)
+                    nodes: dict = data.get("nodes") or {}
+                    node = nodes.get(str(node_id))
+                    if not isinstance(node, dict):
+                        continue
+                    current_status = int(node.get("status", -1))
+                    if current_status == expected_status:
+                        continue
+                    node["status"] = expected_status
+                    LabService.write_lab_json_static(filename, data)
+            except Exception:
+                _logger.exception(
+                    "heartbeat: failed to reconcile lab=%s node=%s", lab_id, node_id
+                )
+                continue
+
+            _logger.info(
+                "heartbeat reconciled: lab=%s node=%s status %d -> %d",
+                lab_id, node_id, current_status, expected_status,
+            )
+
+            # If the process is dead according to reality, clean up the registry entry.
+            if not is_alive:
+                cls._delete_runtime_class(lab_id, node_id, settings)
+
+            try:
+                await ws_hub.publish(
+                    lab_id,
+                    "node_status_reconciled",
+                    {"node_id": node_id, "status": expected_status},
+                    rev=str(lab_id),
+                )
+            except Exception:
+                _logger.exception(
+                    "heartbeat: ws publish failed for lab=%s node=%s", lab_id, node_id
+                )
+
+    @staticmethod
+    def _check_alive_sync(runtime: dict[str, Any], kind: str, settings: Any) -> bool:
+        """Synchronous liveness check suitable for run_in_executor."""
+        if kind == "docker":
+            import subprocess as _sp
+            import shutil as _sh
+            docker_binary = _sh.which("docker")
+            if not docker_binary:
+                docker_binary = "docker"
+            container_name = runtime.get("container_name")
+            if not container_name:
+                return False
+            result = _sp.run(
+                [
+                    docker_binary,
+                    "--host",
+                    settings.DOCKER_HOST,
+                    "inspect",
+                    "-f",
+                    "{{.State.Running}}",
+                    container_name,
+                ],
+                capture_output=True,
+                text=True,
+            )
+            return result.returncode == 0 and result.stdout.strip() == "true"
+
+        # QEMU / other — use psutil
+        pid = runtime.get("pid")
+        if not pid:
+            return False
+        try:
+            process = psutil.Process(int(pid))
+        except psutil.Error:
+            return False
+        expected_create_time = runtime.get("pid_create_time")
+        if expected_create_time and abs(process.create_time() - expected_create_time) > 1:
+            return False
+        return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+
+    @classmethod
+    def _delete_runtime_class(cls, lab_id: str, node_id: int, settings: Any) -> None:
+        """Remove registry entry and state file (class-level, no instance needed)."""
+        key = f"{lab_id}:{node_id}"
+        with cls._lock:
+            cls._registry.pop(key, None)
+        runtime_dir = settings.TMP_DIR / "node-runtime"
+        state_path = runtime_dir / f"{lab_id}-{node_id}.json"
+        try:
+            if state_path.exists():
+                state_path.unlink()
+        except OSError:
+            pass
 
     def _load_registry(self) -> None:
         with self._lock:

--- a/backend/tests/test_node_status_heartbeat.py
+++ b/backend/tests/test_node_status_heartbeat.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for US-104 — node status heartbeat reconciliation."""
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.node_runtime_service import NodeRuntimeService, _TRANSITION_SUPPRESS_S
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    NodeRuntimeService.reset_registry()
+    yield
+    NodeRuntimeService.reset_registry()
+
+
+@pytest.fixture()
+def tmp_settings(tmp_path):
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    return SimpleNamespace(
+        LABS_DIR=labs_dir,
+        TMP_DIR=tmp_dir,
+        DOCKER_HOST="unix:///var/run/docker.sock",
+    )
+
+
+def _write_lab(labs_dir: Path, lab_id: str, nodes: dict) -> str:
+    """Write a minimal v2 lab.json; return relative filename."""
+    data = {
+        "schema": 2,
+        "id": lab_id,
+        "meta": {"name": "test-lab"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": nodes,
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    filename = f"{lab_id}.json"
+    (labs_dir / filename).write_text(json.dumps(data))
+    return filename
+
+
+def _register_runtime(settings, lab_id: str, node_id: int, kind: str, **extra) -> dict:
+    """Inject a runtime record into the registry and write a state file."""
+    runtime_dir = settings.TMP_DIR / "node-runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    runtime = {
+        "lab_id": lab_id,
+        "node_id": node_id,
+        "kind": kind,
+        **extra,
+    }
+    key = f"{lab_id}:{node_id}"
+    with NodeRuntimeService._lock:
+        NodeRuntimeService._registry[key] = runtime
+        NodeRuntimeService._loaded = True
+    state_path = runtime_dir / f"{lab_id}-{node_id}.json"
+    state_path.write_text(json.dumps(runtime))
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_settings(monkeypatch, tmp_settings):
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.get_settings", lambda: tmp_settings
+    )
+    monkeypatch.setattr(
+        "app.services.lab_service.get_settings", lambda: tmp_settings
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: Docker node — container stopped externally → status flips 2→0 + WS publish
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_docker_node_stopped_externally_triggers_reconcile(monkeypatch, tmp_settings):
+    """When a Docker container is found not-running, heartbeat writes status=0 to lab.json
+    and publishes a node_status_reconciled WS event."""
+    lab_id = "lab-docker-test"
+    node_id = 1
+    container_name = f"nova-ve-{lab_id.replace('-', '')[:12]}-{node_id}"
+
+    # Write lab.json with status=2 (running)
+    nodes = {str(node_id): {"id": node_id, "name": "alpine", "type": "docker", "status": 2}}
+    _write_lab(tmp_settings.LABS_DIR, lab_id, nodes)
+
+    # Register a running runtime
+    _register_runtime(tmp_settings, lab_id, node_id, "docker", container_name=container_name)
+
+    _patch_settings(monkeypatch, tmp_settings)
+
+    # Mock: container is NOT running (externally stopped)
+    def fake_check_alive(runtime, kind, settings):
+        return False  # container stopped
+
+    monkeypatch.setattr(NodeRuntimeService, "_check_alive_sync", staticmethod(fake_check_alive))
+
+    # Capture WS publishes
+    published = []
+
+    async def fake_publish(lab_id_arg, event_type, payload, rev=""):
+        published.append({"lab_id": lab_id_arg, "type": event_type, "payload": payload})
+
+    from app.services import ws_hub as ws_hub_mod
+    monkeypatch.setattr(ws_hub_mod.ws_hub, "publish", fake_publish)
+
+    await NodeRuntimeService._run_heartbeat_cycle()
+
+    # lab.json should now have status=0
+    updated = json.loads((tmp_settings.LABS_DIR / f"{lab_id}.json").read_text())
+    assert updated["nodes"][str(node_id)]["status"] == 0
+
+    # WS event published
+    assert len(published) == 1
+    assert published[0]["type"] == "node_status_reconciled"
+    assert published[0]["payload"]["node_id"] == node_id
+    assert published[0]["payload"]["status"] == 0
+
+    # Registry entry cleaned up for dead node
+    assert f"{lab_id}:{node_id}" not in NodeRuntimeService._registry
+
+
+# ---------------------------------------------------------------------------
+# Test: Docker node — container running, status already correct → no write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_write_when_status_matches(monkeypatch, tmp_settings):
+    """Heartbeat does nothing when lab.json status already matches live state."""
+    lab_id = "lab-nodiff"
+    node_id = 2
+
+    nodes = {str(node_id): {"id": node_id, "name": "router", "type": "docker", "status": 2}}
+    _write_lab(tmp_settings.LABS_DIR, lab_id, nodes)
+    _register_runtime(tmp_settings, lab_id, node_id, "docker", container_name="c1")
+
+    _patch_settings(monkeypatch, tmp_settings)
+
+    def fake_check_alive(runtime, kind, settings):
+        return True  # still running
+
+    monkeypatch.setattr(NodeRuntimeService, "_check_alive_sync", staticmethod(fake_check_alive))
+
+    published = []
+
+    async def fake_publish(*args, **kwargs):
+        published.append(args)
+
+    from app.services import ws_hub as ws_hub_mod
+    monkeypatch.setattr(ws_hub_mod.ws_hub, "publish", fake_publish)
+
+    original_mtime = (tmp_settings.LABS_DIR / f"{lab_id}.json").stat().st_mtime
+
+    await NodeRuntimeService._run_heartbeat_cycle()
+
+    # File not touched
+    assert (tmp_settings.LABS_DIR / f"{lab_id}.json").stat().st_mtime == original_mtime
+    assert published == []
+
+
+# ---------------------------------------------------------------------------
+# Test: QEMU node — process alive, status=0 in lab → flips to 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_qemu_node_started_externally_triggers_reconcile(monkeypatch, tmp_settings):
+    """When QEMU pid exists but lab.json has status=0, heartbeat flips to status=2."""
+    lab_id = "lab-qemu-test"
+    node_id = 3
+    pid = 99999
+
+    nodes = {str(node_id): {"id": node_id, "name": "vyos", "type": "qemu", "status": 0}}
+    _write_lab(tmp_settings.LABS_DIR, lab_id, nodes)
+    _register_runtime(
+        tmp_settings, lab_id, node_id, "qemu",
+        pid=pid, pid_create_time=12345.0,
+    )
+
+    _patch_settings(monkeypatch, tmp_settings)
+
+    def fake_check_alive(runtime, kind, settings):
+        return True  # process is running
+
+    monkeypatch.setattr(NodeRuntimeService, "_check_alive_sync", staticmethod(fake_check_alive))
+
+    published = []
+
+    async def fake_publish(lab_id_arg, event_type, payload, rev=""):
+        published.append({"type": event_type, "payload": payload})
+
+    from app.services import ws_hub as ws_hub_mod
+    monkeypatch.setattr(ws_hub_mod.ws_hub, "publish", fake_publish)
+
+    await NodeRuntimeService._run_heartbeat_cycle()
+
+    updated = json.loads((tmp_settings.LABS_DIR / f"{lab_id}.json").read_text())
+    assert updated["nodes"][str(node_id)]["status"] == 2
+
+    assert len(published) == 1
+    assert published[0]["type"] == "node_status_reconciled"
+    assert published[0]["payload"]["status"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: suppression window — recent start/stop is not reconciled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_suppressed_within_transition_window(monkeypatch, tmp_settings):
+    """Node within 30s transition window is skipped by heartbeat."""
+    lab_id = "lab-suppress"
+    node_id = 4
+
+    nodes = {str(node_id): {"id": node_id, "name": "box", "type": "docker", "status": 2}}
+    _write_lab(tmp_settings.LABS_DIR, lab_id, nodes)
+    _register_runtime(tmp_settings, lab_id, node_id, "docker", container_name="c2")
+
+    # Record a transition just now → suppressed
+    NodeRuntimeService._record_transition(lab_id, node_id)
+
+    _patch_settings(monkeypatch, tmp_settings)
+
+    def fake_check_alive(runtime, kind, settings):
+        return False  # externally stopped — would normally trigger reconcile
+
+    monkeypatch.setattr(NodeRuntimeService, "_check_alive_sync", staticmethod(fake_check_alive))
+
+    published = []
+
+    async def fake_publish(*args, **kwargs):
+        published.append(args)
+
+    from app.services import ws_hub as ws_hub_mod
+    monkeypatch.setattr(ws_hub_mod.ws_hub, "publish", fake_publish)
+
+    await NodeRuntimeService._run_heartbeat_cycle()
+
+    # status should NOT have changed — suppression window active
+    lab_data = json.loads((tmp_settings.LABS_DIR / f"{lab_id}.json").read_text())
+    assert lab_data["nodes"][str(node_id)]["status"] == 2
+    assert published == []
+
+
+# ---------------------------------------------------------------------------
+# Test: suppression window expires after _TRANSITION_SUPPRESS_S
+# ---------------------------------------------------------------------------
+
+def test_suppression_expires():
+    """_is_suppressed returns False once the window has elapsed."""
+    lab_id = "lab-exp"
+    node_id = 5
+    # Inject a timestamp older than the suppress window
+    NodeRuntimeService._transition_timestamps[(lab_id, node_id)] = (
+        time.monotonic() - _TRANSITION_SUPPRESS_S - 1
+    )
+    assert NodeRuntimeService._is_suppressed(lab_id, node_id) is False
+
+
+# ---------------------------------------------------------------------------
+# Test: empty registry → cycle is a no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_registry_no_op(monkeypatch, tmp_settings):
+    """Heartbeat cycle with no registry entries does nothing."""
+    _patch_settings(monkeypatch, tmp_settings)
+    check_called = []
+
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_check_alive_sync",
+        staticmethod(lambda *a, **kw: check_called.append(1) or True),
+    )
+
+    await NodeRuntimeService._run_heartbeat_cycle()
+    assert check_called == []


### PR DESCRIPTION
Closes #84. Part of #80.

## Summary

- Adds `NodeRuntimeService._heartbeat_loop()`, started at app startup, which polls live runtime state every 5 seconds and reconciles `node.status` in `lab.json` (2=running, 0=stopped) when it diverges from reality
- Docker nodes: checks via `docker inspect -f '{{.State.Running}}'`; QEMU nodes: checks via `psutil.pid_exists` with PID create-time guard against PID reuse
- A 30-second suppression window around deliberate `start_node` / `stop_node` transitions prevents the heartbeat from fighting explicit user actions
- Divergent state triggers a `node_status_reconciled` WebSocket event so the UI updates without a full page reload; cleans up stale registry/state-file entries for genuinely dead nodes
- Lab files are written under `lab_lock` to coordinate with existing persistence locks, avoiding write races

## Test plan

- [x] `test_docker_node_stopped_externally_triggers_reconcile` — status 2→0 + WS publish when container not running
- [x] `test_no_write_when_status_matches` — no file write or WS event when status is already correct
- [x] `test_qemu_node_started_externally_triggers_reconcile` — status 0→2 + WS publish when pid alive
- [x] `test_suppressed_within_transition_window` — heartbeat skips node within 30s of start/stop
- [x] `test_suppression_expires` — suppression window correctly expires after `_TRANSITION_SUPPRESS_S`
- [x] `test_empty_registry_no_op` — empty registry cycle is a no-op (no subprocess calls)
- [x] Full backend suite: 105 passed, 0 failed