### PR TITLE
US-100: instance ID provisioning (#86)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.routers import auth, folders, labs, links, listing, networks, system, u
 from app.database import engine
 from app.config import get_settings
 from app.services.lab_lock import LabLockTimeout
+from app.services.host_net import HostNetInstanceIdMissing, get_instance_id
 
 
 def lab_lock_timeout_handler(request: Request, exc: LabLockTimeout) -> JSONResponse:
@@ -49,6 +50,19 @@ app.add_exception_handler(LabLockTimeout, lab_lock_timeout_handler)
 
 @app.on_event("startup")
 async def startup():
+    import logging
+    _logger = logging.getLogger("nova-ve")
+    try:
+        instance_id = get_instance_id()
+        _logger.info("nova-ve instance ID: %s", instance_id)
+    except HostNetInstanceIdMissing as exc:
+        _logger.critical(
+            "FATAL: instance ID not provisioned — deploy/scripts/provision-ubuntu-2604.sh did not run. "
+            "Cannot derive collision-resistant bridge names. %s",
+            exc,
+        )
+        raise SystemExit(1) from exc
+
     from sqlalchemy import text
     async with engine.connect() as conn:
         result = await conn.execute(

--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""
+host_net — Linux bridge / TAP name helpers and instance-ID provisioning.
+
+Bridge name format : nove{lab_hash:04x}n{network_id}   (≤14 chars, network_id ≤ 99999)
+TAP name format    : nve{lab_hash:04x}d{node_id}i{iface}  (≤13 chars, node_id ≤ 999, iface ≤ 99)
+
+lab_hash is a 16-bit value derived from blake2b(instance_id + ":" + lab_id).
+Using blake2b (not Python's built-in hash()) because hash() is salted per-process since Python 3.3.
+
+Instance ID is read from:
+  $NOVA_VE_INSTANCE_DIR/instance_id  (default dir: /etc/nova-ve)
+
+Precedence rules (file-wins with explicit env override):
+  1. If the file exists and is non-empty → use file value (authoritative).
+  2. If NOVA_VE_INSTANCE_ID is set AND NOVA_VE_INSTANCE_ID_OVERRIDE_OK=1 → use env value
+     (WARNING logged on every call).
+  3. Otherwise → raise HostNetInstanceIdMissing.
+"""
+
+import hashlib
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger("nova-ve")
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+class HostNetInstanceIdMissing(RuntimeError):
+    """Raised when the instance ID cannot be resolved.
+
+    This means deploy/scripts/provision-ubuntu-2604.sh did not run (or the
+    instance_id file was removed).  The backend MUST NOT start without a
+    valid instance ID — bridge name collisions across hosts would result.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Instance-ID resolution
+# ---------------------------------------------------------------------------
+
+_INSTANCE_DIR_DEFAULT = "/etc/nova-ve"
+_INSTANCE_FILE_NAME = "instance_id"
+
+
+def _instance_id_file() -> Path:
+    """Return the path to the instance_id file, honouring NOVA_VE_INSTANCE_DIR."""
+    instance_dir = os.environ.get("NOVA_VE_INSTANCE_DIR", _INSTANCE_DIR_DEFAULT)
+    return Path(instance_dir) / _INSTANCE_FILE_NAME
+
+
+def get_instance_id() -> str:
+    """Return the instance ID string, applying the file-wins precedence rules.
+
+    Raises HostNetInstanceIdMissing if the ID cannot be resolved.
+    """
+    id_file = _instance_id_file()
+
+    # --- Try the file first (authoritative when present and non-empty) ----
+    if id_file.exists():
+        value = id_file.read_text(encoding="ascii").strip()
+        if value:
+            return value
+        # File exists but is empty — treat as missing.
+
+    # --- Env-var override (only with explicit OVERRIDE_OK flag) -----------
+    env_id = os.environ.get("NOVA_VE_INSTANCE_ID", "").strip()
+    override_ok = os.environ.get("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", "").strip() == "1"
+
+    if env_id and override_ok:
+        logger.warning(
+            "WARNING: using NOVA_VE_INSTANCE_ID env override (file ignored); "
+            "persist via deploy script for production"
+        )
+        return env_id
+
+    # --- Neither source is usable — fail hard ----------------------------
+    raise HostNetInstanceIdMissing(
+        f"Instance ID file '{id_file}' is missing or empty and no valid env override "
+        "is configured (set both NOVA_VE_INSTANCE_ID and NOVA_VE_INSTANCE_ID_OVERRIDE_OK=1 "
+        "for a temporary override, or run deploy/scripts/provision-ubuntu-2604.sh). "
+        "Cannot derive collision-resistant bridge names without a per-host instance ID."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bridge / TAP name derivation
+# ---------------------------------------------------------------------------
+
+
+def _lab_hash(lab_id: str, instance_id: str) -> int:
+    """Return a deterministic 16-bit hash of (instance_id, lab_id).
+
+    blake2b with digest_size=2 → 2 bytes → 0x0000..0xFFFF.
+    """
+    raw = hashlib.blake2b(
+        f"{instance_id}:{lab_id}".encode("utf-8"), digest_size=2
+    ).hexdigest()
+    return int(raw, 16)
+
+
+def bridge_name(lab_id: str, network_id: int) -> str:
+    """Return the Linux bridge name for a network.
+
+    Format: nove{lab_hash:04x}n{network_id}
+    Max length: 4 + 4 + 1 + 5 = 14 chars  (network_id ≤ 99999)
+    IFNAMSIZ limit: 15 usable chars.
+    """
+    instance_id = get_instance_id()
+    h = _lab_hash(lab_id, instance_id)
+    name = f"nove{h:04x}n{network_id}"
+    assert len(name) <= 14, f"bridge_name overflow: {name!r} ({len(name)} chars)"
+    return name
+
+
+def tap_name(lab_id: str, node_id: int, iface: int) -> str:
+    """Return the TAP interface name for a node NIC.
+
+    Format: nve{lab_hash:04x}d{node_id}i{iface}
+    Max length: 3 + 4 + 1 + 3 + 1 + 2 = 14 chars  (node_id ≤ 999, iface ≤ 99)
+    """
+    instance_id = get_instance_id()
+    h = _lab_hash(lab_id, instance_id)
+    name = f"nve{h:04x}d{node_id}i{iface}"
+    assert len(name) <= 14, f"tap_name overflow: {name!r} ({len(name)} chars)"
+    return name

--- a/backend/tests/test_instance_id.py
+++ b/backend/tests/test_instance_id.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression tests for US-100: per-instance ID provisioning.
+
+Covers:
+  - First-run (file missing) + env override → returns env value with WARNING
+  - Second-run (file present) → loads from file (deterministic)
+  - File present + env var set (no override flag) → file wins, no warning
+  - File missing + no env → raises HostNetInstanceIdMissing
+  - File missing + env-only (no OVERRIDE_OK) → raises HostNetInstanceIdMissing
+  - _lab_hash is deterministic across calls
+  - _lab_hash returns a 16-bit value (0 ≤ x ≤ 0xFFFF)
+  - bridge_name fits the 14-char budget for edge-case network_id=99999
+  - tap_name fits the 14-char budget for edge-case node_id=999, iface=99
+"""
+
+import importlib
+import logging
+import os
+
+import pytest
+
+import app.services.host_net as host_net
+from app.services.host_net import (
+    HostNetInstanceIdMissing,
+    _lab_hash,
+    bridge_name,
+    get_instance_id,
+    tap_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reload_and_patch(monkeypatch, tmp_path, instance_dir=None, env_id=None, override_ok=None):
+    """Patch NOVA_VE_INSTANCE_DIR and optional env vars, then reload the module."""
+    if instance_dir is not None:
+        monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    else:
+        monkeypatch.delenv("NOVA_VE_INSTANCE_DIR", raising=False)
+
+    if env_id is not None:
+        monkeypatch.setenv("NOVA_VE_INSTANCE_ID", env_id)
+    else:
+        monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+
+    if override_ok is not None:
+        monkeypatch.setenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", override_ok)
+    else:
+        monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+
+    importlib.reload(host_net)
+
+
+# ---------------------------------------------------------------------------
+# get_instance_id — file-based resolution
+# ---------------------------------------------------------------------------
+
+
+def test_file_present_returns_file_value(monkeypatch, tmp_path):
+    """File present and non-empty → returns file value."""
+    instance_dir = tmp_path / "etc-nova-ve"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("test-uuid-1234\n")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    result = host_net.get_instance_id()
+    assert result == "test-uuid-1234"
+
+
+def test_file_present_second_run_is_identical(monkeypatch, tmp_path):
+    """Second call with same file → same value (idempotent load)."""
+    instance_dir = tmp_path / "etc-nova-ve"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("stable-uuid-abcd")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    assert host_net.get_instance_id() == host_net.get_instance_id()
+
+
+def test_file_missing_no_env_raises(monkeypatch, tmp_path):
+    """File missing + no env vars → raises HostNetInstanceIdMissing."""
+    instance_dir = tmp_path / "no-such-dir"
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    with pytest.raises(host_net.HostNetInstanceIdMissing):
+        host_net.get_instance_id()
+
+
+def test_file_missing_env_only_no_override_flag_raises(monkeypatch, tmp_path):
+    """Env var alone (no OVERRIDE_OK=1) → still raises, even if NOVA_VE_INSTANCE_ID set."""
+    instance_dir = tmp_path / "no-such-dir"
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID", "some-env-uuid")
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    with pytest.raises(host_net.HostNetInstanceIdMissing):
+        host_net.get_instance_id()
+
+
+def test_file_missing_env_with_override_flag_honored(monkeypatch, tmp_path, caplog):
+    """Env var + OVERRIDE_OK=1 (no file) → honored, WARNING emitted."""
+    instance_dir = tmp_path / "no-such-dir"
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID", "override-uuid-5678")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", "1")
+    importlib.reload(host_net)
+
+    with caplog.at_level(logging.WARNING, logger="nova-ve"):
+        result = host_net.get_instance_id()
+
+    assert result == "override-uuid-5678"
+    assert any("WARNING" in r.message for r in caplog.records)
+
+
+def test_file_present_env_set_no_override_flag_file_wins_no_warning(
+    monkeypatch, tmp_path, caplog
+):
+    """File present + env var set (no OVERRIDE_OK) → file wins, no WARNING logged."""
+    instance_dir = tmp_path / "etc-nova-ve"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("file-uuid-wins")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID", "env-uuid-ignored")
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    with caplog.at_level(logging.WARNING, logger="nova-ve"):
+        result = host_net.get_instance_id()
+
+    assert result == "file-uuid-wins"
+    assert not any("WARNING" in r.message for r in caplog.records)
+
+
+def test_file_empty_falls_through_to_env_override(monkeypatch, tmp_path):
+    """Empty file + env override + OVERRIDE_OK=1 → env value used."""
+    instance_dir = tmp_path / "etc-nova-ve"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("   \n")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID", "env-uuid-fallback")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", "1")
+    importlib.reload(host_net)
+
+    result = host_net.get_instance_id()
+    assert result == "env-uuid-fallback"
+
+
+# ---------------------------------------------------------------------------
+# _lab_hash — determinism and bit-width
+# ---------------------------------------------------------------------------
+
+
+def test_lab_hash_is_deterministic():
+    """Same inputs always produce the same hash."""
+    h1 = _lab_hash("lab-abc", "inst-xyz")
+    h2 = _lab_hash("lab-abc", "inst-xyz")
+    assert h1 == h2
+
+
+def test_lab_hash_different_instance_ids_produce_different_hashes():
+    """Different instance IDs → different hashes (collision resistance)."""
+    h1 = _lab_hash("same-lab", "instance-A")
+    h2 = _lab_hash("same-lab", "instance-B")
+    assert h1 != h2
+
+
+def test_lab_hash_different_lab_ids_produce_different_hashes():
+    """Different lab IDs on the same instance → different hashes."""
+    h1 = _lab_hash("lab-1", "same-instance")
+    h2 = _lab_hash("lab-2", "same-instance")
+    assert h1 != h2
+
+
+def test_lab_hash_fits_16_bits():
+    """Hash value is always in [0, 0xFFFF]."""
+    for lab_id, instance_id in [
+        ("lab-abc", "inst-xyz"),
+        ("x" * 64, "y" * 64),
+        ("", ""),
+    ]:
+        h = _lab_hash(lab_id, instance_id)
+        assert 0 <= h <= 0xFFFF, f"hash {h} out of 16-bit range"
+
+
+# ---------------------------------------------------------------------------
+# bridge_name / tap_name — IFNAMSIZ budget
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_name_max_network_id_fits_14_chars(monkeypatch, tmp_path):
+    """bridge_name with network_id=99999 must be ≤14 chars."""
+    instance_dir = tmp_path / "etc-nova-ve"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("test-instance-id")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    name = host_net.bridge_name("some-lab-id", 99999)
+    assert len(name) <= 14, f"bridge_name too long: {name!r} ({len(name)} chars)"
+    assert name.startswith("nove")
+
+
+def test_tap_name_max_node_iface_fits_14_chars(monkeypatch, tmp_path):
+    """tap_name with node_id=999, iface=99 must be ≤14 chars."""
+    instance_dir = tmp_path / "etc-nova-ve"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("test-instance-id")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    name = host_net.tap_name("some-lab-id", 999, 99)
+    assert len(name) <= 14, f"tap_name too long: {name!r} ({len(name)} chars)"
+    assert name.startswith("nve")
+
+
+def test_bridge_name_format(monkeypatch, tmp_path):
+    """bridge_name produces the expected prefix+hash+suffix structure."""
+    instance_dir = tmp_path / "etc-nova-ve"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("fixed-instance")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    name = host_net.bridge_name("my-lab", 7)
+    # nove + 4 hex chars + n + network_id
+    import re
+    assert re.fullmatch(r"nove[0-9a-f]{4}n[0-9]+", name), f"unexpected format: {name!r}"
+
+
+def test_tap_name_format(monkeypatch, tmp_path):
+    """tap_name produces the expected prefix+hash+suffix structure."""
+    instance_dir = tmp_path / "etc-nova-ve"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("fixed-instance")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    importlib.reload(host_net)
+
+    name = host_net.tap_name("my-lab", 3, 1)
+    import re
+    assert re.fullmatch(r"nve[0-9a-f]{4}d[0-9]+i[0-9]+", name), f"unexpected format: {name!r}"

--- a/deploy/DEPLOYMENT_CONTRACT.md
+++ b/deploy/DEPLOYMENT_CONTRACT.md
@@ -76,12 +76,48 @@ Route ownership:
 
 - App checkout root: the absolute repo path where `deploy/scripts/provision-ubuntu-2604.sh` is executed; recommended location is `/opt/nova-ve`
 - Backend env file: `/etc/nova-ve/backend.env`
+- **Instance ID file: `/etc/nova-ve/instance_id`** — written once by `provision-ubuntu-2604.sh`, never overwritten; authoritative source for bridge/TAP name derivation
 - Static frontend root: `/var/lib/nova-ve/www`
 - Labs: `/var/lib/nova-ve/labs`
 - Images: `/var/lib/nova-ve/images`
 - Temp: `/var/lib/nova-ve/tmp`
 - Guacamole support state: `/var/lib/nova-ve/guacamole`
 - Guacamole DB credentials and backend access URL are carried in `/etc/nova-ve/backend.env`
+
+## Instance ID and Multi-Host Constraints
+
+nova-ve generates collision-resistant Linux bridge and TAP interface names using a per-deployment instance ID.
+
+### What it is
+
+`/etc/nova-ve/instance_id` holds a UUID (generated via `/proc/sys/kernel/random/uuid` at first provisioning).
+The backend derives a 16-bit `lab_hash = blake2b(instance_id + ":" + lab_id, digest_size=2)` used in:
+- Bridge names: `nove{lab_hash:04x}n{network_id}` (≤14 chars)
+- TAP names: `nve{lab_hash:04x}d{node_id}i{iface}` (≤13 chars)
+
+### Rules
+
+- `/etc/nova-ve/instance_id` **MUST NOT live on a shared filesystem** (NFS, CIFS, etc.).
+  Each physical or virtual host must have a unique value on its local filesystem.
+- If a host VM is cloned from an image, `provision-ubuntu-2604.sh` must be re-run on the
+  clone so a new UUID is generated. The script is idempotent only within a single host
+  (it never overwrites an existing non-empty file). Clones share the original UUID unless
+  the file is explicitly regenerated.
+- The backend startup will **FAIL HARD** with a clear error message if the file is missing
+  or empty. There is no silent fallback — this is intentional to prevent bridge name
+  collisions across hosts.
+
+### Temporary override (non-production only)
+
+To run the backend on a dev machine without a provisioned file, set both:
+```
+NOVA_VE_INSTANCE_ID=<some-uuid>
+NOVA_VE_INSTANCE_ID_OVERRIDE_OK=1
+```
+The backend will emit a `WARNING` on every startup when these are active.
+This override is **not suitable for production** — persist via the deploy script instead.
+The override env var is ignored if the file exists (file-wins precedence prevents a stale
+shell variable from silently colliding bridge names against a production host).
 
 ## Toolchain Expectations
 

--- a/deploy/scripts/provision-ubuntu-2604.sh
+++ b/deploy/scripts/provision-ubuntu-2604.sh
@@ -216,6 +216,24 @@ install_nova_ve_net_helper() {
   install -m 0440 -o root -g root "${sudoers_src}" "${sudoers_dst}"
 }
 
+ensure_instance_id() {
+  local id_dir="/etc/nova-ve"
+  local id_file="${id_dir}/instance_id"
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "+ ensure ${id_file} exists (idempotent)"
+    return 0
+  fi
+  install -d -m 0755 -o root -g root "${id_dir}"
+  if [[ ! -f "${id_file}" ]] || [[ ! -s "${id_file}" ]]; then
+    cat /proc/sys/kernel/random/uuid > "${id_file}"
+    chmod 0644 "${id_file}"
+    chown root:root "${id_file}"
+    echo "Generated instance ID: $(cat "${id_file}")"
+  else
+    echo "Instance ID already exists: $(cat "${id_file}")"
+  fi
+}
+
 require_target_host
 
 run apt-get update
@@ -245,6 +263,7 @@ run systemctl enable docker
 run systemctl restart docker
 run usermod -aG docker "${APP_OWNER}"
 ensure_backend_env
+ensure_instance_id
 
 ensure_database
 


### PR DESCRIPTION
Closes #86. Part of #80.

Wave 6 deploy precondition — provisions per-instance ID used to derive lab_hash for collision-resistant Linux bridge/TAP names.

## Summary
- `backend/app/services/host_net.py` (NEW): `get_instance_id()` reads `/etc/nova-ve/instance_id` with file-wins precedence; env-var override only when both `NOVA_VE_INSTANCE_ID` and `NOVA_VE_INSTANCE_ID_OVERRIDE_OK=1` are set (WARNING logged on every use); raises `HostNetInstanceIdMissing` if neither source is valid — no silent fallback
- `_lab_hash(lab_id, instance_id)` uses `blake2b(digest_size=2)` for a deterministic 16-bit hash; `bridge_name()` and `tap_name()` produce names within the 14-char IFNAMSIZ budget
- `backend/app/main.py`: startup fails hard with `SystemExit(1)` + FATAL log if instance ID is missing
- `deploy/scripts/provision-ubuntu-2604.sh`: `ensure_instance_id()` writes UUID from `/proc/sys/kernel/random/uuid` to `/etc/nova-ve/instance_id` (mode `0644 root:root`); idempotent — never overwrites a non-empty file
- `deploy/DEPLOYMENT_CONTRACT.md`: documents the instance_id file location, multi-host constraint (must not live on a shared filesystem), clone-regen requirement, and the temporary env-var override procedure
- `NOVA_VE_INSTANCE_DIR` env var overrides the `/etc/nova-ve` directory for test isolation

## Test plan
- [ ] `test_file_present_returns_file_value` — file present → returns file value
- [ ] `test_file_present_second_run_is_identical` — load is idempotent across calls
- [ ] `test_file_missing_no_env_raises` — missing file + no env → `HostNetInstanceIdMissing`
- [ ] `test_file_missing_env_only_no_override_flag_raises` — env set but no `OVERRIDE_OK` → still raises
- [ ] `test_file_missing_env_with_override_flag_honored` — env + `OVERRIDE_OK=1` → honored, WARNING emitted
- [ ] `test_file_present_env_set_no_override_flag_file_wins_no_warning` — file wins, no WARNING
- [ ] `test_file_empty_falls_through_to_env_override` — empty file falls through to env override path
- [ ] `test_lab_hash_is_deterministic` — same inputs always same hash
- [ ] `test_lab_hash_different_instance_ids_produce_different_hashes` — collision resistance
- [ ] `test_lab_hash_different_lab_ids_produce_different_hashes` — per-lab differentiation
- [ ] `test_lab_hash_fits_16_bits` — hash always in [0, 0xFFFF]
- [ ] `test_bridge_name_max_network_id_fits_14_chars` — `network_id=99999` stays ≤14 chars
- [ ] `test_tap_name_max_node_iface_fits_14_chars` — `node_id=999, iface=99` stays ≤14 chars
- [ ] `test_bridge_name_format` — matches `nove[0-9a-f]{4}n[0-9]+`
- [ ] `test_tap_name_format` — matches `nve[0-9a-f]{4}d[0-9]+i[0-9]+`