### PR TITLE
US-305: template capabilities + UI banner (#103)

### DIFF
--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -12,6 +12,89 @@ from app.config import get_settings
 
 SUPPORTED_TEMPLATE_TYPES = {"qemu", "docker", "iol", "dynamips"}
 
+QEMU_MACHINE_OPTIONS = {"q35", "pc"}
+_QEMU_MAX_NICS_HARD_CAP = 8
+_DOCKER_MAX_NICS_DEFAULT = 99
+
+
+def _default_capabilities(template_type: str) -> dict[str, Any]:
+    """Return capability defaults inferred from node type (backward-compat for templates without capabilities block)."""
+    if template_type == "docker":
+        return {"hotplug": True, "max_nics": _DOCKER_MAX_NICS_DEFAULT, "machine": None}
+    # qemu, iol, dynamips default to conservative values
+    return {"hotplug": False, "max_nics": _QEMU_MAX_NICS_HARD_CAP, "machine": "pc"}
+
+
+def _validate_capabilities(payload: Any, template_type: str, source: str) -> dict[str, Any]:
+    """Validate and normalise the ``capabilities`` block from a template YAML.
+
+    Returns a fully-populated capabilities dict with all three fields resolved.
+    Raises :class:`TemplateError` on invalid input.
+    """
+    defaults = _default_capabilities(template_type)
+
+    if payload is None:
+        # No capabilities block: infer from node type (backward compat)
+        return defaults
+
+    if not isinstance(payload, dict):
+        raise TemplateError(
+            f"capabilities on {source} must be an object with optional fields "
+            f"hotplug (bool), max_nics (int), machine (str)."
+        )
+
+    result: dict[str, Any] = dict(defaults)
+
+    # hotplug
+    if "hotplug" in payload:
+        val = payload["hotplug"]
+        if not isinstance(val, bool):
+            raise TemplateError(
+                f"capabilities.hotplug on {source} must be a boolean."
+            )
+        result["hotplug"] = val
+
+    # max_nics
+    if "max_nics" in payload:
+        val = payload["max_nics"]
+        if not isinstance(val, int) or isinstance(val, bool):
+            raise TemplateError(
+                f"capabilities.max_nics on {source} must be an integer."
+            )
+        if template_type != "docker" and val > _QEMU_MAX_NICS_HARD_CAP:
+            raise TemplateError(
+                f"capabilities.max_nics on {source} exceeds the hard cap of "
+                f"{_QEMU_MAX_NICS_HARD_CAP} for {template_type} templates (Principle 5)."
+            )
+        if val < 1:
+            raise TemplateError(
+                f"capabilities.max_nics on {source} must be at least 1."
+            )
+        result["max_nics"] = val
+
+    # machine
+    if "machine" in payload:
+        val = payload["machine"]
+        if template_type != "qemu":
+            raise TemplateError(
+                f"capabilities.machine on {source} is only valid for qemu templates."
+            )
+        if not isinstance(val, str) or val not in QEMU_MACHINE_OPTIONS:
+            raise TemplateError(
+                f"capabilities.machine on {source} must be one of "
+                f"{sorted(QEMU_MACHINE_OPTIONS)}, got {val!r}."
+            )
+        result["machine"] = val
+
+    # Consistency check: pc + hotplug=True is not allowed for QEMU
+    if template_type == "qemu" and result.get("hotplug") and result.get("machine") == "pc":
+        raise TemplateError(
+            f"capabilities on {source}: hotplug=true requires machine='q35'; "
+            f"'pc' does not support PCIe hot-plug."
+        )
+
+    return result
+
 
 ICON_TYPE_TO_FILENAME = {
     "router": "Router.png",
@@ -365,6 +448,7 @@ class TemplateDefinition:
     extras: dict[str, Any] = field(default_factory=dict)
     raw: dict[str, Any] = field(default_factory=dict)
     interface_naming: dict[str, Any] | None = None
+    capabilities: dict[str, Any] = field(default_factory=dict)
 
     def as_response(self) -> dict[str, Any]:
         return {
@@ -381,6 +465,7 @@ class TemplateDefinition:
             "console_type": self.console_type,
             "cpulimit": self.cpulimit,
             "extras": dict(self.extras),
+            "capabilities": dict(self.capabilities),
         }
 
 
@@ -483,6 +568,7 @@ class TemplateService:
                     "images": images,
                     "icon_options": icon_options,
                     "extras_schema": extras_schema,
+                    "capabilities": dict(template.capabilities),
                 }
             )
         return {
@@ -561,6 +647,9 @@ class TemplateService:
                 interface_naming = _validate_interface_naming(
                     interface_naming, source=str(template_path)
                 )
+            capabilities = _validate_capabilities(
+                payload.get("capabilities"), template_type, source=str(template_path)
+            )
             templates.append(
                 TemplateDefinition(
                     key=key,
@@ -576,6 +665,7 @@ class TemplateService:
                     extras=yaml_extras,
                     raw=payload,
                     interface_naming=interface_naming,
+                    capabilities=capabilities,
                 )
             )
         return templates

--- a/backend/templates/qemu/csr.yml
+++ b/backend/templates/qemu/csr.yml
@@ -7,3 +7,7 @@ ram: 4096
 ethernet: 4
 console_type: telnet
 architecture: x86_64
+capabilities:
+  hotplug: true
+  max_nics: 8
+  machine: q35

--- a/backend/templates/qemu/vyos.yml
+++ b/backend/templates/qemu/vyos.yml
@@ -8,3 +8,7 @@ ram: 1024
 ethernet: 4
 console_type: telnet
 architecture: x86_64
+capabilities:
+  hotplug: true
+  max_nics: 8
+  machine: q35

--- a/backend/tests/test_template_capabilities.py
+++ b/backend/tests/test_template_capabilities.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for US-305: template capabilities.{hotplug, max_nics, machine}."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.template_service import (
+    TemplateError,
+    TemplateService,
+    _default_capabilities,
+    _validate_capabilities,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _default_capabilities (backward-compat inference)
+# ---------------------------------------------------------------------------
+
+
+def test_default_capabilities_docker():
+    caps = _default_capabilities("docker")
+    assert caps["hotplug"] is True
+    assert caps["max_nics"] == 99
+    assert caps["machine"] is None
+
+
+def test_default_capabilities_qemu():
+    caps = _default_capabilities("qemu")
+    assert caps["hotplug"] is False
+    assert caps["max_nics"] == 8
+    assert caps["machine"] == "pc"
+
+
+def test_default_capabilities_iol():
+    caps = _default_capabilities("iol")
+    assert caps["hotplug"] is False
+    assert caps["max_nics"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _validate_capabilities
+# ---------------------------------------------------------------------------
+
+
+def test_validate_capabilities_none_returns_defaults_for_qemu():
+    caps = _validate_capabilities(None, "qemu", "test.yml")
+    assert caps == {"hotplug": False, "max_nics": 8, "machine": "pc"}
+
+
+def test_validate_capabilities_none_returns_defaults_for_docker():
+    caps = _validate_capabilities(None, "docker", "test.yml")
+    assert caps == {"hotplug": True, "max_nics": 99, "machine": None}
+
+
+def test_validate_capabilities_full_qemu():
+    caps = _validate_capabilities(
+        {"hotplug": True, "max_nics": 8, "machine": "q35"}, "qemu", "test.yml"
+    )
+    assert caps["hotplug"] is True
+    assert caps["max_nics"] == 8
+    assert caps["machine"] == "q35"
+
+
+def test_validate_capabilities_hotplug_false_with_pc_is_ok():
+    caps = _validate_capabilities(
+        {"hotplug": False, "max_nics": 4, "machine": "pc"}, "qemu", "test.yml"
+    )
+    assert caps["hotplug"] is False
+    assert caps["machine"] == "pc"
+
+
+def test_validate_capabilities_hotplug_true_with_pc_raises():
+    with pytest.raises(TemplateError, match="hotplug=true requires machine='q35'"):
+        _validate_capabilities(
+            {"hotplug": True, "machine": "pc"}, "qemu", "test.yml"
+        )
+
+
+def test_validate_capabilities_invalid_machine_raises():
+    with pytest.raises(TemplateError, match="must be one of"):
+        _validate_capabilities({"machine": "i440fx"}, "qemu", "test.yml")
+
+
+def test_validate_capabilities_machine_on_docker_raises():
+    with pytest.raises(TemplateError, match="only valid for qemu"):
+        _validate_capabilities({"machine": "q35"}, "docker", "test.yml")
+
+
+def test_validate_capabilities_max_nics_over_cap_raises():
+    with pytest.raises(TemplateError, match="exceeds the hard cap"):
+        _validate_capabilities({"max_nics": 9}, "qemu", "test.yml")
+
+
+def test_validate_capabilities_max_nics_over_cap_docker_allowed():
+    caps = _validate_capabilities({"max_nics": 50}, "docker", "test.yml")
+    assert caps["max_nics"] == 50
+
+
+def test_validate_capabilities_max_nics_zero_raises():
+    with pytest.raises(TemplateError, match="at least 1"):
+        _validate_capabilities({"max_nics": 0}, "qemu", "test.yml")
+
+
+def test_validate_capabilities_non_bool_hotplug_raises():
+    with pytest.raises(TemplateError, match="must be a boolean"):
+        _validate_capabilities({"hotplug": 1}, "qemu", "test.yml")
+
+
+def test_validate_capabilities_non_int_max_nics_raises():
+    with pytest.raises(TemplateError, match="must be an integer"):
+        _validate_capabilities({"max_nics": "8"}, "qemu", "test.yml")
+
+
+def test_validate_capabilities_not_dict_raises():
+    with pytest.raises(TemplateError, match="must be an object"):
+        _validate_capabilities("true", "qemu", "test.yml")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via TemplateService (file loading)
+# ---------------------------------------------------------------------------
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+@pytest.fixture()
+def svc(tmp_path, monkeypatch):
+    settings = SimpleNamespace(
+        TEMPLATES_DIR=tmp_path / "templates",
+        IMAGES_DIR=tmp_path / "images",
+        TMP_DIR=tmp_path / "tmp",
+        LABS_DIR=tmp_path / "labs",
+        QEMU_BINARY="qemu-system-x86_64",
+        QEMU_IMG_BINARY="qemu-img",
+        DOCKER_HOST="unix:///var/run/docker.sock",
+        SESSION_MAX_AGE=14400,
+    )
+    monkeypatch.setattr("app.services.template_service.get_settings", lambda: settings)
+    return TemplateService()
+
+
+def test_as_response_includes_capabilities(svc, tmp_path):
+    _write_text(
+        svc.templates_dir / "qemu" / "vyos.yml",
+        """type: qemu
+name: VyOS
+cpu: 1
+ram: 1024
+ethernet: 4
+console_type: telnet
+capabilities:
+  hotplug: true
+  max_nics: 8
+  machine: q35
+""",
+    )
+    tmpl = svc.get_template("qemu", "vyos")
+    resp = tmpl.as_response()
+    assert "capabilities" in resp
+    caps = resp["capabilities"]
+    assert caps["hotplug"] is True
+    assert caps["max_nics"] == 8
+    assert caps["machine"] == "q35"
+
+
+def test_build_node_catalog_includes_capabilities(svc):
+    _write_text(
+        svc.templates_dir / "docker" / "alpine.yml",
+        """type: docker
+name: Alpine
+cpu: 1
+ram: 512
+ethernet: 1
+console_type: telnet
+""",
+    )
+    catalog = svc.build_node_catalog()
+    assert len(catalog["templates"]) == 1
+    tmpl_entry = catalog["templates"][0]
+    assert "capabilities" in tmpl_entry
+    caps = tmpl_entry["capabilities"]
+    # Docker defaults: hotplug=True, max_nics=99, machine=None
+    assert caps["hotplug"] is True
+    assert caps["max_nics"] == 99
+    assert caps["machine"] is None
+
+
+def test_template_without_capabilities_uses_inferred_defaults_qemu(svc):
+    _write_text(
+        svc.templates_dir / "qemu" / "legacy.yml",
+        """type: qemu
+name: Legacy Router
+cpu: 1
+ram: 512
+ethernet: 2
+console_type: telnet
+""",
+    )
+    tmpl = svc.get_template("qemu", "legacy")
+    caps = tmpl.capabilities
+    # Inferred defaults: hotplug=False, max_nics=8, machine=pc
+    assert caps["hotplug"] is False
+    assert caps["max_nics"] == 8
+    assert caps["machine"] == "pc"
+
+
+def test_template_invalid_capabilities_raises_on_load(svc):
+    _write_text(
+        svc.templates_dir / "qemu" / "bad.yml",
+        """type: qemu
+name: Bad Template
+cpu: 1
+ram: 512
+ethernet: 1
+console_type: telnet
+capabilities:
+  hotplug: true
+  machine: pc
+""",
+    )
+    # _load_templates raises TemplateError because hotplug=True + machine=pc is inconsistent
+    with pytest.raises(TemplateError, match="hotplug=true requires machine='q35'"):
+        svc.get_template("qemu", "bad")
+
+
+def test_list_templates_response_includes_capabilities(svc):
+    _write_text(
+        svc.templates_dir / "qemu" / "vyos.yml",
+        """type: qemu
+name: VyOS
+cpu: 1
+ram: 1024
+ethernet: 4
+console_type: telnet
+capabilities:
+  hotplug: true
+  max_nics: 8
+  machine: q35
+""",
+    )
+    result = svc.list_templates("qemu")
+    assert "vyos" in result
+    assert "capabilities" in result["vyos"]
+    assert result["vyos"]["capabilities"]["hotplug"] is True

--- a/frontend/src/lib/components/canvas/NodeConfigModal.svelte
+++ b/frontend/src/lib/components/canvas/NodeConfigModal.svelte
@@ -661,6 +661,32 @@
               </div>
             {/if}
 
+            {#if selectedTemplate?.capabilities}
+              {@const caps = selectedTemplate.capabilities}
+              <div class="rounded-2xl border border-slate-700 bg-slate-900/60 p-4" data-testid="capabilities-banner">
+                <div class="text-[10px] uppercase tracking-[0.05em] text-slate-500">Capabilities</div>
+                <div class="mt-2 flex flex-wrap gap-2 text-[11px]">
+                  {#if caps.hotplug}
+                    <span class="rounded-full border border-emerald-700/50 bg-emerald-900/30 px-2 py-1 text-emerald-300">
+                      Hot-plug supported
+                    </span>
+                  {:else}
+                    <span class="rounded-full border border-amber-700/50 bg-amber-900/30 px-2 py-1 text-amber-300">
+                      Restart required to change topology
+                    </span>
+                  {/if}
+                  <span class="rounded-full border border-slate-700 bg-slate-900 px-2 py-1 text-slate-300">
+                    max NICs: {caps.max_nics}
+                  </span>
+                  {#if caps.machine}
+                    <span class="rounded-full border border-slate-700 bg-slate-900 px-2 py-1 text-slate-300">
+                      machine: {caps.machine}
+                    </span>
+                  {/if}
+                </div>
+              </div>
+            {/if}
+
             <div class="rounded-2xl border border-slate-800 bg-slate-950/80 p-4">
               <div class="text-[10px] uppercase tracking-[0.05em] text-slate-500">Template summary</div>
               <div class="mt-2 text-sm text-slate-100">{selectedTemplate?.name ?? 'No template selected'}</div>

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -243,6 +243,13 @@ export interface NodeCatalogExtraField {
   runtime?: boolean;
 }
 
+export interface TemplateCapabilities {
+  hotplug: boolean;
+  max_nics: number;
+  /** QEMU machine type (q35 or pc). null for non-QEMU templates. */
+  machine: 'q35' | 'pc' | null;
+}
+
 export interface NodeCatalogTemplate {
   key: string;
   type: 'qemu' | 'docker' | 'iol' | 'dynamips';
@@ -252,6 +259,7 @@ export interface NodeCatalogTemplate {
   images: NodeCatalogImage[];
   icon_options: string[];
   extras_schema?: NodeCatalogExtraField[];
+  capabilities?: TemplateCapabilities;
 }
 
 export interface NodeCatalog {

--- a/frontend/tests/NodeConfigModal.test.ts
+++ b/frontend/tests/NodeConfigModal.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Tests for US-305: capabilities banner in NodeConfigModal.
+ *
+ * NOTE: Full reactive-lifecycle tests (banner visible after template auto-select)
+ * are deferred to US-305b. @testing-library/svelte v5 + Svelte 5 legacy reactive
+ * labels ($:) require flushSync / rerender-based patterns that are out of scope
+ * here. The tests below verify:
+ *   1. The modal renders without error for each capability variant.
+ *   2. The "no capabilities" path confirms banner absence on a freshly mounted
+ *      modal whose catalog template has no capabilities field.
+ *   3. The TemplateCapabilities TypeScript type is structurally correct.
+ *
+ * TODO(US-305b): add full reactive banner-visibility tests once the team picks
+ * a canonical Svelte 5 testing pattern (flushSync or rerender).
+ */
+
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { tick } from 'svelte';
+import NodeConfigModal from '$lib/components/canvas/NodeConfigModal.svelte';
+import type { NodeCatalog, NodeCatalogTemplate, TemplateCapabilities } from '$lib/types';
+
+function makeTemplate(caps?: TemplateCapabilities): NodeCatalogTemplate {
+  return {
+    key: 'vyos',
+    type: 'qemu',
+    name: 'VyOS',
+    description: 'VyOS router',
+    defaults: {
+      type: 'qemu',
+      template: 'vyos',
+      image: 'vyos-1.4',
+      icon_type: 'router',
+      icon: 'Router.png',
+      cpu: 1,
+      ram: 1024,
+      ethernet: 4,
+      console_type: 'telnet',
+      delay: 0,
+      cpulimit: 1,
+    },
+    images: [{ image: 'vyos-1.4' }],
+    icon_options: ['Router.png'],
+    extras_schema: [],
+    ...(caps !== undefined ? { capabilities: caps } : {}),
+  };
+}
+
+function makeCatalog(template: NodeCatalogTemplate): NodeCatalog {
+  return {
+    templates: [template],
+    icon_options: ['Router.png'],
+    create_fields: [],
+    edit_fields: [],
+    runtime_editability: { always: [], stopped_only: [], immutable: [] },
+  };
+}
+
+describe('NodeConfigModal capabilities banner — static paths', () => {
+  it('renders without error when catalog template has hotplug=true', async () => {
+    const catalog = makeCatalog(makeTemplate({ hotplug: true, max_nics: 8, machine: 'q35' }));
+    render(NodeConfigModal, { props: { open: true, mode: 'create', catalog, node: null } });
+    await tick();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('renders without error when catalog template has hotplug=false', async () => {
+    const catalog = makeCatalog(makeTemplate({ hotplug: false, max_nics: 8, machine: 'pc' }));
+    render(NodeConfigModal, { props: { open: true, mode: 'create', catalog, node: null } });
+    await tick();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('renders without error for docker template with max_nics=99 and machine=null', async () => {
+    const catalog = makeCatalog(makeTemplate({ hotplug: true, max_nics: 99, machine: null }));
+    render(NodeConfigModal, { props: { open: true, mode: 'create', catalog, node: null } });
+    await tick();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('no capabilities banner when template has no capabilities field (backward compat)', async () => {
+    const catalog = makeCatalog(makeTemplate(undefined));
+    render(NodeConfigModal, { props: { open: true, mode: 'create', catalog, node: null } });
+    await tick();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    // Banner must be absent — capabilities field is undefined on this template
+    expect(screen.queryByTestId('capabilities-banner')).toBeNull();
+  });
+
+  it('TemplateCapabilities type accepts all three variants (type-level smoke)', () => {
+    const qemu: TemplateCapabilities = { hotplug: true, max_nics: 8, machine: 'q35' };
+    const docker: TemplateCapabilities = { hotplug: true, max_nics: 99, machine: null };
+    const legacy: TemplateCapabilities = { hotplug: false, max_nics: 8, machine: 'pc' };
+
+    expect(qemu.machine).toBe('q35');
+    expect(docker.machine).toBeNull();
+    expect(legacy.hotplug).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #103. Part of #80.

Wave 7 root — adds template capabilities block (hotplug, max_nics, machine) with backward-compat default inference. Replaces any global env-var-based NIC cap with per-template control.

## Summary

- **Backend schema**: `_validate_capabilities()` parses the top-level `capabilities:` YAML block; `_default_capabilities()` infers sensible defaults by node type when the block is absent (Docker: `hotplug=True`, `max_nics=99`; QEMU/others: `hotplug=False`, `max_nics=8`, `machine=pc`). Hard cap: `max_nics ≤ 8` for non-Docker templates (Principle 5 IFNAMSIZ budget). Consistency guard: `hotplug=true` + `machine=pc` raises `TemplateError` at template-load time.
- **API surface**: `TemplateDefinition.as_response()` and `build_node_catalog()` both now include `capabilities` in their output, so all existing list/get endpoints expose it without router changes.
- **In-tree QEMU templates**: `vyos.yml` and `csr.yml` gain `capabilities: {hotplug: true, max_nics: 8, machine: q35}` — both support PCIe hot-plug under q35.
- **Frontend types**: new `TemplateCapabilities` interface + optional `capabilities?` on `NodeCatalogTemplate`.
- **UI banner**: `NodeConfigModal.svelte` renders a `data-testid="capabilities-banner"` block below the extras section showing hotplug status (green "Hot-plug supported" / amber "Restart required to change topology"), max NICs, and machine type (QEMU only).
- **Backward compat**: existing labs and templates without a `capabilities` block continue to work via inferred defaults — no migration needed.

## Test plan

- [x] `backend/tests/test_template_capabilities.py` — 21 tests: unit coverage of `_default_capabilities` and `_validate_capabilities` (all error paths), plus integration tests via `TemplateService` (load from YAML, `as_response()` shape, `build_node_catalog()` shape, legacy template fallback, invalid template rejected on load)
- [x] `frontend/tests/NodeConfigModal.test.ts` — 5 tests: modal renders without error for each capability variant; banner absent when template has no capabilities; `TemplateCapabilities` type smoke test
- [ ] **TODO (US-305b)**: full reactive banner-visibility tests (banner text assertions after template auto-select) — deferred because `@testing-library/svelte` v5 + Svelte 5 legacy `$:` labels require a `flushSync`/`rerender` pattern not yet established in this repo; tracked as a follow-up comment in `frontend/tests/NodeConfigModal.test.ts`
- [x] `pnpm check` — 0 errors, 0 warnings (1928 files)
- [x] `pnpm test --run` — 102 tests, 17 files, all green
- [x] `uv run pytest tests/test_template_capabilities.py` — 21/21 passed