### PR TITLE
US-103: one-shot link dedup script (#83)

### DIFF
--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from app.config import get_settings
 from app.services.lab_lock import lab_lock
 from app.services.lab_service import LabService, _normalize_relative_lab_path
+from app.services.link_utils import _endpoint_key, _link_pair_key  # noqa: F401 — re-exported
 from app.services.ws_hub import ws_hub
 
 
@@ -29,20 +30,6 @@ class DuplicateLinkError(Exception):
     def __init__(self, existing_link: dict) -> None:
         super().__init__("link already exists")
         self.existing_link = existing_link
-
-
-def _endpoint_key(ep: dict) -> tuple:
-    """Return a hashable key for a normalised endpoint dict."""
-    if "network_id" in ep:
-        return ("network", int(ep["network_id"]))
-    return ("node", int(ep["node_id"]), int(ep.get("interface_index", 0)))
-
-
-def _link_pair_key(ep_a: dict, ep_b: dict) -> tuple:
-    """Return a canonical (order-independent) key for a {from, to} pair."""
-    ka = _endpoint_key(ep_a)
-    kb = _endpoint_key(ep_b)
-    return (min(ka, kb), max(ka, kb))
 
 
 def _refcount(lab_data: dict, network_id: int) -> int:

--- a/backend/app/services/link_utils.py
+++ b/backend/app/services/link_utils.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure link-endpoint helpers shared between link_service and standalone scripts.
+
+These functions have zero heavy dependencies so they can be imported by
+scripts/dedup_links.py without triggering the full app stack (database, etc.).
+"""
+
+from __future__ import annotations
+
+
+def _endpoint_key(ep: dict) -> tuple:
+    """Return a hashable key for a normalised endpoint dict."""
+    if "network_id" in ep:
+        return ("network", int(ep["network_id"]))
+    return ("node", int(ep["node_id"]), int(ep.get("interface_index", 0)))
+
+
+def _link_pair_key(ep_a: dict, ep_b: dict) -> tuple:
+    """Return a canonical (order-independent) key for a {from, to} pair."""
+    ka = _endpoint_key(ep_a)
+    kb = _endpoint_key(ep_b)
+    return (min(ka, kb), max(ka, kb))

--- a/backend/tests/test_dedup_links_script.py
+++ b/backend/tests/test_dedup_links_script.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""US-103 — Tests for scripts/dedup_links.py.
+
+Strategy: import the script module directly (not subprocess) so tests run
+fast and get proper pytest tracebacks.  The process_lab() and
+_dedup_links_v2() functions are the units under test.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Make the repo scripts/ directory importable.
+# File lives at backend/tests/test_dedup_links_script.py → parents[2] = repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import dedup_links  # noqa: E402 — imported after sys.path setup
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_link(
+    link_id: str,
+    from_ep: dict[str, Any],
+    to_ep: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "id": link_id,
+        "from": from_ep,
+        "to": to_ep,
+        "style_override": None,
+        "label": "",
+        "color": "",
+        "width": "1",
+        "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+    }
+
+
+def _seed_lab(
+    labs_dir: Path,
+    name: str = "lab.json",
+    links: list[dict[str, Any]] | None = None,
+) -> Path:
+    payload: dict[str, Any] = {
+        "schema": 2,
+        "id": name.replace(".json", ""),
+        "meta": {"name": name},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {},
+        "networks": {},
+        "links": links or [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    lab_path = labs_dir / name
+    lab_path.write_text(json.dumps(payload), encoding="utf-8")
+    return lab_path
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _dedup_links_v2
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_no_duplicates():
+    """Clean lab with no duplicates — zero removed."""
+    links = [
+        _make_link("lnk_001", {"node_id": 1, "interface_index": 0}, {"network_id": 5}),
+        _make_link("lnk_002", {"node_id": 2, "interface_index": 0}, {"network_id": 5}),
+    ]
+    deduped, removed = dedup_links._dedup_links(links)
+    assert removed == 0
+    assert len(deduped) == 2
+
+
+def test_dedup_identical_pair():
+    """A→B followed by A→B keeps first, removes second."""
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+    links = [
+        _make_link("lnk_001", ep_a, ep_b),
+        _make_link("lnk_002", ep_a, ep_b),
+    ]
+    deduped, removed = dedup_links._dedup_links(links)
+    assert removed == 1
+    assert len(deduped) == 1
+    assert deduped[0]["id"] == "lnk_001"
+
+
+def test_dedup_reversed_pair():
+    """B→A after A→B is detected as a duplicate (bidirectional)."""
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+    links = [
+        _make_link("lnk_001", ep_a, ep_b),
+        _make_link("lnk_002", ep_b, ep_a),  # reversed
+    ]
+    deduped, removed = dedup_links._dedup_links(links)
+    assert removed == 1
+    assert deduped[0]["id"] == "lnk_001"
+
+
+def test_dedup_keeps_first_occurrence():
+    """When three copies exist, only the first is kept."""
+    ep_a = {"node_id": 3, "interface_index": 1}
+    ep_b = {"network_id": 7}
+    links = [
+        _make_link("lnk_001", ep_a, ep_b),
+        _make_link("lnk_002", ep_a, ep_b),
+        _make_link("lnk_003", ep_b, ep_a),
+    ]
+    deduped, removed = dedup_links._dedup_links(links)
+    assert removed == 2
+    assert len(deduped) == 1
+    assert deduped[0]["id"] == "lnk_001"
+
+
+def test_dedup_distinct_pairs_untouched():
+    """Two different node→network pairs are both kept."""
+    links = [
+        _make_link("lnk_001", {"node_id": 1, "interface_index": 0}, {"network_id": 5}),
+        _make_link("lnk_002", {"node_id": 2, "interface_index": 0}, {"network_id": 5}),
+        _make_link("lnk_003", {"node_id": 1, "interface_index": 1}, {"network_id": 6}),
+    ]
+    deduped, removed = dedup_links._dedup_links(links)
+    assert removed == 0
+    assert len(deduped) == 3
+
+
+def test_dedup_empty_links():
+    """Empty links list is a no-op."""
+    deduped, removed = dedup_links._dedup_links([])
+    assert removed == 0
+    assert deduped == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests using process_lab()
+# ---------------------------------------------------------------------------
+
+
+def test_process_lab_no_op_when_clean(tmp_path):
+    """process_lab returns 0 removed on an already-clean lab."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    lab_path = _seed_lab(
+        labs_dir,
+        links=[
+            _make_link("lnk_001", {"node_id": 1, "interface_index": 0}, {"network_id": 5}),
+        ],
+    )
+    before, removed = dedup_links.process_lab(lab_path, labs_dir, dry_run=False)
+    assert removed == 0
+    assert before == 1
+    # File is untouched (no tmp written).
+    assert not (lab_path.with_suffix(".json.tmp")).exists()
+
+
+def test_process_lab_removes_ab_ba_duplicate(tmp_path):
+    """process_lab collapses A→B + B→A duplicate, keeps lnk_001."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+    lab_path = _seed_lab(
+        labs_dir,
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+            _make_link("lnk_002", ep_b, ep_a),
+        ],
+    )
+
+    before, removed = dedup_links.process_lab(lab_path, labs_dir, dry_run=False)
+
+    assert before == 2
+    assert removed == 1
+
+    saved = json.loads(lab_path.read_text())
+    assert len(saved["links"]) == 1
+    assert saved["links"][0]["id"] == "lnk_001"
+
+
+def test_process_lab_removes_ab_ab_duplicate(tmp_path):
+    """process_lab collapses A→B + A→B duplicate, keeps lnk_001."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    ep_a = {"node_id": 2, "interface_index": 0}
+    ep_b = {"network_id": 10}
+    lab_path = _seed_lab(
+        labs_dir,
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+            _make_link("lnk_002", ep_a, ep_b),
+        ],
+    )
+
+    before, removed = dedup_links.process_lab(lab_path, labs_dir, dry_run=False)
+
+    assert removed == 1
+    saved = json.loads(lab_path.read_text())
+    assert len(saved["links"]) == 1
+    assert saved["links"][0]["id"] == "lnk_001"
+
+
+def test_process_lab_multi_lab_batch(tmp_path):
+    """main() processes multiple labs and reports correct totals."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+
+    # lab_a has a duplicate
+    _seed_lab(
+        labs_dir,
+        name="lab_a.json",
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+            _make_link("lnk_002", ep_b, ep_a),
+        ],
+    )
+    # lab_b is clean
+    _seed_lab(
+        labs_dir,
+        name="lab_b.json",
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+        ],
+    )
+
+    rc = dedup_links.main(["--labs-dir", str(labs_dir)])
+    assert rc == 0
+
+    saved_a = json.loads((labs_dir / "lab_a.json").read_text())
+    assert len(saved_a["links"]) == 1
+
+    saved_b = json.loads((labs_dir / "lab_b.json").read_text())
+    assert len(saved_b["links"]) == 1
+
+
+def test_process_lab_dry_run_does_not_write(tmp_path):
+    """dry_run=True reports duplicates but does not modify the file."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+    lab_path = _seed_lab(
+        labs_dir,
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+            _make_link("lnk_002", ep_b, ep_a),
+        ],
+    )
+    original_text = lab_path.read_text()
+
+    before, removed = dedup_links.process_lab(lab_path, labs_dir, dry_run=True)
+
+    assert removed == 1
+    # File must be unchanged.
+    assert lab_path.read_text() == original_text
+    assert not (lab_path.with_suffix(".json.tmp")).exists()
+
+
+def test_main_dry_run_does_not_write(tmp_path):
+    """main() with --dry-run leaves files untouched."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+    lab_path = _seed_lab(
+        labs_dir,
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+            _make_link("lnk_002", ep_b, ep_a),
+        ],
+    )
+    original_text = lab_path.read_text()
+
+    rc = dedup_links.main(["--labs-dir", str(labs_dir), "--dry-run"])
+
+    assert rc == 0
+    assert lab_path.read_text() == original_text
+
+
+def test_process_lab_idempotent(tmp_path):
+    """Running process_lab twice on the same lab is a no-op on the second run."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+    lab_path = _seed_lab(
+        labs_dir,
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+            _make_link("lnk_002", ep_b, ep_a),
+        ],
+    )
+
+    before1, removed1 = dedup_links.process_lab(lab_path, labs_dir, dry_run=False)
+    assert removed1 == 1
+
+    # Second run — should report 0 removed.
+    before2, removed2 = dedup_links.process_lab(lab_path, labs_dir, dry_run=False)
+    assert removed2 == 0
+    assert before2 == 1
+
+
+def test_main_nonexistent_labs_dir(tmp_path):
+    """main() exits 1 when labs_dir does not exist."""
+    rc = dedup_links.main(["--labs-dir", str(tmp_path / "nonexistent")])
+    assert rc == 1

--- a/scripts/dedup_links.py
+++ b/scripts/dedup_links.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""One-shot dedup script for existing labs — US-103.
+
+Walks every ``*.json`` file under ``LABS_DIR``, collapses canonical-pair
+duplicate links (keeps the entry with the lowest ``id`` string, drops the
+rest), and writes the result back atomically.  Running twice is a no-op.
+
+Pair-key logic is imported from ``app.services.link_utils`` — the same
+canonical key used by the production POST /links duplicate check (US-102).
+
+Usage::
+
+    # dry-run (no files written):
+    python scripts/dedup_links.py --labs-dir /var/lib/nova-ve/labs --dry-run
+
+    # live run:
+    sudo /home/ubuntu/nova-ve-git/.venv/bin/python scripts/dedup_links.py \\
+        --labs-dir /var/lib/nova-ve/labs
+
+Exit codes:
+    0  — all labs processed (including labs that had nothing to dedup)
+    1  — one or more labs could not be processed (errors printed to stderr)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Ensure the backend package is importable when the script is run from the
+# repo root (python scripts/dedup_links.py) or from backend/.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BACKEND_DIR = _REPO_ROOT / "backend"
+for _p in (_BACKEND_DIR, _REPO_ROOT):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+# Import only the pure helpers — no database/ORM imports triggered.
+from app.services.link_utils import _link_pair_key  # noqa: E402
+from app.services.lab_lock import lab_lock  # noqa: E402
+
+
+def _dedup_links(links: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    """Return (deduped_links, n_removed).
+
+    Uses the same canonical pair-key logic as the production POST /links
+    duplicate check (US-102).  Keeps the first occurrence of each pair
+    (lowest lnk_NNN id) and drops subsequent duplicates.
+    """
+    seen: set[tuple] = set()
+    kept: list[dict[str, Any]] = []
+    removed = 0
+
+    for link in links:
+        ep_from = link.get("from")
+        ep_to = link.get("to")
+        if not isinstance(ep_from, dict) or not isinstance(ep_to, dict):
+            # Malformed link — keep as-is, do not crash.
+            kept.append(link)
+            continue
+        try:
+            pair_key = _link_pair_key(ep_from, ep_to)
+        except (ValueError, TypeError, KeyError):
+            # Unparseable endpoints — keep as-is.
+            kept.append(link)
+            continue
+
+        if pair_key not in seen:
+            seen.add(pair_key)
+            kept.append(link)
+        else:
+            removed += 1
+
+    return kept, removed
+
+
+def process_lab(
+    lab_path: Path,
+    labs_dir: Path,
+    *,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Process a single lab file.
+
+    Returns ``(links_before, links_removed)``.
+    Raises on I/O or JSON errors.
+    """
+    # lab_id is the path relative to labs_dir, POSIX-style.
+    try:
+        rel = lab_path.relative_to(labs_dir)
+    except ValueError:
+        rel = lab_path.name  # type: ignore[assignment]
+    lab_id = Path(rel).as_posix()
+
+    with lab_lock(lab_id, labs_dir):
+        raw = lab_path.read_text(encoding="utf-8")
+        data: dict[str, Any] = json.loads(raw)
+
+        if not isinstance(data, dict) or data.get("schema") != 2:
+            # Legacy v1 or non-lab file — skip silently.
+            return 0, 0
+
+        links: list[dict[str, Any]] = data.get("links") or []
+        before = len(links)
+
+        deduped, removed = _dedup_links(links)
+
+        if removed == 0:
+            return before, 0
+
+        if dry_run:
+            return before, removed
+
+        data["links"] = deduped
+        # Remove synthesized legacy shim so write does not regenerate links[].
+        data.pop("topology", None)
+
+        # Atomic write: write to .tmp then rename.
+        tmp_path = lab_path.with_suffix(".json.tmp")
+        try:
+            tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            os.replace(tmp_path, lab_path)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    return before, removed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--labs-dir",
+        type=Path,
+        default=Path("/var/lib/nova-ve/labs"),
+        help="Path to the labs directory (default: /var/lib/nova-ve/labs)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print what would change without writing any files",
+    )
+    args = parser.parse_args(argv)
+
+    labs_dir: Path = args.labs_dir.resolve()
+    dry_run: bool = args.dry_run
+
+    if not labs_dir.is_dir():
+        print(f"[dedup_links] ERROR: labs_dir does not exist: {labs_dir}", file=sys.stderr)
+        return 1
+
+    if dry_run:
+        print(f"[dedup_links] DRY RUN — no files will be written. labs_dir={labs_dir}")
+    else:
+        print(f"[dedup_links] Starting link dedup. labs_dir={labs_dir}")
+
+    lab_files = sorted(labs_dir.rglob("*.json"))
+    total_labs = 0
+    total_removed = 0
+    errors = 0
+
+    for lab_path in lab_files:
+        # Skip temp files accidentally globbed.
+        if lab_path.stem.endswith(".tmp"):
+            continue
+
+        try:
+            before, removed = process_lab(lab_path, labs_dir, dry_run=dry_run)
+        except Exception as exc:
+            print(
+                f"[dedup_links] ERROR processing {lab_path}: {exc}",
+                file=sys.stderr,
+            )
+            errors += 1
+            continue
+
+        if before == 0 and removed == 0:
+            # Non-lab file or legacy schema — skip reporting.
+            continue
+
+        total_labs += 1
+        total_removed += removed
+
+        if removed > 0:
+            action = "would remove" if dry_run else "removed"
+            print(
+                f"[dedup_links] {lab_path.name}: {action} {removed} duplicate link(s) "
+                f"({before} → {before - removed})"
+            )
+        else:
+            print(f"[dedup_links] {lab_path.name}: clean (no duplicates)")
+
+    suffix = " (dry run)" if dry_run else ""
+    print(
+        f"[dedup_links] Done{suffix}. "
+        f"labs={total_labs}, links_removed={total_removed}, errors={errors}"
+    )
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #83. Part of #80.

Final Wave 5 story — migrates existing labs that accumulated duplicate links before US-102 (#82) hardened POST /links.

## Summary
- Adds `scripts/dedup_links.py`: walks all `*.json` files in `LABS_DIR`, collapses canonical-pair duplicate links (keeps first occurrence by lnk_NNN id), writes back atomically via `.json.tmp` + `os.replace()`
- Extracts `_endpoint_key` and `_link_pair_key` into `backend/app/services/link_utils.py` (zero heavy deps) so both `link_service.py` and the standalone script share the exact same pair-key logic — no drift possible
- `--dry-run` flag prints what would change without writing; exit 0 on success even if no changes; exit 1 only on real errors
- Idempotent: running twice is a no-op (second pass finds zero duplicates)

## Test plan
- [x] `test_dedup_no_duplicates` — clean lab returns 0 removed
- [x] `test_dedup_identical_pair` — A→B + A→B keeps first, drops second
- [x] `test_dedup_reversed_pair` — B→A after A→B detected as duplicate (bidirectional)
- [x] `test_dedup_keeps_first_occurrence` — three copies → only first kept
- [x] `test_process_lab_removes_ab_ba_duplicate` — integration: file is written correctly
- [x] `test_process_lab_removes_ab_ab_duplicate` — integration: symmetric case
- [x] `test_process_lab_multi_lab_batch` — `main()` processes multiple labs, correct totals
- [x] `test_process_lab_dry_run_does_not_write` — file unchanged after dry_run
- [x] `test_main_dry_run_does_not_write` — CLI --dry-run leaves files untouched
- [x] `test_process_lab_idempotent` — second run is a no-op
- [x] `test_main_nonexistent_labs_dir` — exits 1 when labs_dir missing
- All 448 tests green: `backend/.venv/bin/python -m pytest tests/ -x`

## Operator usage
```bash
# Dry run first (safe):
sudo /home/ubuntu/nova-ve-git/.venv/bin/python scripts/dedup_links.py \
    --labs-dir /var/lib/nova-ve/labs --dry-run

# Live run:
sudo /home/ubuntu/nova-ve-git/.venv/bin/python scripts/dedup_links.py \
    --labs-dir /var/lib/nova-ve/labs
```
Expected: alpine-docker-demo `links[]` reduces from 7 to 3.