### PR TITLE
US-202: real Linux bridge in create_network (#88)

### DIFF
--- a/backend/app/routers/networks.py
+++ b/backend/app/routers/networks.py
@@ -84,7 +84,16 @@ async def create_network(
     if err is not None:
         return err
 
-    payload = await network_service.create_network(lab_path, request.model_dump())
+    try:
+        payload = await network_service.create_network(lab_path, request.model_dump())
+    except NetworkServiceError as exc:
+        body: Dict[str, Any] = {
+            "code": exc.code,
+            "status": "fail",
+            "message": exc.message,
+        }
+        body.update(exc.extra)
+        return JSONResponse(status_code=exc.code, content=body)
     return JSONResponse(
         status_code=201,
         content={

--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 """
-host_net — Linux bridge / TAP name helpers and instance-ID provisioning.
+host_net — Linux bridge / TAP name helpers, instance-ID provisioning, and
+thin Python wrappers around the privileged ``nova-ve-net.py`` helper.
 
 Bridge name format : nove{lab_hash:04x}n{network_id}   (≤14 chars, network_id ≤ 99999)
 TAP name format    : nve{lab_hash:04x}d{node_id}i{iface}  (≤13 chars, node_id ≤ 999, iface ≤ 99)
@@ -17,12 +18,18 @@ Precedence rules (file-wins with explicit env override):
   2. If NOVA_VE_INSTANCE_ID is set AND NOVA_VE_INSTANCE_ID_OVERRIDE_OK=1 → use env value
      (WARNING logged on every call).
   3. Otherwise → raise HostNetInstanceIdMissing.
+
+Privileged helper (US-201) is invoked via:
+  sudo $NOVA_VE_HELPER_BIN <verb> [args...]
+where NOVA_VE_HELPER_BIN defaults to /opt/nova-ve/bin/nova-ve-net.py.
 """
 
 import hashlib
 import logging
 import os
+import subprocess
 from pathlib import Path
+from typing import Sequence
 
 logger = logging.getLogger("nova-ve")
 
@@ -38,6 +45,31 @@ class HostNetInstanceIdMissing(RuntimeError):
     instance_id file was removed).  The backend MUST NOT start without a
     valid instance ID — bridge name collisions across hosts would result.
     """
+
+
+class HostNetError(RuntimeError):
+    """Base class for nova-ve-net helper invocation failures."""
+
+    def __init__(self, message: str, *, returncode: int = 0, stderr: str = ""):
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class HostNetValidationError(HostNetError):
+    """Helper rejected an argument (regex / ownership) → exit code 2."""
+
+
+class HostNetEEXIST(HostNetError):
+    """The kernel object already exists (e.g. duplicate bridge name)."""
+
+
+class HostNetEINVAL(HostNetError):
+    """The helper's underlying ``ip`` invocation rejected the request."""
+
+
+class HostNetUnknown(HostNetError):
+    """Unknown verb or unparseable failure."""
 
 
 # ---------------------------------------------------------------------------
@@ -129,3 +161,100 @@ def tap_name(lab_id: str, node_id: int, iface: int) -> str:
     name = f"nve{h:04x}d{node_id}i{iface}"
     assert len(name) <= 14, f"tap_name overflow: {name!r} ({len(name)} chars)"
     return name
+
+
+# ---------------------------------------------------------------------------
+# Privileged helper invocation (US-201 wrapper)
+# ---------------------------------------------------------------------------
+
+_HELPER_BIN_DEFAULT = "/opt/nova-ve/bin/nova-ve-net.py"
+_SUDO_BIN_DEFAULT = "/usr/bin/sudo"
+_IP_BIN_DEFAULT = "/sbin/ip"
+
+
+def _helper_bin() -> str:
+    return os.environ.get("NOVA_VE_HELPER_BIN", _HELPER_BIN_DEFAULT)
+
+
+def _sudo_bin() -> str:
+    return os.environ.get("NOVA_VE_SUDO_BIN", _SUDO_BIN_DEFAULT)
+
+
+def _ip_bin() -> str:
+    return os.environ.get("NOVA_VE_IP_BIN", _IP_BIN_DEFAULT)
+
+
+def _run(argv: Sequence[str]) -> "subprocess.CompletedProcess[str]":
+    """Spawn ``argv`` (shell=False) and return the completed process.
+
+    Captures stdout+stderr as text. Tests monkey-patch this function.
+    """
+    return subprocess.run(
+        list(argv),
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _classify_helper_failure(
+    stderr: str, returncode: int
+) -> HostNetError:
+    """Map helper exit code + stderr to a typed exception."""
+    msg = stderr.strip() or f"nova-ve-net.py exited with {returncode}"
+    if returncode == 2:
+        return HostNetValidationError(msg, returncode=returncode, stderr=stderr)
+    if returncode == 3:
+        return HostNetUnknown(msg, returncode=returncode, stderr=stderr)
+    # exit 1 — underlying ``ip`` invocation failed.
+    lower = stderr.lower()
+    if "exists" in lower or "file exists" in lower:
+        return HostNetEEXIST(msg, returncode=returncode, stderr=stderr)
+    if "does not exist" in lower or "cannot find" in lower or "no such" in lower:
+        return HostNetEINVAL(msg, returncode=returncode, stderr=stderr)
+    return HostNetEINVAL(msg, returncode=returncode, stderr=stderr)
+
+
+def _invoke_helper(verb: str, *args: str) -> "subprocess.CompletedProcess[str]":
+    """Run ``sudo <helper> <verb> [args...]`` and raise typed errors on failure."""
+    argv = [_sudo_bin(), "-n", _helper_bin(), verb, *args]
+    proc = _run(argv)
+    if proc.returncode != 0:
+        raise _classify_helper_failure(proc.stderr or "", proc.returncode)
+    return proc
+
+
+def bridge_exists(name: str) -> bool:
+    """Return True if a Linux interface with ``name`` is currently present.
+
+    Used for idempotency in ``create_network``: we re-use a pre-existing
+    bridge with the right name rather than failing on EEXIST. The query
+    runs without sudo (``ip link show`` is unprivileged read access).
+    """
+    try:
+        proc = _run([_ip_bin(), "link", "show", name])
+    except FileNotFoundError:
+        # ``ip`` missing entirely — treat as "no" so callers see a real
+        # bridge_add error if they go on to provision.
+        return False
+    return proc.returncode == 0
+
+
+def bridge_add(name: str) -> None:
+    """Create a Linux bridge with ``name`` via the privileged helper.
+
+    Raises :class:`HostNetEEXIST` if the bridge already exists, or other
+    :class:`HostNetError` subclasses on validation / kernel failures.
+    Idempotency is the *caller's* responsibility — call
+    :func:`bridge_exists` first if no-op-on-exists semantics are desired.
+    """
+    _invoke_helper("bridge-add", name)
+
+
+def bridge_del(name: str) -> None:
+    """Delete the Linux bridge ``name`` via the privileged helper.
+
+    Raises :class:`HostNetEINVAL` if the bridge does not exist.
+    """
+    _invoke_helper("bridge-del", name)

--- a/backend/app/services/network_service.py
+++ b/backend/app/services/network_service.py
@@ -3,19 +3,25 @@
 
 """Per-resource network service for v2 lab.json mutations.
 
-US-063 + US-064. All mutations acquire the per-lab flock, persist via
-:class:`LabService`, recompute the MAC registry, and publish WS events.
+US-063 + US-064 — JSON-side mutations under the per-lab flock.
+US-202 — ``create_network`` / ``delete_network`` provision and tear down
+the matching Linux bridge via the privileged helper, persisting
+``runtime.bridge_name`` on the network record.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 from app.config import get_settings
+from app.services import host_net
 from app.services.lab_lock import lab_lock
 from app.services.lab_service import LabService, _normalize_relative_lab_path
 from app.services.link_service import _refcount, _recompute_mac_registry
 from app.services.ws_hub import ws_hub
+
+logger = logging.getLogger("nova-ve")
 
 
 class NetworkServiceError(Exception):
@@ -66,11 +72,13 @@ class NetworkService:
 
         with lab_lock(normalized, labs_dir):
             data = LabService.read_lab_json_static(normalized)
+            lab_id = str(data.get("id") or normalized)
             networks = data.setdefault("networks", {})
             next_id = max(
                 (int(key) for key in networks.keys() if str(key).isdigit()),
                 default=0,
             ) + 1
+            bridge = host_net.bridge_name(lab_id, next_id)
             network = {
                 "id": next_id,
                 "name": request.get("name", "Net"),
@@ -87,10 +95,34 @@ class NetworkService:
                 "implicit": False,
                 "smart": -1,
                 "config": {},
+                "runtime": {"bridge_name": bridge},
             }
             networks[str(next_id)] = network
             data.pop("topology", None)
+            # Persist BEFORE provisioning so on-disk state never leads the
+            # kernel state. If bridge_add then fails we roll the file back.
             LabService.write_lab_json_static(normalized, data)
+            try:
+                # Idempotent: pre-existing bridge with the right name is a
+                # no-op (e.g. backend restarted mid-create, or US-202b
+                # backfill already provisioned it).
+                if not host_net.bridge_exists(bridge):
+                    host_net.bridge_add(bridge)
+            except host_net.HostNetError as exc:
+                # Roll back the JSON write — never leave inconsistent state.
+                networks.pop(str(next_id), None)
+                data["networks"] = networks
+                LabService.write_lab_json_static(normalized, data)
+                logger.error(
+                    "create_network: bridge_add(%s) failed (%s); rolled back lab.json",
+                    bridge,
+                    exc,
+                )
+                raise NetworkServiceError(
+                    409,
+                    f"Failed to provision bridge {bridge}: {exc}",
+                    extra={"bridge": bridge},
+                ) from exc
             _recompute_mac_registry(normalized, data)
             payload = _serialize_network(network, 0)
 
@@ -122,6 +154,34 @@ class NetworkService:
             data.pop("topology", None)
             LabService.write_lab_json_static(normalized, data)
             _recompute_mac_registry(normalized, data)
+            # Tear down the bridge AFTER the JSON write commits. Best-effort:
+            # a bridge that has already been removed (e.g. by the orphan
+            # sweeper from US-206) is logged but not propagated as a 5xx —
+            # the network record is gone either way.
+            runtime = network.get("runtime") or {}
+            bridge = runtime.get("bridge_name")
+            if not bridge:
+                # Pre-Wave-6 record — recompute the name to clean up.
+                lab_id = str(data.get("id") or normalized)
+                try:
+                    bridge = host_net.bridge_name(lab_id, int(network_id))
+                except Exception:  # noqa: BLE001 — defensive
+                    bridge = None
+            if bridge:
+                try:
+                    host_net.bridge_del(bridge)
+                except host_net.HostNetEINVAL:
+                    logger.info(
+                        "delete_network: bridge %s already absent; nothing to do",
+                        bridge,
+                    )
+                except host_net.HostNetError as exc:
+                    logger.warning(
+                        "delete_network: bridge_del(%s) failed (%s); "
+                        "JSON record removed regardless",
+                        bridge,
+                        exc,
+                    )
 
         await ws_hub.publish(normalized, "network_deleted", {"network": removed})
         return removed

--- a/backend/tests/test_network_service.py
+++ b/backend/tests/test_network_service.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""US-202 — ``network_service.create_network`` provisions a real Linux bridge.
+
+Asserts the contract specified in
+``.omc/plans/network-runtime-wiring.md`` § US-202:
+
+  * ``host_net.bridge_add`` is invoked with the
+    ``nove{lab_hash:04x}n{network_id}`` name derived from the lab UUID and
+    instance ID.
+  * The same lab_id with different instance_ids yields different bridge
+    names (collision-resistant cross-host).
+  * The bridge name is persisted on the network record under
+    ``runtime.bridge_name`` (US-401 schema field, hoisted by US-202).
+  * ``create_network`` is idempotent: when a bridge with the right name
+    already exists (``bridge_exists`` returns True), ``bridge_add`` is
+    NOT invoked.
+  * On ``bridge_add`` failure, the JSON write is rolled back (no leaked
+    network record) and a typed ``NetworkServiceError`` with status 409
+    is raised.
+  * ``delete_network`` invokes ``bridge_del`` with the persisted name.
+
+The privileged helper is MOCKED throughout — no real ``ip link add``
+calls are spawned (CI is un-privileged and would corrupt host network
+state otherwise).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import host_net, network_service as network_service_mod
+from app.services.network_service import (
+    NetworkService,
+    NetworkServiceError,
+)
+
+
+@pytest.fixture()
+def labs_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "labs"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def instance_id(monkeypatch, tmp_path: Path) -> str:
+    """Seed a deterministic instance_id for bridge_name() derivation."""
+    instance_dir = tmp_path / "nova-ve-instance"
+    instance_dir.mkdir()
+    value = "test-instance-uuid-202"
+    (instance_dir / "instance_id").write_text(value)
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    return value
+
+
+@pytest.fixture()
+def settings(monkeypatch, labs_dir):
+    s = SimpleNamespace(LABS_DIR=labs_dir)
+    monkeypatch.setattr(network_service_mod, "get_settings", lambda: s)
+    monkeypatch.setattr("app.services.lab_service.get_settings", lambda: s)
+    monkeypatch.setattr("app.services.link_service.get_settings", lambda: s)
+    return s
+
+
+@pytest.fixture()
+def stub_publish(monkeypatch):
+    captured: list[tuple] = []
+
+    async def fake_publish(lab_id, event_type, payload, rev=""):
+        captured.append((lab_id, event_type, payload))
+        return SimpleNamespace(seq=len(captured), type=event_type, rev=rev, payload=payload)
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", fake_publish)
+    return captured
+
+
+@pytest.fixture()
+def helper_mocks(monkeypatch):
+    """Capture every host_net call and disable real subprocess invocation."""
+    calls = {"bridge_add": [], "bridge_del": [], "bridge_exists": []}
+
+    def fake_add(name: str) -> None:
+        calls["bridge_add"].append(name)
+
+    def fake_del(name: str) -> None:
+        calls["bridge_del"].append(name)
+
+    def fake_exists(name: str) -> bool:
+        calls["bridge_exists"].append(name)
+        return False
+
+    monkeypatch.setattr(host_net, "bridge_add", fake_add)
+    monkeypatch.setattr(host_net, "bridge_del", fake_del)
+    monkeypatch.setattr(host_net, "bridge_exists", fake_exists)
+    return calls
+
+
+def _seed_lab(labs_dir: Path, lab_id: str = "lab-uuid-aaa") -> str:
+    name = "lab.json"
+    (labs_dir / name).write_text(
+        json.dumps(
+            {
+                "schema": 2,
+                "id": lab_id,
+                "meta": {"name": name},
+                "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+                "nodes": {},
+                "networks": {},
+                "links": [],
+                "defaults": {"link_style": "orthogonal"},
+            }
+        )
+    )
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Happy path: bridge is provisioned with the canonical name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_network_provisions_bridge(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    lab_name = _seed_lab(labs_dir, lab_id="lab-uuid-aaa")
+    expected_bridge = host_net.bridge_name("lab-uuid-aaa", 1)
+
+    payload = await NetworkService().create_network(lab_name, {"name": "lan"})
+
+    # Bridge_add was invoked exactly once with the canonical name.
+    assert helper_mocks["bridge_add"] == [expected_bridge]
+    # Idempotency probe was performed.
+    assert helper_mocks["bridge_exists"] == [expected_bridge]
+    # runtime.bridge_name persisted on the response payload.
+    assert payload["runtime"]["bridge_name"] == expected_bridge
+    # And on disk.
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"]["1"]["runtime"]["bridge_name"] == expected_bridge
+
+
+@pytest.mark.asyncio
+async def test_create_network_bridge_name_uses_helper_format(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """The bridge name is exactly ``host_net.bridge_name(lab_id, network_id)``.
+
+    Pinned via the public helper so a future tweak to the naming scheme
+    only has to change one place.
+    """
+    lab_name = _seed_lab(labs_dir, lab_id="another-lab")
+    await NetworkService().create_network(lab_name, {"name": "n1"})
+    [name] = helper_mocks["bridge_add"]
+    assert name == host_net.bridge_name("another-lab", 1)
+    # IFNAMSIZ-safe: ≤14 chars.
+    assert len(name) <= 14
+    assert name.startswith("nove")
+
+
+# ---------------------------------------------------------------------------
+# Cross-host collision resistance
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_name_differs_across_instance_ids(monkeypatch, tmp_path):
+    """Same lab_id on two hosts must produce different bridge names."""
+    dir_a = tmp_path / "a"
+    dir_a.mkdir()
+    (dir_a / "instance_id").write_text("host-a-uuid")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(dir_a))
+    name_a = host_net.bridge_name("shared-lab-id", 1)
+
+    dir_b = tmp_path / "b"
+    dir_b.mkdir()
+    (dir_b / "instance_id").write_text("host-b-uuid")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(dir_b))
+    name_b = host_net.bridge_name("shared-lab-id", 1)
+
+    assert name_a != name_b, (
+        "lab_hash collapsed across hosts — bridge names would collide!"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: pre-existing bridge → no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_network_idempotent_when_bridge_exists(
+    instance_id, settings, monkeypatch, stub_publish, labs_dir
+):
+    lab_name = _seed_lab(labs_dir, lab_id="idem-lab")
+    add_calls: list[str] = []
+    monkeypatch.setattr(host_net, "bridge_exists", lambda n: True)
+    monkeypatch.setattr(
+        host_net, "bridge_add", lambda n: add_calls.append(n)
+    )
+    monkeypatch.setattr(host_net, "bridge_del", lambda n: None)
+
+    payload = await NetworkService().create_network(lab_name, {"name": "lan"})
+
+    # Pre-existing bridge → bridge_add MUST NOT run.
+    assert add_calls == []
+    # The runtime.bridge_name is still stamped — caller must be able to
+    # tear down the bridge later.
+    assert payload["runtime"]["bridge_name"] == host_net.bridge_name("idem-lab", 1)
+
+
+# ---------------------------------------------------------------------------
+# Failure rollback: bridge_add raises → JSON record removed, 409 raised
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_network_rolls_back_on_bridge_add_failure(
+    instance_id, settings, monkeypatch, stub_publish, labs_dir
+):
+    lab_name = _seed_lab(labs_dir, lab_id="fail-lab")
+
+    def boom(name: str) -> None:
+        raise host_net.HostNetEEXIST(
+            "RTNETLINK answers: File exists", returncode=1, stderr="exists"
+        )
+
+    monkeypatch.setattr(host_net, "bridge_exists", lambda n: False)
+    monkeypatch.setattr(host_net, "bridge_add", boom)
+    monkeypatch.setattr(host_net, "bridge_del", lambda n: None)
+
+    with pytest.raises(NetworkServiceError) as excinfo:
+        await NetworkService().create_network(lab_name, {"name": "lan"})
+
+    assert excinfo.value.code == 409
+    # The lab.json was rolled back — no orphaned network record left over.
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"] == {}, "lab.json was not rolled back on failure!"
+
+
+@pytest.mark.asyncio
+async def test_create_network_rollback_on_validation_error(
+    instance_id, settings, monkeypatch, stub_publish, labs_dir
+):
+    """A regex-rejection from the helper also triggers full rollback."""
+    lab_name = _seed_lab(labs_dir, lab_id="val-lab")
+
+    def reject(name: str) -> None:
+        raise host_net.HostNetValidationError(
+            "argument failed validation: bridge_name",
+            returncode=2,
+            stderr="argument failed validation: bridge_name",
+        )
+
+    monkeypatch.setattr(host_net, "bridge_exists", lambda n: False)
+    monkeypatch.setattr(host_net, "bridge_add", reject)
+    monkeypatch.setattr(host_net, "bridge_del", lambda n: None)
+
+    with pytest.raises(NetworkServiceError) as excinfo:
+        await NetworkService().create_network(lab_name, {"name": "lan"})
+
+    assert excinfo.value.code == 409
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"] == {}
+
+
+# ---------------------------------------------------------------------------
+# delete_network tears the bridge down
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_network_removes_bridge(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """``delete_network`` reads the persisted runtime.bridge_name and
+    invokes ``bridge_del`` with that exact value."""
+    lab_name = _seed_lab(labs_dir, lab_id="del-lab")
+    await NetworkService().create_network(lab_name, {"name": "lan"})
+    expected_bridge = host_net.bridge_name("del-lab", 1)
+
+    helper_mocks["bridge_del"].clear()
+    await NetworkService().delete_network(lab_name, 1)
+
+    assert helper_mocks["bridge_del"] == [expected_bridge]
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"] == {}
+
+
+@pytest.mark.asyncio
+async def test_delete_network_tolerates_already_absent_bridge(
+    instance_id, settings, monkeypatch, stub_publish, labs_dir
+):
+    """If the bridge has already been swept (US-206), delete_network
+    completes successfully — the JSON record is the source of truth for
+    the API response, the kernel state is best-effort cleanup."""
+    lab_name = _seed_lab(labs_dir, lab_id="absent-lab")
+    monkeypatch.setattr(host_net, "bridge_exists", lambda n: False)
+    monkeypatch.setattr(host_net, "bridge_add", lambda n: None)
+
+    await NetworkService().create_network(lab_name, {"name": "lan"})
+
+    def gone(name: str) -> None:
+        raise host_net.HostNetEINVAL(
+            "Cannot find device", returncode=1, stderr="does not exist"
+        )
+
+    monkeypatch.setattr(host_net, "bridge_del", gone)
+
+    # No exception — the network record is gone either way.
+    removed = await NetworkService().delete_network(lab_name, 1)
+    assert removed["id"] == 1

--- a/backend/tests/test_networks_api.py
+++ b/backend/tests/test_networks_api.py
@@ -110,7 +110,7 @@ def route_settings(tmp_path):
 
 
 @pytest.fixture()
-def patched_route_settings(monkeypatch, route_settings):
+def patched_route_settings(monkeypatch, tmp_path, route_settings):
     monkeypatch.setattr("app.services.lab_service.get_settings", lambda: route_settings)
     monkeypatch.setattr("app.services.template_service.get_settings", lambda: route_settings)
     monkeypatch.setattr("app.services.node_runtime_service.get_settings", lambda: route_settings)
@@ -119,6 +119,18 @@ def patched_route_settings(monkeypatch, route_settings):
     monkeypatch.setattr("app.services.link_service.get_settings", lambda: route_settings)
     monkeypatch.setattr("app.services.network_service.get_settings", lambda: route_settings)
     monkeypatch.setattr("app.routers.labs.get_settings", lambda: route_settings)
+    # US-202: every network create/delete now derives a bridge name and
+    # invokes the privileged helper. Provide a per-test instance_id so
+    # bridge_name() works deterministically, and stub the helper so no
+    # real `ip link add` runs (CI is un-privileged + would corrupt host
+    # network state).
+    instance_dir = tmp_path / "nova-ve-instance"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text("test-instance-uuid")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
+    monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
     return route_settings
 
 


### PR DESCRIPTION
Closes #88. Part of #80.

Wave 6 critical path — wires `network_service.create_network` to the privileged helper from US-201 to actually `ip link add` a Linux bridge with collision-resistant name `nove{lab_hash:04x}n{network_id}`. Persists `runtime.bridge_name` for later teardown.

Unblocks US-203, US-301 (and transitively most of Wave 6).

## Summary
- `host_net.py` gains thin Python wrappers (`bridge_add`, `bridge_del`, `bridge_exists`) that shell out to `sudo /opt/nova-ve/bin/nova-ve-net.py`, plus a typed `HostNetError` hierarchy (`HostNetValidationError`, `HostNetEEXIST`, `HostNetEINVAL`, `HostNetUnknown`) classifying helper exit codes.
- `network_service.create_network` now derives the bridge name via `host_net.bridge_name(lab_id, network_id)`, probes `bridge_exists` for idempotency, calls `bridge_add`, and stamps `runtime.bridge_name` on the network record so US-401 / US-205 / US-206 teardown paths can find it.
- `network_service.delete_network` invokes `bridge_del` with the persisted runtime name; an already-absent bridge (e.g. swept by US-206) is logged but never propagated as 5xx — the network record is gone either way.
- `routers/networks.py:create_network` now maps `NetworkServiceError` → typed JSON response (previously uncaught — would have 500'd on bridge_add failure).

## Test plan
Helper invocations are MOCKED — never real `ip link add` (CI is un-privileged + would corrupt host network state).

- [x] `tests/test_network_service.py` (NEW, 8 cases):
  - [x] `test_create_network_provisions_bridge` — `bridge_add` called once with `nove{hash:04x}n1`, idempotency probe runs, payload+disk both carry `runtime.bridge_name`.
  - [x] `test_create_network_bridge_name_uses_helper_format` — name is exactly `host_net.bridge_name(lab_id, 1)`, ≤14 chars, starts with `nove`.
  - [x] `test_bridge_name_differs_across_instance_ids` — same `lab_id` on two hosts produces different bridge names (collision-resistant).
  - [x] `test_create_network_idempotent_when_bridge_exists` — `bridge_exists` True → `bridge_add` is NOT called, but `runtime.bridge_name` is still stamped.
  - [x] `test_create_network_rolls_back_on_bridge_add_failure` — `HostNetEEXIST` raised → JSON record removed, 409 raised.
  - [x] `test_create_network_rollback_on_validation_error` — `HostNetValidationError` triggers same rollback path.
  - [x] `test_delete_network_removes_bridge` — `bridge_del` called with the persisted name.
  - [x] `test_delete_network_tolerates_already_absent_bridge` — `HostNetEINVAL` from `bridge_del` is logged + suppressed.
- [x] `tests/test_networks_api.py` — existing 8 cases extended with `instance_id` + helper-stub fixture; all still pass.
- [x] Full backend suite: 442/442 pytest cases pass.
- [ ] Privileged CI integration (deferred to a privileged runner): `ip link show {bridge}` after create returns the bridge; not-found after delete.

## Idempotency / rollback
- **Idempotency:** `bridge_exists(name)` runs `ip link show <name>` (unprivileged read); if present, `bridge_add` is skipped. `runtime.bridge_name` is stamped either way so callers always have a teardown handle. Survives backend mid-create restarts and US-202b backfill.
- **Rollback contract (per plan):** `lab.json` is written BEFORE `bridge_add` runs. If `bridge_add` raises any `HostNetError`, the network record is popped from `data["networks"]`, `lab.json` is rewritten under the same `lab_lock`, and `NetworkServiceError(code=409, ...)` is raised. The router maps this to a 409 JSON response. On-disk state never leads kernel state.
- **Helper failure modes** classified in `_classify_helper_failure(stderr, returncode)`:
  - exit 2 → `HostNetValidationError` (regex / pid-ownership rejection)
  - exit 3 → `HostNetUnknown` (argparse / unknown verb)
  - exit 1 + "exists" stderr → `HostNetEEXIST`
  - exit 1 + "does not exist" / "no such" / "cannot find" stderr → `HostNetEINVAL`
  - exit 1 (other) → `HostNetEINVAL` (best-effort default)