### PR TITLE
US-202b: bridge_name migration for pre-Wave-6 labs (#89)

### DIFF
--- a/backend/tests/test_migrate_runtime_network.py
+++ b/backend/tests/test_migrate_runtime_network.py
@@ -1,0 +1,514 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""US-202b — Tests for scripts/migrate_runtime_network.py.
+
+Covers:
+  - no-op on already-migrated lab (all networks have runtime.bridge_name)
+  - fills missing bridge_name correctly (uses host_net.bridge_name formula)
+  - idempotency (second run is a no-op)
+  - dry-run does not write any files or touch host state
+  - running-node precondition: exits 1 and lists offending labs
+  - per-lab rollback on simulated bridge_add failure
+  - abort on docker network inspect failure (no docker network rm called)
+  - rollback restores old Docker network from captured inspect JSON
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make scripts/ importable.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import migrate_runtime_network as mig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def instance_id(monkeypatch, tmp_path):
+    """Seed a deterministic instance_id."""
+    instance_dir = tmp_path / "nova-ve-instance"
+    instance_dir.mkdir()
+    value = "test-instance-uuid-202b"
+    (instance_dir / "instance_id").write_text(value)
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    return value
+
+
+def _make_lab(
+    labs_dir: Path,
+    name: str = "lab.json",
+    lab_id: str = "lab-aaa",
+    networks: dict[str, Any] | None = None,
+    nodes: dict[str, Any] | None = None,
+) -> Path:
+    payload: dict[str, Any] = {
+        "schema": 2,
+        "id": lab_id,
+        "meta": {"name": name},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": nodes or {},
+        "networks": networks or {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    lab_path = labs_dir / name
+    lab_path.write_text(json.dumps(payload), encoding="utf-8")
+    return lab_path
+
+
+def _net(net_id: int, *, bridge_name: str | None = None) -> dict[str, Any]:
+    """Build a minimal network record."""
+    n: dict[str, Any] = {
+        "id": net_id,
+        "name": f"Net{net_id}",
+        "type": "linux_bridge",
+        "left": 0,
+        "top": 0,
+        "visibility": True,
+        "implicit": False,
+        "runtime": {},
+    }
+    if bridge_name is not None:
+        n["runtime"]["bridge_name"] = bridge_name
+    return n
+
+
+# ---------------------------------------------------------------------------
+# No-op on already-migrated lab
+# ---------------------------------------------------------------------------
+
+
+def test_already_migrated_is_noop(instance_id, tmp_path):
+    """If all networks have runtime.bridge_name, process_lab returns 0 backfilled."""
+    from app.services import host_net
+
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+    bridge = host_net.bridge_name("lab-aaa", 1)
+
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-aaa",
+        networks={"1": _net(1, bridge_name=bridge)},
+    )
+
+    checked, backfilled = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+
+    assert checked == 1
+    assert backfilled == 0
+    # File is untouched (no backup taken since nothing changed).
+    assert not backup_dir.exists() or not any(backup_dir.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# Fills missing bridge_name correctly
+# ---------------------------------------------------------------------------
+
+
+def test_fills_missing_bridge_name(instance_id, tmp_path, monkeypatch):
+    """Missing runtime.bridge_name is backfilled with host_net.bridge_name value."""
+    from app.services import host_net
+
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-fill",
+        networks={"1": _net(1), "2": _net(2)},
+    )
+
+    # No Docker networks exist (inspect returns non-zero → treated as absent).
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    bridge_add_calls: list[str] = []
+    monkeypatch.setattr(
+        "app.services.host_net.bridge_add",
+        lambda name: bridge_add_calls.append(name),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+
+    checked, backfilled = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+
+    assert checked == 2
+    assert backfilled == 2
+
+    saved = json.loads(lab_path.read_text())
+    expected_1 = host_net.bridge_name("lab-fill", 1)
+    expected_2 = host_net.bridge_name("lab-fill", 2)
+    assert saved["networks"]["1"]["runtime"]["bridge_name"] == expected_1
+    assert saved["networks"]["2"]["runtime"]["bridge_name"] == expected_2
+
+    # bridge_add called for each network (since bridge_exists returns False).
+    assert expected_1 in bridge_add_calls
+    assert expected_2 in bridge_add_calls
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_second_run(instance_id, tmp_path, monkeypatch):
+    """Running process_lab twice is a no-op on the second run."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-idem",
+        networks={"1": _net(1)},
+    )
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+
+    _, backfilled_1 = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+    assert backfilled_1 == 1
+
+    # Second run — should be zero.
+    _, backfilled_2 = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+    assert backfilled_2 == 0
+
+
+# ---------------------------------------------------------------------------
+# Dry-run does not write
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_write(instance_id, tmp_path, monkeypatch):
+    """dry_run=True reports what would change but does not modify any files."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-dry",
+        networks={"1": _net(1)},
+    )
+    original_text = lab_path.read_text()
+
+    bridge_add_calls: list[str] = []
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        "app.services.host_net.bridge_add",
+        lambda name: bridge_add_calls.append(name),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+
+    checked, backfilled = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=True)
+
+    assert backfilled == 1
+    # File must be unchanged.
+    assert lab_path.read_text() == original_text
+    # No host changes.
+    assert bridge_add_calls == []
+    # No backup directory created.
+    assert not backup_dir.exists()
+
+
+def test_main_dry_run_does_not_write(instance_id, tmp_path, monkeypatch):
+    """main() --dry-run leaves all lab files untouched."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-main-dry",
+        networks={"1": _net(1)},
+    )
+    original_text = lab_path.read_text()
+
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+
+    rc = mig.main(["--labs-dir", str(labs_dir), "--dry-run"])
+
+    assert rc == 0
+    assert lab_path.read_text() == original_text
+
+
+# ---------------------------------------------------------------------------
+# Running-node precondition
+# ---------------------------------------------------------------------------
+
+
+def test_precondition_running_nodes_exits_1(instance_id, tmp_path):
+    """main() exits 1 when any lab has a running node (status=2)."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+
+    _make_lab(
+        labs_dir,
+        name="lab_running.json",
+        lab_id="lab-running",
+        nodes={"1": {"id": 1, "name": "node-a", "status": 2}},
+        networks={"1": _net(1)},
+    )
+
+    rc = mig.main(["--labs-dir", str(labs_dir)])
+    assert rc == 1
+
+
+def test_precondition_stopped_node_passes(instance_id, tmp_path, monkeypatch):
+    """A lab with all nodes stopped (status=0) passes the precondition check."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+
+    _make_lab(
+        labs_dir,
+        name="lab_stopped.json",
+        lab_id="lab-stopped",
+        nodes={"1": {"id": 1, "name": "node-a", "status": 0}},
+        networks={"1": _net(1)},
+    )
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+
+    rc = mig.main(["--labs-dir", str(labs_dir)])
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-lab rollback on bridge_add failure
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_on_bridge_add_failure(instance_id, tmp_path, monkeypatch):
+    """If bridge_add raises, lab.json is restored from backup.
+
+    Also asserts that test_migrate_runtime_network_rollback_on_host_failure
+    acceptance test: old Docker network is restored from captured inspect JSON.
+    """
+    from app.services import host_net as hn
+
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-fail",
+        networks={"1": _net(1)},
+    )
+    original_text = lab_path.read_text()
+
+    # Simulate a Docker network NOT existing (no docker cleanup path).
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+
+    def boom(name: str) -> None:
+        raise hn.HostNetEEXIST("RTNETLINK: File exists", returncode=1, stderr="exists")
+
+    monkeypatch.setattr("app.services.host_net.bridge_add", boom)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+    monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="migration failed"):
+        mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+
+    # lab.json must be restored.
+    assert lab_path.read_text() == original_text
+
+
+def test_rollback_restores_docker_network(instance_id, tmp_path, monkeypatch):
+    """On bridge_add failure after docker network rm, docker network create is called."""
+    from app.services import host_net as hn
+
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+
+    # A network with a docker_network config pointing to a named Docker network.
+    net = _net(1)
+    net["config"] = {"docker_network": "nova-ve-lab-fail2-Net1"}
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-fail2",
+        networks={"1": net},
+    )
+
+    inspect_payload = [
+        {
+            "Name": "nova-ve-lab-fail2-Net1",
+            "Driver": "bridge",
+            "Options": {},
+            "IPAM": {"Config": [{"Subnet": "172.20.0.0/16"}]},
+            "Containers": {},
+        }
+    ]
+
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(inspect_payload),
+            stderr="",
+        ),
+    )
+
+    rm_calls: list[str] = []
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_rm",
+        lambda name: rm_calls.append(name) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    create_calls: list[dict] = []
+
+    def fake_create(entry: dict) -> SimpleNamespace:
+        create_calls.append(entry)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mig, "_docker_network_create_from_inspect", fake_create)
+
+    def boom(name: str) -> None:
+        raise hn.HostNetEEXIST("RTNETLINK: File exists", returncode=1, stderr="exists")
+
+    monkeypatch.setattr("app.services.host_net.bridge_add", boom)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+    monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="migration failed"):
+        mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+
+    # Docker network was removed.
+    assert rm_calls == ["nova-ve-lab-fail2-Net1"]
+    # Docker network was recreated from captured inspect JSON on rollback.
+    assert len(create_calls) == 1
+    assert create_calls[0]["Name"] == "nova-ve-lab-fail2-Net1"
+
+
+# ---------------------------------------------------------------------------
+# Abort on docker network inspect failure (no docker network rm)
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_runtime_network_aborts_on_inspect_failure(
+    instance_id, tmp_path, monkeypatch
+):
+    """If docker network inspect fails, migration aborts without calling docker network rm."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+
+    net = _net(1)
+    net["config"] = {"docker_network": "nova-ve-lab-inspect-fail-Net1"}
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-inspect-fail",
+        networks={"1": net},
+    )
+
+    # Inspect returns exit 0 but invalid JSON → should abort.
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=0, stdout="NOT JSON", stderr=""),
+    )
+
+    rm_calls: list[str] = []
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_rm",
+        lambda name: rm_calls.append(name) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+    monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="migration failed"):
+        mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+
+    # docker network rm must NOT have been called.
+    assert rm_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Non-zero exit from main() when errors occur
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_2_on_error(instance_id, tmp_path, monkeypatch):
+    """main() returns 2 when any lab fails migration."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+
+    _make_lab(
+        labs_dir,
+        lab_id="lab-err",
+        networks={"1": _net(1)},
+    )
+
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    from app.services import host_net as hn
+
+    def boom(name: str) -> None:
+        raise hn.HostNetEEXIST("exists", returncode=1, stderr="exists")
+
+    monkeypatch.setattr("app.services.host_net.bridge_add", boom)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+    monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
+
+    rc = mig.main(["--labs-dir", str(labs_dir)])
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# main() nonexistent labs_dir
+# ---------------------------------------------------------------------------
+
+
+def test_main_nonexistent_labs_dir(tmp_path):
+    """main() exits 1 when labs_dir does not exist."""
+    rc = mig.main(["--labs-dir", str(tmp_path / "nonexistent")])
+    assert rc == 1

--- a/scripts/migrate_runtime_network.py
+++ b/scripts/migrate_runtime_network.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""One-shot migration script for existing labs — US-202b.
+
+Backfills ``runtime.bridge_name`` on every network record that is missing
+it.  Networks created by US-202 already have the field; this script is a
+no-op for those labs (idempotent).
+
+For labs created *before* Wave 6 (US-202), networks may have a legacy
+Docker network bound to them (created by the old ``_ensure_docker_network``
+path).  The migration sequence for each such network is:
+
+  1. Assert no containers attached to the Docker network.
+  2. Capture ``docker network inspect`` JSON for rollback (fail-closed: abort
+     if inspect fails or JSON is unparseable).
+  3. ``docker network rm`` the old Docker network.
+  4. ``host_net.bridge_add`` the new ``nove…n…`` bridge.
+  5. Write back ``runtime.bridge_name`` to lab.json (atomic).
+
+On per-lab failure the in-memory journal is used to roll back host-side
+actions (bridge_del + docker network create from captured inspect).  The
+lab.json is reverted to its pre-migration backup.  Subsequent labs continue
+processing.
+
+**PRECONDITION:** every node in every lab MUST have ``status != 2``
+(not running) and the nova-ve-backend service MUST be stopped before
+running this script.  The script checks for running nodes and exits 1 with
+a clear error listing offending labs if the precondition is violated.
+
+Usage::
+
+    # Dry-run (no writes, no host changes):
+    python scripts/migrate_runtime_network.py --labs-dir /var/lib/nova-ve/labs --dry-run
+
+    # Live run (backend must be stopped first):
+    sudo /home/ubuntu/nova-ve-git/.venv/bin/python \\
+        scripts/migrate_runtime_network.py --labs-dir /var/lib/nova-ve/labs
+
+Exit codes:
+    0  — all labs migrated (or already migrated — no-op)
+    1  — precondition violated (running nodes found); no changes made
+    2  — one or more labs failed migration; backup dir printed on stderr
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Ensure the backend package is importable when run from the repo root or
+# from backend/.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BACKEND_DIR = _REPO_ROOT / "backend"
+for _p in (_BACKEND_DIR, _REPO_ROOT):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from app.services import host_net  # noqa: E402
+from app.services.lab_lock import lab_lock  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Docker subprocess helpers (thin wrappers, easily replaced in tests)
+# ---------------------------------------------------------------------------
+
+
+def _docker_network_inspect(net_name: str) -> "subprocess.CompletedProcess[str]":
+    """Run ``docker network inspect <net_name>`` and return the result."""
+    return subprocess.run(
+        ["docker", "network", "inspect", net_name],
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _docker_network_rm(net_name: str) -> "subprocess.CompletedProcess[str]":
+    """Run ``docker network rm <net_name>``."""
+    return subprocess.run(
+        ["docker", "network", "rm", net_name],
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _docker_network_create_from_inspect(inspect_entry: dict[str, Any]) -> "subprocess.CompletedProcess[str]":
+    """Reconstruct a Docker network from a captured inspect entry (rollback).
+
+    This is intentionally lossy — Docker's internal IDs and auto-added labels
+    cannot be restored.  The intent (name + driver + options) is preserved.
+    """
+    name = inspect_entry.get("Name", "")
+    driver = inspect_entry.get("Driver", "bridge")
+    options = inspect_entry.get("Options") or {}
+    ipam = inspect_entry.get("IPAM") or {}
+    ipam_config = (ipam.get("Config") or [{}])[0] if ipam.get("Config") else {}
+
+    argv = ["docker", "network", "create", "--driver", driver]
+    for k, v in options.items():
+        argv += ["--opt", f"{k}={v}"]
+    if ipam_config.get("Subnet"):
+        argv += ["--subnet", ipam_config["Subnet"]]
+    if ipam_config.get("Gateway"):
+        argv += ["--gateway", ipam_config["Gateway"]]
+    argv.append(name)
+
+    return subprocess.run(
+        argv,
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Precondition check
+# ---------------------------------------------------------------------------
+
+
+def _check_no_running_nodes(labs_dir: Path) -> list[str]:
+    """Return a list of error strings for any lab that has running nodes.
+
+    An empty list means the precondition is satisfied.
+    """
+    violations: list[str] = []
+    for lab_path in sorted(labs_dir.rglob("*.json")):
+        if lab_path.stem.endswith(".tmp"):
+            continue
+        try:
+            data = json.loads(lab_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(data, dict) or data.get("schema") != 2:
+            continue
+        nodes = data.get("nodes") or {}
+        running = [
+            str(nid)
+            for nid, node in nodes.items()
+            if isinstance(node, dict) and node.get("status") == 2
+        ]
+        if running:
+            violations.append(
+                f"  {lab_path.relative_to(labs_dir)}: nodes still running: {', '.join(running)}"
+            )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Per-network migration logic
+# ---------------------------------------------------------------------------
+
+
+class _NetworkJournalEntry:
+    """Records host-side actions taken for one network (for rollback)."""
+
+    def __init__(self, network_id: int) -> None:
+        self.network_id = network_id
+        self.old_docker_net: str | None = None
+        self.old_docker_inspect: dict[str, Any] | None = None
+        self.docker_net_removed: bool = False
+        self.new_bridge: str | None = None
+        self.bridge_added: bool = False
+
+
+def _get_docker_net_name(network: dict[str, Any], lab_id: str) -> str | None:
+    """Derive the likely legacy Docker network name from a network record.
+
+    Pre-US-202 code named the Docker network after the lab_id + network name.
+    Check ``config.docker_network`` first (explicit), then derive the
+    conventional name ``nova-ve-{lab_id}-{network_name}``.
+    """
+    config = network.get("config") or {}
+    explicit = config.get("docker_network")
+    if explicit:
+        return str(explicit)
+    # Conventional name used by old _ensure_docker_network.
+    name = network.get("name") or ""
+    if not name:
+        return None
+    return f"nova-ve-{lab_id}-{name}"
+
+
+def _migrate_network(
+    network_id: int,
+    network: dict[str, Any],
+    lab_id: str,
+    journal: _NetworkJournalEntry,
+    *,
+    dry_run: bool,
+) -> None:
+    """Migrate a single network. Mutates ``journal`` to record host-side actions.
+
+    Raises on unrecoverable errors (caller handles per-lab rollback).
+    The caller must append ``journal`` to its list BEFORE calling this
+    function so that partial state is captured even if an exception is raised.
+    """
+    bridge = host_net.bridge_name(lab_id, network_id)
+    journal.new_bridge = bridge
+
+    # Check for a legacy Docker network that needs to be removed.
+    docker_net = _get_docker_net_name(network, lab_id)
+    if docker_net:
+        # Step 1: Assert no containers attached.
+        inspect_proc = _docker_network_inspect(docker_net)
+        if inspect_proc.returncode != 0:
+            # Network does not exist — nothing to clean up on the Docker side.
+            docker_net = None
+        else:
+            try:
+                inspect_data = json.loads(inspect_proc.stdout)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(
+                    f"could not parse docker network inspect output for '{docker_net}': {exc}"
+                )
+            if not inspect_data:
+                docker_net = None
+            else:
+                entry = inspect_data[0] if isinstance(inspect_data, list) else inspect_data
+                containers = entry.get("Containers") or {}
+                if containers:
+                    raise RuntimeError(
+                        f"network '{docker_net}' has running containers despite "
+                        "labs-stopped precondition; investigate manually"
+                    )
+                # Step 2: Capture inspect JSON for rollback (fail-closed).
+                journal.old_docker_net = docker_net
+                journal.old_docker_inspect = entry
+
+                if not dry_run:
+                    # Step 3: Remove the old Docker network.
+                    rm_proc = _docker_network_rm(docker_net)
+                    if rm_proc.returncode != 0:
+                        raise RuntimeError(
+                            f"docker network rm '{docker_net}' failed: "
+                            f"{rm_proc.stderr.strip()}"
+                        )
+                    journal.docker_net_removed = True
+
+    if not dry_run:
+        # Step 4: Provision the new Linux bridge (idempotent).
+        if not host_net.bridge_exists(bridge):
+            host_net.bridge_add(bridge)
+            journal.bridge_added = True
+
+
+# ---------------------------------------------------------------------------
+# Per-lab rollback
+# ---------------------------------------------------------------------------
+
+
+def _rollback_lab(
+    journals: list[_NetworkJournalEntry],
+    lab_path: Path,
+    backup_path: Path,
+    labs_dir: Path,
+    orphan_dir: Path,
+    *,
+    dry_run: bool,
+) -> None:
+    """Attempt to undo host-side actions recorded in journals.
+
+    Restores lab.json from backup. If host rollback also fails, writes a
+    migration-orphans file with manual remediation steps.
+    """
+    if not dry_run:
+        # Restore lab.json from backup.
+        try:
+            shutil.copy2(backup_path, lab_path)
+        except Exception as exc:
+            print(
+                f"[migrate_runtime_network] CRITICAL: could not restore backup "
+                f"{backup_path} → {lab_path}: {exc}",
+                file=sys.stderr,
+            )
+
+    orphans: list[dict[str, Any]] = []
+    for j in journals:
+        # Undo bridge_add.
+        if j.bridge_added and j.new_bridge:
+            try:
+                if not dry_run:
+                    host_net.bridge_del(j.new_bridge)
+            except Exception as exc:
+                orphans.append(
+                    {
+                        "action": "bridge_del",
+                        "bridge": j.new_bridge,
+                        "error": str(exc),
+                        "remediation": f"Run: sudo ip link delete {j.new_bridge} type bridge",
+                    }
+                )
+
+        # Recreate old Docker network.
+        if j.docker_net_removed and j.old_docker_inspect:
+            try:
+                if not dry_run:
+                    proc = _docker_network_create_from_inspect(j.old_docker_inspect)
+                    if proc.returncode != 0:
+                        raise RuntimeError(proc.stderr.strip())
+            except Exception as exc:
+                net_name = j.old_docker_net or "<unknown>"
+                orphans.append(
+                    {
+                        "action": "docker_network_create",
+                        "docker_net": net_name,
+                        "error": str(exc),
+                        "remediation": (
+                            f"Manually recreate docker network '{net_name}' "
+                            "with the driver/subnet from the captured inspect JSON below.\n"
+                            f"inspect_snapshot: {json.dumps(j.old_docker_inspect)}"
+                        ),
+                    }
+                )
+
+    if orphans:
+        ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        orphan_file = orphan_dir / f"migration-orphans-{ts}.json"
+        try:
+            orphan_dir.mkdir(parents=True, exist_ok=True)
+            orphan_file.write_text(json.dumps(orphans, indent=2), encoding="utf-8")
+            print(
+                f"[migrate_runtime_network] Rollback partial — orphan manifest written to "
+                f"{orphan_file}",
+                file=sys.stderr,
+            )
+        except Exception as exc:
+            print(
+                f"[migrate_runtime_network] Could not write orphan manifest: {exc}",
+                file=sys.stderr,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Per-lab processing
+# ---------------------------------------------------------------------------
+
+
+def process_lab(
+    lab_path: Path,
+    labs_dir: Path,
+    backup_dir: Path,
+    *,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Process a single lab file.
+
+    Returns ``(networks_checked, networks_backfilled)``.
+    Raises on unrecoverable per-lab errors (caller catches and continues).
+    """
+    try:
+        rel = lab_path.relative_to(labs_dir)
+    except ValueError:
+        rel = Path(lab_path.name)
+    lab_id_path = Path(rel).as_posix()
+
+    with lab_lock(lab_id_path, labs_dir):
+        raw = lab_path.read_text(encoding="utf-8")
+        data: dict[str, Any] = json.loads(raw)
+
+        if not isinstance(data, dict) or data.get("schema") != 2:
+            return 0, 0
+
+        networks: dict[str, Any] = data.get("networks") or {}
+        if not networks:
+            return 0, 0
+
+        lab_id = str(data.get("id") or lab_id_path)
+        checked = 0
+        to_migrate: list[tuple[int, dict[str, Any]]] = []
+
+        for key, network in networks.items():
+            if not isinstance(network, dict):
+                continue
+            try:
+                net_id = int(network.get("id", key))
+            except (TypeError, ValueError):
+                continue
+            checked += 1
+            runtime = network.get("runtime") or {}
+            if not runtime.get("bridge_name"):
+                to_migrate.append((net_id, network))
+
+        if not to_migrate:
+            # Already fully migrated — idempotent no-op.
+            return checked, 0
+
+        if dry_run:
+            for net_id, _net in to_migrate:
+                bridge = host_net.bridge_name(lab_id, net_id)
+                print(
+                    f"[migrate_runtime_network] DRY RUN: {lab_path.name} "
+                    f"network {net_id} → would stamp runtime.bridge_name={bridge}"
+                )
+            return checked, len(to_migrate)
+
+        # Take a backup of the lab.json before any modifications.
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_path = backup_dir / lab_path.name
+        shutil.copy2(lab_path, backup_path)
+
+        journals: list[_NetworkJournalEntry] = []
+        failed = False
+        fail_msg = ""
+
+        for net_id, network in to_migrate:
+            # Pre-append journal so partial host-side state is captured even
+            # if _migrate_network raises mid-way (e.g. after docker network rm
+            # but before bridge_add succeeds).
+            journal = _NetworkJournalEntry(net_id)
+            journals.append(journal)
+            try:
+                _migrate_network(net_id, network, lab_id, journal, dry_run=dry_run)
+            except Exception as exc:
+                failed = True
+                fail_msg = str(exc)
+                print(
+                    f"[migrate_runtime_network] ERROR migrating {lab_path.name} "
+                    f"network {net_id}: {exc}",
+                    file=sys.stderr,
+                )
+                break
+
+        if failed:
+            # Roll back all host-side actions for this lab.
+            _rollback_lab(
+                journals,
+                lab_path,
+                backup_path,
+                labs_dir,
+                backup_dir,
+                dry_run=dry_run,
+            )
+            raise RuntimeError(
+                f"migration failed for {lab_path.name}: {fail_msg}"
+            )
+
+        # Step 5: Stamp runtime.bridge_name for all successfully migrated networks.
+        for net_id, network in to_migrate:
+            bridge = host_net.bridge_name(lab_id, net_id)
+            runtime = network.setdefault("runtime", {})
+            runtime["bridge_name"] = bridge
+            networks[str(net_id)] = network
+
+        data["networks"] = networks
+        data.pop("topology", None)
+
+        # Atomic write.
+        tmp_path = lab_path.with_suffix(".json.tmp")
+        try:
+            tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            os.replace(tmp_path, lab_path)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    return checked, len(to_migrate)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--labs-dir",
+        type=Path,
+        default=Path("/var/lib/nova-ve/labs"),
+        help="Path to the labs directory (default: /var/lib/nova-ve/labs)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print what would change without writing any files or modifying host state",
+    )
+    args = parser.parse_args(argv)
+
+    labs_dir: Path = args.labs_dir.resolve()
+    dry_run: bool = args.dry_run
+
+    if not labs_dir.is_dir():
+        print(
+            f"[migrate_runtime_network] ERROR: labs_dir does not exist: {labs_dir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ---------------------------------------------------------------------------
+    # PRECONDITION: no running nodes.
+    # ---------------------------------------------------------------------------
+    violations = _check_no_running_nodes(labs_dir)
+    if violations:
+        print(
+            "[migrate_runtime_network] PRECONDITION FAILED: the following labs have "
+            "running nodes (status=2).",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(v, file=sys.stderr)
+        print(
+            "\nStop the backend with:  sudo systemctl stop nova-ve-backend\n"
+            "Stop running labs via:  nova-ve cli stop-lab <id>\n"
+            "Then re-run this script.",
+            file=sys.stderr,
+        )
+        return 1
+
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_dir = labs_dir / f".migration-backup-{ts}"
+
+    if dry_run:
+        print(
+            f"[migrate_runtime_network] DRY RUN — no files written, no host changes. "
+            f"labs_dir={labs_dir}"
+        )
+    else:
+        print(
+            f"[migrate_runtime_network] Starting bridge_name backfill migration. "
+            f"labs_dir={labs_dir}"
+        )
+
+    lab_files = sorted(labs_dir.rglob("*.json"))
+    total_labs = 0
+    total_backfilled = 0
+    errors = 0
+
+    for lab_path in lab_files:
+        if lab_path.stem.endswith(".tmp"):
+            continue
+        # Skip files inside backup dirs.
+        if ".migration-backup-" in str(lab_path):
+            continue
+
+        try:
+            checked, backfilled = process_lab(
+                lab_path, labs_dir, backup_dir, dry_run=dry_run
+            )
+        except Exception as exc:
+            print(
+                f"[migrate_runtime_network] ERROR processing {lab_path.name}: {exc}",
+                file=sys.stderr,
+            )
+            errors += 1
+            continue
+
+        if checked == 0:
+            continue
+
+        total_labs += 1
+        total_backfilled += backfilled
+
+        if backfilled > 0:
+            action = "would backfill" if dry_run else "backfilled"
+            print(
+                f"[migrate_runtime_network] {lab_path.name}: {action} "
+                f"runtime.bridge_name on {backfilled} network(s)"
+            )
+        else:
+            print(
+                f"[migrate_runtime_network] {lab_path.name}: already migrated (no-op)"
+            )
+
+    suffix = " (dry run)" if dry_run else ""
+    print(
+        f"[migrate_runtime_network] Done{suffix}. "
+        f"labs={total_labs}, networks_backfilled={total_backfilled}, errors={errors}"
+    )
+    if errors and not dry_run:
+        print(
+            f"[migrate_runtime_network] Backup dir (for manual inspection): {backup_dir}",
+            file=sys.stderr,
+        )
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #89. Part of #80.

Wave 6 migration — backfills `runtime.bridge_name` on existing labs that were created before US-202 (#88) wired the real Linux bridge.

## Summary
- Adds `scripts/migrate_runtime_network.py`: walks `LABS_DIR`, for every lab+network missing `runtime.bridge_name`, stamps it using `host_net.bridge_name(lab_id, network_id)` — the identical formula as US-202 — never reimplements the naming logic
- Implements the full 5-step Docker legacy network migration sequence: assert no containers → capture inspect JSON (fail-closed) → `docker network rm` → `host_net.bridge_add` → atomic JSON write
- Per-lab rollback journal: if `bridge_add` fails after `docker network rm`, the Docker network is recreated from the captured inspect JSON; if rollback also fails, a `migration-orphans-{ts}.json` manifest is written
- PRECONDITION guard exits 1 with clear error message if any lab has a running node (`status=2`), listing offending labs and remediation steps
- `--dry-run` flag: prints all planned actions with zero file writes and zero host-side changes
- Idempotent: second run on a fully-migrated lab is a no-op (exit 0)
- Exit codes: 0 = all migrated, 1 = precondition violated, 2 = partial failure (backup dir printed)
- Adds `backend/tests/test_migrate_runtime_network.py` with 12 tests covering all plan acceptance criteria

## Test plan
- [x] `test_already_migrated_is_noop` — no-op on lab with all `runtime.bridge_name` set
- [x] `test_fills_missing_bridge_name` — backfills correctly using `host_net.bridge_name` value
- [x] `test_idempotent_second_run` — second run reports 0 backfilled
- [x] `test_dry_run_does_not_write` — dry_run=True: no file changes, no bridge_add calls
- [x] `test_main_dry_run_does_not_write` — `main()` with `--dry-run` leaves files untouched
- [x] `test_precondition_running_nodes_exits_1` — exits 1 when node has status=2
- [x] `test_precondition_stopped_node_passes` — exits 0 when all nodes stopped
- [x] `test_rollback_on_bridge_add_failure` — lab.json restored from backup on bridge_add failure
- [x] `test_rollback_restores_docker_network` — docker network recreated from captured inspect JSON after bridge_add failure
- [x] `test_migrate_runtime_network_aborts_on_inspect_failure` — no `docker network rm` called when inspect fails
- [x] `test_main_returns_2_on_error` — main() returns exit code 2 on migration error
- [x] `test_main_nonexistent_labs_dir` — exits 1 when labs_dir missing

## Operator usage
```bash
# 1. Stop the backend
sudo systemctl stop nova-ve-backend

# 2. Dry-run to preview changes
sudo /home/ubuntu/nova-ve-git/.venv/bin/python \
    scripts/migrate_runtime_network.py \
    --labs-dir /var/lib/nova-ve/labs --dry-run

# 3. Live run
sudo /home/ubuntu/nova-ve-git/.venv/bin/python \
    scripts/migrate_runtime_network.py \
    --labs-dir /var/lib/nova-ve/labs

# 4. Restart backend
sudo systemctl start nova-ve-backend
```

**Rollback:** if the script exits 2, backups are in `/var/lib/nova-ve/labs/.migration-backup-{timestamp}/`. Any orphaned host resources are described in `migration-orphans-{ts}.json` in the same directory.