### PR TITLE
US-301: QEMU pcie-root-port pre-alloc (q35) (#99)

### DIFF
--- a/backend/app/schemas/node.py
+++ b/backend/app/schemas/node.py
@@ -46,6 +46,11 @@ class NodeBase(BaseModel):
     interfaces: List[NodeInterface] = Field(default_factory=list)
     extras: Dict[str, Any] = Field(default_factory=dict)
     interface_naming_scheme: Optional[str] = None
+    # US-301: pinned QEMU machine type. ``None`` means "inherit from
+    # ``template.capabilities.machine``"; pre-Wave-7 nodes are stamped
+    # with ``'pc'`` by ``scripts/migrate_runtime_network.py`` so the q35
+    # default never silently changes their PCI topology.
+    machine_override: Optional[Literal["pc", "q35"]] = None
 
     @model_validator(mode='after')
     def _check_iface_naming_scheme(self):

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1,5 +1,26 @@
 # Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
+"""Node runtime adapter for QEMU and Docker labs.
+
+US-301 — pcie-root-port slot policy
+------------------------------------
+QEMU PCI hot-plug requires pre-allocated ``pcie-root-port`` chassis on q35.
+At VM start we pre-allocate ``template.capabilities.max_nics`` root ports.
+Slot 0 is reserved on q35 (the root complex itself); the first usable slot
+is ``1``. Initial NICs declared at boot occupy ``rp0..rp{N-1}`` in
+``interface_index`` order. Hot-add (US-303) scans for free slots starting
+from ``rp{max_nics-1}`` downward so additions never collide with the
+boot-time positional layout. Hot-remove (US-304) frees the matching slot.
+
+Machine-type discrimination:
+- ``node.machine_override`` (set by ``scripts/migrate_runtime_network.py``
+  on pre-Wave-7 QEMU nodes) wins if present.
+- Otherwise the launcher reads ``template.capabilities.machine`` (default
+  ``q35`` for new templates, ``pc`` for legacy YAMLs that omit the field
+  via inferred defaults).
+- Templates with ``capabilities.machine='pc' AND hotplug=true`` are
+  rejected at template-load time (template_service._validate_capabilities).
+"""
 
 import asyncio
 import base64
@@ -845,6 +866,8 @@ class NodeRuntimeService:
                 f"QEMU binary not found for arch {architecture}: {self.settings.QEMU_BINARY}"
             )
 
+        machine, max_nics, hotplug_capable = self._resolve_qemu_machine(node)
+
         work_dir = self._work_dir(lab_id, node["id"])
         work_dir.mkdir(parents=True, exist_ok=True)
         overlay_path = self._ensure_qemu_overlay(work_dir, node)
@@ -860,7 +883,7 @@ class NodeRuntimeService:
             "-display",
             "none",
             "-machine",
-            f"type=pc,accel={accel}",
+            f"type={machine},accel={accel}",
             "-smp",
             str(node.get("cpu", 1)),
             "-m",
@@ -886,14 +909,31 @@ class NodeRuntimeService:
         qmp_socket_path = work_dir / "qmp.sock"
         cmd += ["-qmp", f"unix:{qmp_socket_path},server,nowait"]
 
+        # US-301: q35 pre-allocates pcie-root-port chassis for hot-plug.
+        # Slot 0 is reserved on q35 (root complex); first usable slot is 1.
+        allocated_slots: list[int] = []
+        if machine == "q35" and max_nics > 0:
+            for i in range(max_nics):
+                slot = i + 1
+                cmd += [
+                    "-device",
+                    f"pcie-root-port,id=rp{i},chassis={slot},slot={slot}",
+                ]
+                allocated_slots.append(i)
+
         nic_model = _extra_str(extras, "qemu_nic") or "e1000"
         first_mac = node.get("firstmac") or extras.get("firstmac")
         for index in range(int(node.get("ethernet", 0))):
+            device_args = (
+                f"{nic_model},netdev=net{index},mac={self._mac_for_index(first_mac, index)}"
+            )
+            if machine == "q35" and index < max_nics:
+                device_args += f",bus=rp{index}"
             cmd += [
                 "-netdev",
                 f"user,id=net{index}",
                 "-device",
-                f"{nic_model},netdev=net{index},mac={self._mac_for_index(first_mac, index)}",
+                device_args,
             ]
 
         if iso_path:
@@ -938,8 +978,64 @@ class NodeRuntimeService:
             "stderr_log": str(stderr_log),
             "qmp_socket": str(qmp_socket_path),
             "command": cmd,
+            "machine": machine,
+            "max_nics": max_nics,
+            "hotplug_capable": hotplug_capable,
+            "allocated_slots": allocated_slots,
             "started_at": time.time(),
         }
+
+    def _resolve_qemu_machine(self, node: dict[str, Any]) -> tuple[str, int, bool]:
+        """Resolve machine type, max_nics, and hotplug capability for a QEMU node.
+
+        Resolution chain (US-301):
+        1. ``node.machine_override`` (set by US-202b migration on pre-Wave-7 nodes
+           or by an operator opt-in flow) — wins unconditionally.
+        2. ``template.capabilities.machine`` from the YAML template — new
+           templates default to ``q35``; legacy YAMLs default to ``pc`` via
+           ``_default_capabilities`` inferred defaults.
+        3. Final fallback ``pc`` if no template can be resolved.
+
+        Returns ``(machine, max_nics, hotplug_capable)``. ``max_nics`` is read
+        from the same template's ``capabilities.max_nics`` (default 8).
+        """
+        override = node.get("machine_override")
+        capabilities: dict[str, Any] = {}
+        try:
+            from app.services.template_service import (  # local to avoid cycles
+                TemplateError,
+                TemplateService,
+            )
+
+            template_key = str(node.get("template") or "").strip()
+            if template_key:
+                try:
+                    template = TemplateService().get_template("qemu", template_key)
+                    capabilities = dict(template.capabilities or {})
+                except TemplateError:
+                    capabilities = {}
+        except ImportError:
+            capabilities = {}
+
+        if isinstance(override, str) and override in ("pc", "q35"):
+            machine = override
+        else:
+            template_machine = capabilities.get("machine")
+            if isinstance(template_machine, str) and template_machine in ("pc", "q35"):
+                machine = template_machine
+            else:
+                machine = "pc"
+
+        max_nics_value = capabilities.get("max_nics", 8)
+        try:
+            max_nics = int(max_nics_value)
+        except (TypeError, ValueError):
+            max_nics = 8
+        if max_nics < 1:
+            max_nics = 8
+
+        hotplug_capable = bool(capabilities.get("hotplug", False)) and machine == "q35"
+        return machine, max_nics, hotplug_capable
 
     def _start_docker_node(self, lab_data: dict[str, Any], node: dict[str, Any]) -> dict[str, Any]:
         docker_binary = self._resolve_binary("docker")

--- a/backend/tests/test_qemu_pcie_root_ports.py
+++ b/backend/tests/test_qemu_pcie_root_ports.py
@@ -1,0 +1,486 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""US-301 — Pre-allocate ``pcie-root-port`` slots at QEMU start.
+
+These tests use an argv-capture fixture and never actually launch QEMU.
+They verify the q35-only slot pre-allocation discriminator and the legacy
+``pc`` compatibility path.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.node_runtime_service import NodeRuntimeService
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_registry():
+    NodeRuntimeService.reset_registry()
+    yield
+    NodeRuntimeService.reset_registry()
+
+
+@pytest.fixture()
+def runtime_settings(tmp_path):
+    labs_dir = tmp_path / "labs"
+    images_dir = tmp_path / "images"
+    tmp_dir = tmp_path / "tmp"
+    templates_dir = tmp_path / "templates"
+    labs_dir.mkdir()
+    images_dir.mkdir()
+    tmp_dir.mkdir()
+    templates_dir.mkdir()
+    return SimpleNamespace(
+        LABS_DIR=labs_dir,
+        IMAGES_DIR=images_dir,
+        TMP_DIR=tmp_dir,
+        TEMPLATES_DIR=templates_dir,
+        QEMU_BINARY="qemu-system-x86_64",
+        QEMU_IMG_BINARY="qemu-img",
+        DOCKER_HOST="unix:///var/run/docker.sock",
+    )
+
+
+@pytest.fixture()
+def patched_settings(monkeypatch, runtime_settings):
+    monkeypatch.setattr("app.services.node_runtime_service.get_settings", lambda: runtime_settings)
+    monkeypatch.setattr("app.services.template_service.get_settings", lambda: runtime_settings)
+    return runtime_settings
+
+
+def _write_template(settings, key: str, body: str) -> None:
+    qemu_dir = settings.TEMPLATES_DIR / "qemu"
+    qemu_dir.mkdir(parents=True, exist_ok=True)
+    (qemu_dir / f"{key}.yml").write_text(body)
+
+
+def _seed_image(settings, image_name: str = "router-image") -> None:
+    image_dir = settings.IMAGES_DIR / "qemu" / image_name
+    image_dir.mkdir(parents=True, exist_ok=True)
+    (image_dir / "hda.qcow2").write_text("base-image")
+
+
+class _FakeProcess:
+    def __init__(self, pid: int = 4321):
+        self.pid = pid
+
+    def poll(self):
+        return None
+
+
+@pytest.fixture()
+def argv_capture(monkeypatch):
+    """Replace QEMU launch primitives so argv is captured but no real
+    process is created. Returns a list that fills with the QEMU command."""
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, capture_output=False, text=False, **_kwargs):
+        # qemu-img create writes the overlay file; mimic that.
+        if cmd and Path(cmd[0]).name == "qemu-img":
+            Path(cmd[-1]).write_text("overlay-image")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_popen(cmd, cwd=None, stdin=None, stdout=None, stderr=None, start_new_session=None):
+        captured.append(list(cmd))
+        return _FakeProcess()
+
+    monkeypatch.setattr("app.services.node_runtime_service.subprocess.run", fake_run)
+    monkeypatch.setattr("app.services.node_runtime_service.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("app.services.node_runtime_service.time.sleep", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.psutil.Process",
+        lambda pid: SimpleNamespace(
+            create_time=lambda: 111.0,
+            cpu_percent=lambda interval=0.0: 0,
+            memory_info=lambda: SimpleNamespace(rss=0),
+            wait=lambda timeout=5: None,
+            is_running=lambda: True,
+            status=lambda: "sleeping",
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.NodeRuntimeService._resolve_binary",
+        staticmethod(lambda binary: binary),
+    )
+    return captured
+
+
+def _build_lab(node: dict) -> dict:
+    return {
+        "schema": 2,
+        "id": "lab-301",
+        "meta": {"name": "us-301"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {str(node["id"]): node},
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+
+
+def _q35_template(max_nics: int = 8) -> str:
+    return f"""type: qemu
+name: q35-router
+cpu: 1
+ram: 1024
+ethernet: 2
+console_type: telnet
+capabilities:
+  hotplug: true
+  max_nics: {max_nics}
+  machine: q35
+"""
+
+
+def _pc_template() -> str:
+    return """type: qemu
+name: pc-legacy
+cpu: 1
+ram: 1024
+ethernet: 2
+console_type: telnet
+capabilities:
+  hotplug: false
+  max_nics: 4
+  machine: pc
+"""
+
+
+def _slot_args(cmd: list[str]) -> list[tuple[str, str]]:
+    """Extract ``(rp_id, slot)`` pairs from -device pcie-root-port entries."""
+    pairs: list[tuple[str, str]] = []
+    for index, arg in enumerate(cmd):
+        if arg == "-device" and index + 1 < len(cmd):
+            value = cmd[index + 1]
+            if value.startswith("pcie-root-port,"):
+                fields = dict(part.split("=", 1) for part in value.split(",") if "=" in part)
+                pairs.append((fields.get("id", ""), fields.get("slot", "")))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# q35: default max_nics=8 → 8 pre-allocated root ports
+# ---------------------------------------------------------------------------
+
+
+def test_q35_default_preallocates_eight_root_ports(patched_settings, argv_capture):
+    _write_template(patched_settings, "q35router", _q35_template(max_nics=8))
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "r1",
+        "type": "qemu",
+        "template": "q35router",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 2,
+        "extras": {"qemu_nic": "virtio-net-pci"},
+    }
+    lab = _build_lab(node)
+    runtime = NodeRuntimeService().start_node(lab, 1)
+
+    cmd = argv_capture[0]
+    assert "-machine" in cmd
+    machine_arg = cmd[cmd.index("-machine") + 1]
+    assert machine_arg.startswith("type=q35")
+
+    slots = _slot_args(cmd)
+    assert len(slots) == 8
+    # Slot 0 reserved on q35 — first usable is 1; rp ids count from 0.
+    assert slots == [(f"rp{i}", str(i + 1)) for i in range(8)]
+
+    assert runtime["machine"] == "q35"
+    assert runtime["max_nics"] == 8
+    assert runtime["allocated_slots"] == list(range(8))
+    assert runtime["hotplug_capable"] is True
+
+
+# ---------------------------------------------------------------------------
+# q35: custom max_nics=4
+# ---------------------------------------------------------------------------
+
+
+def test_q35_custom_max_nics_preallocates_correct_count(patched_settings, argv_capture):
+    _write_template(patched_settings, "q35slim", _q35_template(max_nics=4))
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "r1",
+        "type": "qemu",
+        "template": "q35slim",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 1,
+        "extras": {"qemu_nic": "e1000"},
+    }
+    runtime = NodeRuntimeService().start_node(_build_lab(node), 1)
+
+    cmd = argv_capture[0]
+    slots = _slot_args(cmd)
+    assert len(slots) == 4
+    assert slots == [("rp0", "1"), ("rp1", "2"), ("rp2", "3"), ("rp3", "4")]
+    assert runtime["max_nics"] == 4
+
+
+# ---------------------------------------------------------------------------
+# pc compat: no pre-allocation, hotplug_capable=False
+# ---------------------------------------------------------------------------
+
+
+def test_pc_machine_emits_no_root_ports(patched_settings, argv_capture):
+    _write_template(patched_settings, "pcrouter", _pc_template())
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "r1",
+        "type": "qemu",
+        "template": "pcrouter",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 1,
+        "extras": {"qemu_nic": "e1000"},
+    }
+    runtime = NodeRuntimeService().start_node(_build_lab(node), 1)
+
+    cmd = argv_capture[0]
+    machine_arg = cmd[cmd.index("-machine") + 1]
+    assert machine_arg.startswith("type=pc")
+    assert _slot_args(cmd) == []
+    assert runtime["machine"] == "pc"
+    assert runtime["hotplug_capable"] is False
+    assert runtime["allocated_slots"] == []
+
+
+# ---------------------------------------------------------------------------
+# machine_override wins over template
+# ---------------------------------------------------------------------------
+
+
+def test_machine_override_pc_overrides_q35_template(patched_settings, argv_capture):
+    """A pre-Wave-7 node stamped with machine_override='pc' must NOT be
+    silently switched to q35 even when the template defaults to q35."""
+    _write_template(patched_settings, "q35router", _q35_template())
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "r1",
+        "type": "qemu",
+        "template": "q35router",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 1,
+        "extras": {"qemu_nic": "e1000"},
+        "machine_override": "pc",
+    }
+    runtime = NodeRuntimeService().start_node(_build_lab(node), 1)
+
+    cmd = argv_capture[0]
+    machine_arg = cmd[cmd.index("-machine") + 1]
+    assert machine_arg.startswith("type=pc")
+    assert _slot_args(cmd) == []
+    assert runtime["machine"] == "pc"
+
+
+def test_machine_override_q35_overrides_pc_template(patched_settings, argv_capture):
+    _write_template(patched_settings, "pcrouter", _pc_template())
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "r1",
+        "type": "qemu",
+        "template": "pcrouter",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 1,
+        "extras": {"qemu_nic": "virtio-net-pci"},
+        "machine_override": "q35",
+    }
+    runtime = NodeRuntimeService().start_node(_build_lab(node), 1)
+
+    cmd = argv_capture[0]
+    machine_arg = cmd[cmd.index("-machine") + 1]
+    assert machine_arg.startswith("type=q35")
+    # max_nics still comes from the pc template (4)
+    assert runtime["max_nics"] == 4
+    assert _slot_args(cmd) == [
+        ("rp0", "1"),
+        ("rp1", "2"),
+        ("rp2", "3"),
+        ("rp3", "4"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Schema rejects invalid machine_override
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_machine_override_rejected_by_schema():
+    from app.schemas.node import NodeBase
+
+    with pytest.raises(Exception):  # pydantic.ValidationError
+        NodeBase(
+            id=1,
+            name="bad",
+            type="qemu",
+            template="q35router",
+            machine_override="i440fx",
+        )
+
+
+def test_machine_override_accepts_valid_values():
+    from app.schemas.node import NodeBase
+
+    n_pc = NodeBase(id=1, name="a", type="qemu", machine_override="pc")
+    n_q35 = NodeBase(id=2, name="b", type="qemu", machine_override="q35")
+    n_none = NodeBase(id=3, name="c", type="qemu", machine_override=None)
+    assert n_pc.machine_override == "pc"
+    assert n_q35.machine_override == "q35"
+    assert n_none.machine_override is None
+
+
+# ---------------------------------------------------------------------------
+# NIC model honored from extras.qemu_nic (not hardcoded)
+# ---------------------------------------------------------------------------
+
+
+def test_nic_model_honored_from_qemu_nic_extra(patched_settings, argv_capture):
+    _write_template(patched_settings, "q35router", _q35_template(max_nics=2))
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "r1",
+        "type": "qemu",
+        "template": "q35router",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 2,
+        "extras": {"qemu_nic": "virtio-net-pci"},
+    }
+    NodeRuntimeService().start_node(_build_lab(node), 1)
+
+    cmd = argv_capture[0]
+    nic_devices: list[str] = []
+    for index, arg in enumerate(cmd):
+        if arg == "-device" and index + 1 < len(cmd):
+            value = cmd[index + 1]
+            if value.startswith(("virtio-net-pci", "e1000", "rtl8139", "vmxnet3", "pcnet")):
+                nic_devices.append(value)
+    assert len(nic_devices) == 2
+    assert all(value.startswith("virtio-net-pci,") for value in nic_devices)
+    # On q35, NICs land on the pre-allocated bus rp{i}
+    assert "bus=rp0" in nic_devices[0]
+    assert "bus=rp1" in nic_devices[1]
+
+
+def test_nic_model_default_e1000_when_extra_missing(patched_settings, argv_capture):
+    _write_template(patched_settings, "q35router", _q35_template(max_nics=1))
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "r1",
+        "type": "qemu",
+        "template": "q35router",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 1,
+        # No extras.qemu_nic — falls back to e1000.
+    }
+    NodeRuntimeService().start_node(_build_lab(node), 1)
+
+    cmd = argv_capture[0]
+    e1000_devices = [
+        cmd[i + 1]
+        for i, arg in enumerate(cmd)
+        if arg == "-device" and i + 1 < len(cmd) and cmd[i + 1].startswith("e1000,")
+    ]
+    assert len(e1000_devices) == 1
+
+
+# ---------------------------------------------------------------------------
+# Slot ID format: id=rpN, chassis=N+1, slot=N+1
+# ---------------------------------------------------------------------------
+
+
+def test_slot_id_format(patched_settings, argv_capture):
+    _write_template(patched_settings, "q35router", _q35_template(max_nics=3))
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "r1",
+        "type": "qemu",
+        "template": "q35router",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 0,
+        "extras": {"qemu_nic": "e1000"},
+    }
+    NodeRuntimeService().start_node(_build_lab(node), 1)
+
+    cmd = argv_capture[0]
+    rp_devices: list[str] = []
+    for index, arg in enumerate(cmd):
+        if arg == "-device" and index + 1 < len(cmd) and cmd[index + 1].startswith("pcie-root-port,"):
+            rp_devices.append(cmd[index + 1])
+    assert rp_devices == [
+        "pcie-root-port,id=rp0,chassis=1,slot=1",
+        "pcie-root-port,id=rp1,chassis=2,slot=2",
+        "pcie-root-port,id=rp2,chassis=3,slot=3",
+    ]
+    # Slot 0 must never be allocated.
+    for value in rp_devices:
+        assert "slot=0" not in value
+
+
+# ---------------------------------------------------------------------------
+# Legacy node with no template field falls back to pc
+# ---------------------------------------------------------------------------
+
+
+def test_node_without_template_falls_back_to_pc(patched_settings, argv_capture):
+    _seed_image(patched_settings)
+
+    node = {
+        "id": 1,
+        "name": "legacy",
+        "type": "qemu",
+        "image": "router-image",
+        "console": "telnet",
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": 1,
+        # No template, no machine_override.
+    }
+    runtime = NodeRuntimeService().start_node(_build_lab(node), 1)
+
+    cmd = argv_capture[0]
+    machine_arg = cmd[cmd.index("-machine") + 1]
+    assert machine_arg.startswith("type=pc")
+    assert _slot_args(cmd) == []
+    assert runtime["machine"] == "pc"


### PR DESCRIPTION
Closes #99. Part of #80.

Wave 7 first executable — pre-allocates pcie-root-port slots at QEMU start (q35 only). Legacy `pc` machine type preserved via discriminator. Unblocks US-302 (per-NIC TAP attach) and US-303/US-304 (hot-add/remove).

## Summary
- `backend/app/services/node_runtime_service.py` (`_start_qemu_node`):
  - Reads machine via the chain `node.machine_override` → `template.capabilities.machine` → `pc` fallback.
  - Emits `-machine type={q35|pc},accel={kvm|tcg}` instead of the hard-coded `type=pc`.
  - For `q35`, pre-allocates `template.capabilities.max_nics` `pcie-root-port` chassis (default 8). Slot 0 reserved on the q35 root complex; first usable is slot 1, so `i in 0..max_nics-1` emits `id=rp{i},chassis={i+1},slot={i+1}`.
  - Initial NICs declared at boot land on `bus=rp{i}` in `interface_index` order; hot-add (US-303) will scan free slots descending from `rp{max_nics-1}`.
  - Persists `machine`, `max_nics`, `hotplug_capable`, and `allocated_slots` on the runtime record so US-302/303/304 can pick up where this story left off.
  - Adds `_resolve_qemu_machine` helper; defers `TemplateService` import to avoid module-load cycles.
  - NIC model still resolved from `extras.qemu_nic` (default `e1000`); no hard-coding.
- `backend/app/schemas/node.py`: adds `machine_override: Optional[Literal['pc', 'q35']] = None` on `NodeBase`. New nodes default to `None` (template wins); pre-Wave-7 QEMU nodes will be stamped with `'pc'` by US-202b's migration script.
- Module docstring on `node_runtime_service.py` documents the slot-allocation policy and machine discriminator (per plan: "Documented in `node_runtime_service.py` module docstring").
- New test file `backend/tests/test_qemu_pcie_root_ports.py` (11 tests, argv-capture only — never actually launches QEMU).

## Test plan
- [x] q35 default → 8 pre-allocated `pcie-root-port` entries with `id=rp{i},chassis={i+1},slot={i+1}` (slot starts at 1).
- [x] q35 with custom `max_nics=4` → exactly 4 root ports.
- [x] Legacy `pc` template → no root ports, `hotplug_capable=False`.
- [x] `machine_override='pc'` overrides a q35 template (load-bearing — protects pre-Wave-7 labs from silent topology change).
- [x] `machine_override='q35'` overrides a `pc` template (operator opt-in flow).
- [x] Invalid `machine_override` (e.g. `i440fx`) rejected by Pydantic schema.
- [x] NIC model honored from `extras.qemu_nic` (`virtio-net-pci`); falls back to `e1000` when omitted.
- [x] `bus=rp{i}` is appended to NIC `-device` lines on q35.
- [x] Slot 0 is never allocated.
- [x] Node with no template/override falls back to `pc` (no surprise q35 default).
- [x] argv-capture fixture replaces `subprocess.Popen`/`subprocess.run`; **no real QEMU is launched** in tests.

Verification:
```
cd backend && /Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/ -x
# 467 passed, 12 warnings in 2.85s
```

## q35 / pc compatibility
**Resolution chain in `_start_qemu_node`** (matches plan precedence):
1. If `node.machine_override` is `'pc'` or `'q35'`, that value wins unconditionally.
2. Otherwise read `template.capabilities.machine` from `TemplateService`.
3. Final fallback `'pc'` (used only when neither field is resolvable — e.g. legacy lab with no template field).

`max_nics` always comes from `template.capabilities.max_nics` (default 8), never hard-coded in node runtime. The `pc` path keeps the existing positional `-device {nic_model},netdev=net{N}` layout exactly as before — no `bus=` suffix, no root ports, no behavior change for existing labs once US-202b stamps `machine_override='pc'`.

`template.capabilities.machine='pc' AND hotplug=true` is rejected at template-load time (already enforced by US-305's `_validate_capabilities`).