### PR TITLE
feat(runtime): per-NIC TAP + bridge attach at QEMU start (US-302, #100)

### DIFF
--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -339,6 +339,25 @@ def addr_up_in_netns(pid: int, iface: str) -> None:
     _invoke_helper("addr-up-in-netns", str(int(pid)), iface)
 
 
+def tap_add(name: str) -> None:
+    """Create a Linux TAP device with ``name`` via the privileged helper.
+
+    Used by the QEMU start path (US-302): one TAP per NIC, attached to the
+    network's bridge before QEMU launches with ``-netdev tap,ifname=...``.
+    Raises :class:`HostNetEEXIST` if a link with ``name`` already exists.
+    """
+    _invoke_helper("tap-add", name)
+
+
+def tap_del(name: str) -> None:
+    """Delete a Linux TAP device via the privileged helper.
+
+    The helper's ``tap-del`` verb is ``ip link del <name>``; it also works
+    for veth host-ends. Raises :class:`HostNetEINVAL` if the link is gone.
+    """
+    _invoke_helper("tap-del", name)
+
+
 def link_del(name: str) -> None:
     """Delete a host-side link (TAP or veth host-end) via the helper.
 

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -169,7 +169,7 @@ class NodeRuntimeService:
             return runtime
 
         if node.get("type") == "qemu":
-            runtime = self._start_qemu_node(lab_id, node)
+            runtime = self._start_qemu_node(lab_data, node)
         elif node.get("type") == "docker":
             runtime = self._start_docker_node(lab_data, node)
         else:
@@ -858,7 +858,9 @@ class NodeRuntimeService:
             return False
         return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
 
-    def _start_qemu_node(self, lab_id: str, node: dict[str, Any]) -> dict[str, Any]:
+    def _start_qemu_node(
+        self, lab_data: dict[str, Any], node: dict[str, Any]
+    ) -> dict[str, Any]:
         extras = _node_extras(node)
         architecture = _extra_str(extras, "architecture") or "x86_64"
         qemu_binary = self._resolve_qemu_binary(architecture)
@@ -867,9 +869,25 @@ class NodeRuntimeService:
                 f"QEMU binary not found for arch {architecture}: {self.settings.QEMU_BINARY}"
             )
 
+        lab_id = self._lab_id(lab_data)
+        node_id = int(node["id"])
         machine, max_nics, hotplug_capable = self._resolve_qemu_machine(node)
 
-        work_dir = self._work_dir(lab_id, node["id"])
+        # US-302: per-NIC TAP attachments. Pre-flight every declared
+        # interface's bridge BEFORE we spawn QEMU so a missing bridge
+        # surfaces a typed NodeRuntimeError instead of leaking a half-
+        # started VM. SLIRP is opt-in via per-interface ``extras.uplink``.
+        attachments = self._qemu_attachments(lab_data, node)
+        for attachment in attachments:
+            bridge = attachment["bridge_name"]
+            if not host_net.bridge_exists(bridge):
+                raise NodeRuntimeError(
+                    f"Bridge {bridge} for network_id={attachment['network_id']} "
+                    f"is not present on the host; provision it via create_network "
+                    f"(US-202) before starting the node."
+                )
+
+        work_dir = self._work_dir(lab_id, node_id)
         work_dir.mkdir(parents=True, exist_ok=True)
         overlay_path = self._ensure_qemu_overlay(work_dir, node)
         iso_path = self._resolve_qemu_iso(node)
@@ -890,9 +908,9 @@ class NodeRuntimeService:
             "-m",
             str(node.get("ram", 1024)),
             "-name",
-            str(node.get("name", f"node-{node['id']}")),
+            str(node.get("name", f"node-{node_id}")),
             "-uuid",
-            str(node.get("uuid") or extras.get("uuid") or f"{lab_id}-{node['id']}"),
+            str(node.get("uuid") or extras.get("uuid") or f"{lab_id}-{node_id}"),
             "-drive",
             f"file={overlay_path},if=virtio,cache=writeback,format=qcow2",
         ]
@@ -924,18 +942,67 @@ class NodeRuntimeService:
 
         nic_model = _extra_str(extras, "qemu_nic") or "e1000"
         first_mac = node.get("firstmac") or extras.get("firstmac")
-        for index in range(int(node.get("ethernet", 0))):
+        attachment_by_index: dict[int, dict[str, Any]] = {
+            int(a["interface_index"]): a for a in attachments
+        }
+        node_interfaces = node.get("interfaces") or []
+        ethernet_count = int(node.get("ethernet", 0))
+
+        # US-302: provision TAPs BEFORE spawning QEMU. Track every TAP we
+        # successfully created so a partial-failure path can sweep them.
+        provisioned_taps: list[str] = []
+        try:
+            tap_names: dict[int, str] = {}
+            for index in range(ethernet_count):
+                if index in attachment_by_index:
+                    tap = host_net.tap_name(lab_id, node_id, index)
+                    bridge = attachment_by_index[index]["bridge_name"]
+                    host_net.tap_add(tap)
+                    provisioned_taps.append(tap)
+                    host_net.link_master(tap, bridge)
+                    host_net.link_up(tap)
+                    tap_names[index] = tap
+        except Exception:
+            for tap in provisioned_taps:
+                host_net.try_link_del(tap)
+            raise
+
+        # ----- Build per-NIC -netdev / -device argv ------------------------
+        for index in range(ethernet_count):
             device_args = (
                 f"{nic_model},netdev=net{index},mac={self._mac_for_index(first_mac, index)}"
             )
             if machine == "q35" and index < max_nics:
                 device_args += f",bus=rp{index}"
-            cmd += [
-                "-netdev",
-                f"user,id=net{index}",
-                "-device",
-                device_args,
-            ]
+
+            if index in tap_names:
+                tap = tap_names[index]
+                cmd += [
+                    "-netdev",
+                    f"tap,id=net{index},ifname={tap},script=no,downscript=no",
+                    "-device",
+                    device_args,
+                ]
+            elif self._interface_uplink(node_interfaces, index):
+                # SLIRP opt-in (extras.uplink: true) — gives the NIC NAT
+                # access to the host's outbound network without a bridge.
+                cmd += [
+                    "-netdev",
+                    f"user,id=net{index}",
+                    "-device",
+                    device_args,
+                ]
+            else:
+                # No network attached and no uplink request — give the NIC
+                # an isolated ``hubport`` netdev (each in its own private
+                # hub, hubid={index}) so it appears in the guest but never
+                # reaches host networking.
+                cmd += [
+                    "-netdev",
+                    f"hubport,id=net{index},hubid={index}",
+                    "-device",
+                    device_args,
+                ]
 
         if iso_path:
             cmd += ["-cdrom", str(iso_path), "-boot", "order=dc"]
@@ -945,39 +1012,56 @@ class NodeRuntimeService:
             try:
                 cmd += shlex.split(extra_args)
             except ValueError as exc:
+                # Sweep TAPs we already created so the lab does not leak
+                # kernel objects when arg parsing rejects the launch.
+                for tap in provisioned_taps:
+                    host_net.try_link_del(tap)
                 raise NodeRuntimeError(f"Invalid qemu_options: {exc}") from exc
 
-        with stdout_log.open("ab") as stdout_handle, stderr_log.open("ab") as stderr_handle:
-            process = subprocess.Popen(
-                cmd,
-                cwd=work_dir,
-                stdin=subprocess.DEVNULL,
-                stdout=stdout_handle,
-                stderr=stderr_handle,
-                start_new_session=True,
-            )
+        try:
+            with stdout_log.open("ab") as stdout_handle, stderr_log.open("ab") as stderr_handle:
+                process = subprocess.Popen(
+                    cmd,
+                    cwd=work_dir,
+                    stdin=subprocess.DEVNULL,
+                    stdout=stdout_handle,
+                    stderr=stderr_handle,
+                    start_new_session=True,
+                )
+        except Exception:
+            for tap in provisioned_taps:
+                host_net.try_link_del(tap)
+            raise
 
         time.sleep(0.1)
         if process.poll() is not None:
             error = self._tail_text(stderr_log, 40) or self._tail_text(stdout_log, 40)
+            for tap in provisioned_taps:
+                host_net.try_link_del(tap)
             raise NodeRuntimeError(error or "QEMU exited immediately after start")
 
         process_info = psutil.Process(process.pid)
 
-        # US-201/US-203: register the PID into the runtime registry BEFORE
-        # any helper-verb call. QEMU does not use the helper today, but
-        # US-303 (hot-attach) will, and the registry is the single source
-        # of truth for pid authorization. Best-effort: a registry write
-        # failure does not abort the QEMU start path because nothing in
-        # the QEMU happy path needs the registry yet.
+        # US-201/US-203: register the PID into the runtime registry. On
+        # registry failure we kill the QEMU process and sweep the TAPs to
+        # keep the rollback symmetric with the docker start path
+        # (``_start_docker_node`` step 4).
         try:
-            runtime_pids.register(process.pid, "qemu", lab_id, int(node["id"]))
-        except Exception:  # noqa: BLE001 — best-effort, see comment above
-            pass
+            runtime_pids.register(process.pid, "qemu", lab_id, node_id)
+        except Exception as exc:
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            for tap in provisioned_taps:
+                host_net.try_link_del(tap)
+            raise NodeRuntimeError(
+                f"Failed to register QEMU PID in runtime registry: {exc}"
+            ) from exc
 
         return {
             "lab_id": lab_id,
-            "node_id": node["id"],
+            "node_id": node_id,
             "kind": "qemu",
             "name": node.get("name"),
             "console": console_mode,
@@ -995,8 +1079,143 @@ class NodeRuntimeService:
             "max_nics": max_nics,
             "hotplug_capable": hotplug_capable,
             "allocated_slots": allocated_slots,
+            "tap_names": list(provisioned_taps),
+            "interface_attachments": [
+                {
+                    "interface_index": a["interface_index"],
+                    "network_id": a["network_id"],
+                    "bridge_name": a["bridge_name"],
+                    "tap_name": tap_names.get(int(a["interface_index"])),
+                }
+                for a in attachments
+            ],
             "started_at": time.time(),
         }
+
+    @staticmethod
+    def _interface_uplink(interfaces: list[Any], interface_index: int) -> bool:
+        """Return True iff the interface's ``extras.uplink`` flag is set.
+
+        SLIRP/user-mode networking is opt-in per interface (US-302). When
+        the interface entry has no explicit network attachment, we keep
+        the legacy ``-netdev user`` only when the operator has marked the
+        interface as an uplink — otherwise the NIC is wired into an
+        isolated socket netdev to keep the guest from leaking onto the
+        host's outbound network.
+        """
+        for entry in interfaces or []:
+            if not isinstance(entry, dict):
+                continue
+            if int(entry.get("index", -1)) == int(interface_index):
+                extras = entry.get("extras") or {}
+                if isinstance(extras, dict) and bool(extras.get("uplink")):
+                    return True
+                return False
+        return False
+
+    def _qemu_attachments(
+        self, lab_data: dict[str, Any], node: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Resolve per-interface bridge attachments for a QEMU node.
+
+        Mirrors :meth:`_docker_attachments`: returns
+        ``{interface_index, network_id, bridge_name}`` records ordered by
+        ``interface_index``. Interfaces with no resolvable network (no
+        link, ``pnet`` external network, or missing network record) are
+        skipped — those NICs fall back to the SLIRP/opt-in uplink path.
+        """
+        lab_id = self._lab_id(lab_data)
+        networks = lab_data.get("networks", {}) or {}
+
+        node_id = int(node.get("id", 0))
+        link_map: dict[int, int] = {}
+        for link in lab_data.get("links", []) or []:
+            endpoints = (link.get("from") or {}, link.get("to") or {})
+            node_endpoint = next(
+                (
+                    endpoint for endpoint in endpoints
+                    if isinstance(endpoint, dict)
+                    and "node_id" in endpoint
+                    and int(endpoint.get("node_id", -1)) == node_id
+                ),
+                None,
+            )
+            network_endpoint = next(
+                (
+                    endpoint for endpoint in endpoints
+                    if isinstance(endpoint, dict) and "network_id" in endpoint
+                ),
+                None,
+            )
+            if node_endpoint and network_endpoint:
+                interface_index = int(node_endpoint.get("interface_index", 0))
+                network_id = int(network_endpoint.get("network_id", 0))
+                if network_id:
+                    link_map[interface_index] = network_id
+
+        attachments: list[dict[str, Any]] = []
+        seen_indices: set[int] = set()
+        interfaces = node.get("interfaces") or []
+        ethernet_count = int(node.get("ethernet", 0))
+        for index, interface in enumerate(interfaces):
+            if not isinstance(interface, dict):
+                continue
+            interface_index = int(interface.get("index", index))
+            if interface_index in seen_indices:
+                continue
+            network_id = int(interface.get("network_id") or 0)
+            if not network_id:
+                network_id = link_map.get(interface_index, 0)
+            if not network_id:
+                continue
+            network = networks.get(str(network_id))
+            if not isinstance(network, dict):
+                continue
+            network_type = str(network.get("type", "linux_bridge"))
+            if network_type.startswith("pnet"):
+                continue
+            runtime_record = network.get("runtime") or {}
+            bridge = runtime_record.get("bridge_name")
+            if not bridge:
+                bridge = host_net.bridge_name(lab_id, network_id)
+            seen_indices.add(interface_index)
+            attachments.append(
+                {
+                    "interface_index": interface_index,
+                    "network_id": network_id,
+                    "bridge_name": bridge,
+                }
+            )
+
+        # Also pick up interfaces that exist only via a `links[]` entry
+        # (no explicit ``interfaces[]`` record) — the QEMU NIC count is
+        # driven by ``ethernet`` and these still need a TAP.
+        for interface_index, network_id in link_map.items():
+            if interface_index in seen_indices:
+                continue
+            if interface_index >= ethernet_count:
+                continue
+            network = networks.get(str(network_id))
+            if not isinstance(network, dict):
+                continue
+            network_type = str(network.get("type", "linux_bridge"))
+            if network_type.startswith("pnet"):
+                continue
+            runtime_record = network.get("runtime") or {}
+            bridge = runtime_record.get("bridge_name")
+            if not bridge:
+                bridge = host_net.bridge_name(lab_id, network_id)
+            seen_indices.add(interface_index)
+            attachments.append(
+                {
+                    "interface_index": interface_index,
+                    "network_id": network_id,
+                    "bridge_name": bridge,
+                }
+            )
+
+        attachments.sort(key=lambda item: item["interface_index"])
+        return attachments
 
     def _resolve_qemu_machine(self, node: dict[str, Any]) -> tuple[str, int, bool]:
         """Resolve machine type, max_nics, and hotplug capability for a QEMU node.
@@ -1371,11 +1590,13 @@ class NodeRuntimeService:
     def _stop_qemu_runtime(self, runtime: dict[str, Any]) -> None:
         pid = runtime.get("pid")
         if not pid:
+            self._sweep_qemu_taps(runtime)
             return
 
         try:
             os.killpg(pid, signal.SIGTERM)
         except ProcessLookupError:
+            self._sweep_qemu_taps(runtime)
             self._unregister_pid(pid)
             return
 
@@ -1387,9 +1608,19 @@ class NodeRuntimeService:
             except ProcessLookupError:
                 pass
 
+        # US-302: sweep the per-NIC TAPs owned by this VM. Best-effort
+        # via ``try_link_del`` so already-removed TAPs (cleanup sweeper
+        # from US-206 ran first) do not raise.
+        self._sweep_qemu_taps(runtime)
+
         # US-201/US-203: drop the QEMU pid from the registry synchronously
         # so a recycled pid cannot inherit this entry's authorization.
         self._unregister_pid(pid)
+
+    @staticmethod
+    def _sweep_qemu_taps(runtime: dict[str, Any]) -> None:
+        for tap in runtime.get("tap_names", []) or []:
+            host_net.try_link_del(tap)
 
     @staticmethod
     def _unregister_pid(pid: int | None) -> None:

--- a/backend/tests/test_node_runtime.py
+++ b/backend/tests/test_node_runtime.py
@@ -1319,3 +1319,374 @@ async def test_live_mac_endpoint_publishes_ws_event(monkeypatch, patched_setting
     assert event["payload"]["state"] == "confirmed"
     assert event["payload"]["planned_mac"] == "aa:bb:cc:dd:ee:01"
     assert event["payload"]["live_mac"] == "aa:bb:cc:dd:ee:01"
+
+
+# ---------------------------------------------------------------------------
+# US-302 — per-NIC TAP + bridge attach at QEMU start (replaces SLIRP)
+# ---------------------------------------------------------------------------
+
+
+def _us302_helper_mock(
+    monkeypatch,
+    *,
+    present_bridges: set[str] | None = None,
+    fail_on: tuple[str, str] | None = None,
+):
+    """Capture every privileged-helper call relevant to US-302.
+
+    ``fail_on`` is ``(verb, name)`` — when the verb is invoked with the
+    matching iface name, the fake raises ``HostNetEINVAL`` so the start
+    path can exercise its rollback.
+    """
+    from app.services import host_net
+
+    if present_bridges is None:
+        present_bridges = set()
+
+    calls: dict[str, list] = {
+        "bridge_exists": [],
+        "tap_add": [],
+        "tap_del": [],
+        "link_master": [],
+        "link_up": [],
+        "try_link_del": [],
+    }
+
+    def _maybe_fail(verb: str, name: str) -> None:
+        if fail_on and fail_on == (verb, name):
+            raise host_net.HostNetEINVAL(
+                f"injected failure: {verb} {name}",
+                returncode=1,
+                stderr="injected",
+            )
+
+    def fake_bridge_exists(name: str) -> bool:
+        calls["bridge_exists"].append(name)
+        return name in present_bridges
+
+    def fake_tap_add(name: str) -> None:
+        calls["tap_add"].append(name)
+        _maybe_fail("tap_add", name)
+
+    def fake_tap_del(name: str) -> None:
+        calls["tap_del"].append(name)
+
+    def fake_link_master(iface: str, bridge: str) -> None:
+        calls["link_master"].append((iface, bridge))
+        _maybe_fail("link_master", iface)
+
+    def fake_link_up(iface: str) -> None:
+        calls["link_up"].append(iface)
+        _maybe_fail("link_up", iface)
+
+    def fake_try_link_del(name: str) -> None:
+        calls["try_link_del"].append(name)
+
+    monkeypatch.setattr(host_net, "bridge_exists", fake_bridge_exists)
+    monkeypatch.setattr(host_net, "tap_add", fake_tap_add)
+    monkeypatch.setattr(host_net, "tap_del", fake_tap_del)
+    monkeypatch.setattr(host_net, "link_master", fake_link_master)
+    monkeypatch.setattr(host_net, "link_up", fake_link_up)
+    monkeypatch.setattr(host_net, "try_link_del", fake_try_link_del)
+    return calls
+
+
+def _us302_names() -> dict:
+    """Compute the canonical bridge/tap names for the US-302 fixture."""
+    from app.services import host_net
+
+    lab_id = "lab-302"
+    return {
+        "lab_id": lab_id,
+        "bridge1": host_net.bridge_name(lab_id, 1),
+        "bridge2": host_net.bridge_name(lab_id, 2),
+        "tap0": host_net.tap_name(lab_id, 1, 0),
+        "tap1": host_net.tap_name(lab_id, 1, 1),
+    }
+
+
+def _us302_lab_data() -> dict:
+    """Two-NIC QEMU node attached to a single linux_bridge network."""
+    names = _us302_names()
+    return {
+        "schema": 2,
+        "id": names["lab_id"],
+        "meta": {"name": "us302"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            "1": {
+                "id": 1,
+                "name": "vyos-1",
+                "type": "qemu",
+                "image": "router-image",
+                "console": "telnet",
+                "cpu": 1,
+                "ram": 1024,
+                "ethernet": 2,
+                "firstmac": "50:00:00:01:00:00",
+                "interfaces": [
+                    {"index": 0, "name": "eth0", "planned_mac": None, "port_position": None},
+                    {"index": 1, "name": "eth1", "planned_mac": None, "port_position": None},
+                ],
+            }
+        },
+        "networks": {
+            "1": {
+                "id": 1,
+                "name": "lab-link",
+                "type": "linux_bridge",
+                "visibility": True,
+                "implicit": False,
+                "config": {},
+                "runtime": {"bridge_name": names["bridge1"]},
+            },
+            "2": {
+                "id": 2,
+                "name": "mgmt",
+                "type": "linux_bridge",
+                "visibility": True,
+                "implicit": False,
+                "config": {},
+                "runtime": {"bridge_name": names["bridge2"]},
+            },
+        },
+        "links": [
+            {
+                "id": "lnk_001",
+                "from": {"node_id": 1, "interface_index": 0},
+                "to": {"network_id": 1},
+                "style_override": None,
+                "label": "",
+                "color": "",
+                "width": "1",
+                "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+            },
+            {
+                "id": "lnk_002",
+                "from": {"node_id": 1, "interface_index": 1},
+                "to": {"network_id": 2},
+                "style_override": None,
+                "label": "",
+                "color": "",
+                "width": "1",
+                "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+            },
+        ],
+        "defaults": {"link_style": "orthogonal"},
+    }
+
+
+def _setup_us302_qemu_runtime(monkeypatch, runtime_settings):
+    """Stage shared mocks for the QEMU start path: image dir, popen, psutil."""
+    image_dir = runtime_settings.IMAGES_DIR / "qemu" / "router-image"
+    image_dir.mkdir(parents=True, exist_ok=True)
+    (image_dir / "hda.qcow2").write_text("base-image")
+
+    _mock_runtime_binaries(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.subprocess.run",
+        _fake_subprocess_run_factory([]),
+    )
+    recorded_popen: list[dict] = []
+
+    def fake_popen(cmd, cwd=None, stdin=None, stdout=None, stderr=None, start_new_session=None):
+        recorded_popen.append({"cmd": list(cmd), "cwd": str(cwd)})
+        return _FakeProcess(7777)
+
+    monkeypatch.setattr("app.services.node_runtime_service.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.psutil.Process",
+        lambda pid: SimpleNamespace(
+            create_time=lambda: 222.0,
+            cpu_percent=lambda interval=0.0: 1.0,
+            memory_info=lambda: SimpleNamespace(rss=1024),
+            wait=lambda timeout=5: None,
+            is_running=lambda: True,
+            status=lambda: "sleeping",
+        ),
+    )
+    return recorded_popen
+
+
+def test_us302_qemu_start_creates_per_nic_tap_and_no_slirp(
+    monkeypatch, patched_settings, _us203_instance_id
+):
+    """Each declared interface gets its own TAP, attached to the right
+    bridge. No `-netdev user` (SLIRP) is in the QEMU argv when every NIC
+    has a network attachment.
+    """
+    names = _us302_names()
+    bridges = {names["bridge1"], names["bridge2"]}
+    helper = _us302_helper_mock(monkeypatch, present_bridges=bridges)
+    recorded_popen = _setup_us302_qemu_runtime(monkeypatch, patched_settings)
+
+    service = NodeRuntimeService()
+    runtime = service.start_node(_us302_lab_data(), 1)
+
+    cmd = recorded_popen[0]["cmd"]
+    netdev_args = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-netdev"]
+
+    # Two NICs => two -netdev tap entries, no -netdev user.
+    tap_args = [a for a in netdev_args if a.startswith("tap,")]
+    user_args = [a for a in netdev_args if a.startswith("user,")]
+    assert len(tap_args) == 2, f"expected 2 -netdev tap entries, got {netdev_args}"
+    assert user_args == [], f"SLIRP must not be used when bridges exist: {user_args}"
+
+    # Each tap arg references the canonical TAP name and the no-script flags.
+    for arg in tap_args:
+        assert "ifname=" in arg
+        assert ",script=no" in arg
+        assert ",downscript=no" in arg
+
+    # Helper sequence: bridge_exists pre-flight, tap_add → link_master → link_up.
+    assert set(helper["bridge_exists"]) == bridges
+    assert len(helper["tap_add"]) == 2
+    assert len(helper["link_master"]) == 2
+    assert len(helper["link_up"]) == 2
+    # link_master pairs each TAP with its declared bridge.
+    masters = dict(helper["link_master"])
+    assert set(masters.values()) == bridges
+
+    # Runtime record carries the TAP names so stop-path can sweep them.
+    assert len(runtime["tap_names"]) == 2
+    assert all(name.startswith("nve") for name in runtime["tap_names"])
+    assert len(runtime["interface_attachments"]) == 2
+
+
+def test_us302_qemu_start_aborts_when_bridge_missing(
+    monkeypatch, patched_settings, _us203_instance_id
+):
+    """Pre-flight bridge presence check raises before QEMU spawns."""
+    helper = _us302_helper_mock(monkeypatch, present_bridges=set())
+    recorded_popen = _setup_us302_qemu_runtime(monkeypatch, patched_settings)
+
+    service = NodeRuntimeService()
+    with pytest.raises(Exception) as excinfo:
+        service.start_node(_us302_lab_data(), 1)
+
+    assert "bridge" in str(excinfo.value).lower()
+    # QEMU never started.
+    assert recorded_popen == []
+    # No TAP work happened.
+    assert helper["tap_add"] == []
+    assert helper["link_master"] == []
+
+
+def test_us302_qemu_start_rolls_back_taps_on_helper_failure(
+    monkeypatch, patched_settings, _us203_instance_id
+):
+    """A mid-loop helper failure sweeps already-created TAPs.
+
+    With ``link_master`` failing on the second NIC, the first TAP must
+    be deleted (try_link_del), the second TAP appended via tap_add must
+    also be deleted, QEMU must NOT have spawned, and the runtime PID
+    registry must stay empty (no register call survives rollback).
+    """
+    from app.services import runtime_pids
+
+    names = _us302_names()
+    bridges = {names["bridge1"], names["bridge2"]}
+    helper = _us302_helper_mock(
+        monkeypatch,
+        present_bridges=bridges,
+        fail_on=("link_master", names["tap1"]),
+    )
+    recorded_popen = _setup_us302_qemu_runtime(monkeypatch, patched_settings)
+
+    service = NodeRuntimeService()
+    with pytest.raises(Exception):
+        service.start_node(_us302_lab_data(), 1)
+
+    # Both TAPs got an add attempt — first succeeded, second failed at link_master.
+    assert helper["tap_add"] == [names["tap0"], names["tap1"]]
+    # Both TAPs are swept on rollback.
+    assert set(helper["try_link_del"]) == {names["tap0"], names["tap1"]}
+    # QEMU never spawned and no PID was registered.
+    assert recorded_popen == []
+    assert runtime_pids.list_entries() == []
+
+
+def test_us302_qemu_argv_contains_netdev_tap_not_user(
+    monkeypatch, patched_settings, _us203_instance_id
+):
+    """Sanity assertion isolated from helper choreography: the assembled
+    QEMU argv uses ``-netdev tap,ifname=...`` and never ``-netdev user``
+    when networks resolve."""
+    names = _us302_names()
+    _us302_helper_mock(
+        monkeypatch, present_bridges={names["bridge1"], names["bridge2"]}
+    )
+    recorded_popen = _setup_us302_qemu_runtime(monkeypatch, patched_settings)
+
+    service = NodeRuntimeService()
+    service.start_node(_us302_lab_data(), 1)
+
+    flat = " ".join(recorded_popen[0]["cmd"])
+    assert "-netdev tap," in flat
+    assert ",ifname=nve" in flat
+    assert "-netdev user," not in flat
+
+
+def test_us302_rollback_symmetry_with_docker_start(
+    monkeypatch, patched_settings, _us203_instance_id
+):
+    """When the registry write fails AFTER QEMU spawned, we kill the
+    process and sweep TAPs (mirrors docker step-4 rollback)."""
+    from app.services import runtime_pids
+
+    names = _us302_names()
+    _us302_helper_mock(
+        monkeypatch, present_bridges={names["bridge1"], names["bridge2"]}
+    )
+    recorded_popen = _setup_us302_qemu_runtime(monkeypatch, patched_settings)
+
+    killed: list = []
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.os.killpg",
+        lambda pid, sig: killed.append((pid, sig)),
+    )
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("registry write blocked")
+
+    monkeypatch.setattr(runtime_pids, "register", boom)
+
+    service = NodeRuntimeService()
+    with pytest.raises(Exception) as excinfo:
+        service.start_node(_us302_lab_data(), 1)
+
+    assert "registry" in str(excinfo.value).lower()
+    # QEMU spawned exactly once and was killed during rollback.
+    assert len(recorded_popen) == 1
+    assert killed and killed[0][0] == 7777
+    # No leaked entry in the registry (register raised, unregister noop).
+    assert runtime_pids.list_entries() == []
+
+
+def test_us302_qemu_stop_sweeps_tap_names(
+    monkeypatch, patched_settings, _us203_instance_id
+):
+    """Stop path must call ``host_net.try_link_del`` for every TAP the
+    start path created (parity with US-203 veth sweep)."""
+    names = _us302_names()
+    helper = _us302_helper_mock(
+        monkeypatch, present_bridges={names["bridge1"], names["bridge2"]}
+    )
+    _setup_us302_qemu_runtime(monkeypatch, patched_settings)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.os.killpg",
+        lambda pid, sig: None,
+    )
+
+    service = NodeRuntimeService()
+    lab_data = _us302_lab_data()
+    runtime = service.start_node(lab_data, 1)
+    expected_taps = set(runtime["tap_names"])
+    assert expected_taps  # sanity
+
+    helper["try_link_del"].clear()
+    service.stop_node(lab_data, 1)
+    assert set(helper["try_link_del"]) == expected_taps


### PR DESCRIPTION
## Summary

Replaces SLIRP/user-mode networking on QEMU start with per-NIC TAP devices wired to the right host bridge.

- `host_net.tap_add` / `tap_del` thin wrappers around the existing privileged helper verbs.
- `node_runtime_service._start_qemu_node` now runs a pre-flight bridge presence check, then for every interface with a resolvable network: `tap_add` -> `link_master` -> `link_up`, and emits `-netdev tap,id=netN,ifname=...,script=no,downscript=no` (no more `-netdev user`).
- Helper-failure rollback sweeps every TAP we created via `try_link_del`. Registry-write failure also kills the QEMU process and sweeps TAPs (mirrors `_start_docker_node` step 4).
- SLIRP is now opt-in per interface via `extras.uplink: true`. Unattached NICs without that flag get an isolated `-netdev hubport` so the guest never leaks onto the host's outbound network.
- `_stop_qemu_runtime` sweeps every TAP listed in `runtime["tap_names"]` (parity with the US-203 veth host-end sweep).

## Test plan

- [x] `pytest backend/tests/` -> 485 passed (was 479 + 6 new US-302 cases).
- [x] New test cases:
  - `test_us302_qemu_start_creates_per_nic_tap_and_no_slirp`
  - `test_us302_qemu_start_aborts_when_bridge_missing`
  - `test_us302_qemu_start_rolls_back_taps_on_helper_failure`
  - `test_us302_qemu_argv_contains_netdev_tap_not_user`
  - `test_us302_rollback_symmetry_with_docker_start`
  - `test_us302_qemu_stop_sweeps_tap_names`
- [ ] Manual on test VM: start `vyos-1`, log in via console, `show interfaces` shows Gi1 with link state UP and DHCP (or same-bridge ICMP from `alpine-a`).

Refs #80
Closes #100