### PR TITLE
feat(net): hot-attach Docker on links[] create (US-204, #91)

### DIFF
--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -11,14 +11,20 @@ and publish WebSocket events.
 
 from __future__ import annotations
 
+import copy
+import logging
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple
 
 from app.config import get_settings
+from app.services import host_net
 from app.services.lab_lock import lab_lock
 from app.services.lab_service import LabService, _normalize_relative_lab_path
 from app.services.link_utils import _endpoint_key, _link_pair_key  # noqa: F401 — re-exported
 from app.services.ws_hub import ws_hub
+
+
+_logger = logging.getLogger("nova-ve.link_service")
 
 
 _IDEMPOTENCY_CACHE_MAX = 1024
@@ -253,6 +259,21 @@ class LinkService:
                     if ex_key == target_key:
                         raise DuplicateLinkError(_link_with_state(existing))
 
+            # Snapshot pre-write state so we can roll back lab.json if
+            # post-write hot-attach (US-204) fails. ``read_lab_json_static``
+            # synthesises ``topology`` from links[]; we strip that derived
+            # field before deep-copying so the rollback write does not
+            # regenerate links[] from a stale shim.
+            original_snapshot = copy.deepcopy(data)
+            original_snapshot.pop("topology", None)
+            # ``implicit_bridge_to_provision`` is the (network_id, bridge_name|None)
+            # for an implicit network synthesised by this call. ``bridge_name``
+            # is None at this stage; the helper resolves it lazily so labs
+            # without a per-host instance_id (typical for unit tests that
+            # never start a node) do not pre-emptively blow up here.
+            implicit_bridge_to_provision: Optional[Tuple[int, Optional[str]]] = None
+            concrete_links_to_attach: List[dict] = []
+
             link_payload: dict
             network_payload: Optional[dict] = None
             promoted_network: Optional[dict] = None
@@ -295,6 +316,18 @@ class LinkService:
                 ws_events.append(("network_created", {"network": dict(implicit_net)}))
                 ws_events.append(("link_created", {"link": _link_with_state(first_link)}))
                 ws_events.append(("link_created", {"link": _link_with_state(second_link)}))
+
+                # US-204: each concrete node↔network link is processed
+                # independently for hot-attach. The implicit network's
+                # bridge must be provisioned exactly once before either
+                # attach call (Codex critic v4 new defect #3). The bridge
+                # name is resolved lazily in ``_hot_attach_running_endpoints``
+                # so labs without a per-host ``instance_id`` (e.g. unit
+                # tests that never start a node) do not blow up on the
+                # ``host_net.bridge_name`` call.
+                implicit_bridge_to_provision = (int(net_id), None)
+                concrete_links_to_attach.append(first_link)
+                concrete_links_to_attach.append(second_link)
 
             else:
                 # Mixed node/network or network/network attach.
@@ -342,6 +375,34 @@ class LinkService:
                     ws_events.append(("network_promoted", {"network": promoted_network}))
                 ws_events.append(("link_created", {"link": _link_with_state(new_link)}))
 
+                # US-204: hot-attach single concrete link (only when the
+                # node-ish endpoint is running). bridge_name resolution
+                # uses the existing network's runtime.bridge_name when
+                # present (US-202 / US-202b), falling back to the canonical
+                # derived name.
+                concrete_links_to_attach.append(new_link)
+
+            # ----------------------------------------------------------
+            # US-204 hot-attach pass — runs INSIDE the lab_lock so we can
+            # roll back lab.json atomically on host-side failure.
+            # ----------------------------------------------------------
+            try:
+                self._hot_attach_running_endpoints(
+                    lab_path=normalized,
+                    lab_data=data,
+                    implicit_bridge=implicit_bridge_to_provision,
+                    concrete_links=concrete_links_to_attach,
+                )
+            except Exception as exc:
+                # Roll back lab.json — JSON file leads kernel state contract.
+                LabService.write_lab_json_static(normalized, original_snapshot)
+                _recompute_mac_registry(normalized, original_snapshot)
+                _logger.error(
+                    "create_link: hot-attach failed (%s); rolled back lab.json",
+                    exc,
+                )
+                raise
+
         for event_type, payload in ws_events:
             await ws_hub.publish(normalized, event_type, payload)
 
@@ -354,6 +415,185 @@ class LinkService:
             ws_events,
         )
         return link_payload, network_payload, False
+
+    def _hot_attach_running_endpoints(
+        self,
+        *,
+        lab_path: str,
+        lab_data: dict,
+        implicit_bridge: Optional[Tuple[int, Optional[str]]],
+        concrete_links: List[dict],
+    ) -> None:
+        """US-204: hot-attach Docker for every concrete node↔network link
+        whose node endpoint is currently running.
+
+        Symmetric with US-203's initial-attach path: both invoke the same
+        per-iface attach helper (``_attach_docker_interface_initial``) so
+        host-side iface naming is identical between first-NIC and Nth-NIC
+        attachments — no special-case for the first NIC.
+
+        ``implicit_bridge`` is set when ``create_link`` synthesises an
+        implicit network from a node↔node request. The bridge for that
+        network is provisioned exactly once before any hot-attach call (the
+        plan's "implicit network's bridge is created via ``host_net.bridge_add``
+        exactly once, before either attach call" requirement).
+
+        On any failure, raises and the caller rolls back lab.json.
+        """
+        # Local import to avoid a module-load cycle (node_runtime_service →
+        # link_service is fine, but link_service → node_runtime_service at
+        # import time would create one if node_runtime_service ever imports
+        # link_service back).
+        from app.services.node_runtime_service import (  # noqa: WPS433 — local import
+            NodeRuntimeError,
+            NodeRuntimeService,
+        )
+
+        # Filter to links that need a hot-attach: node↔network endpoint pairs
+        # where the node is currently running on this host. Network↔network
+        # links and stopped nodes are no-ops at the runtime layer.
+        runtime_service = NodeRuntimeService()
+        lab_id = str(lab_data.get("id") or lab_path)
+        nodes = lab_data.get("nodes") or {}
+
+        # Pre-pass: identify candidate (node_id, interface_index, network_id)
+        # tuples whose node is currently running. We defer bridge_name
+        # resolution (which requires a per-host instance_id) until we know
+        # there is at least one candidate — labs that never start nodes
+        # never trigger the instance_id read.
+        pending: List[Tuple[int, int, int]] = []
+        for link in concrete_links:
+            node_endpoint = None
+            network_endpoint = None
+            for endpoint in (link.get("from"), link.get("to")):
+                if not isinstance(endpoint, dict):
+                    continue
+                if "network_id" in endpoint:
+                    network_endpoint = endpoint
+                elif "node_id" in endpoint:
+                    node_endpoint = endpoint
+            if node_endpoint is None or network_endpoint is None:
+                continue
+
+            try:
+                node_id = int(node_endpoint["node_id"])
+                interface_index = int(node_endpoint.get("interface_index", 0))
+                network_id = int(network_endpoint["network_id"])
+            except (TypeError, ValueError):
+                continue
+
+            # Hot-attach is opt-in by liveness: skip nodes that are not
+            # running (their initial attach will run when the user starts
+            # the node). The runtime registry is the single source of truth.
+            runtime = runtime_service._runtime_record(lab_id, node_id)
+            if runtime is None:
+                continue
+            if runtime.get("kind") != "docker":
+                # QEMU hot-attach is US-303, not US-204.
+                continue
+
+            pending.append((node_id, interface_index, network_id))
+
+        if not pending:
+            return
+
+        # Resolve the implicit network's bridge name lazily — only now do we
+        # know there is at least one running endpoint that needs the kernel
+        # object.
+        resolved_implicit_bridge: Optional[Tuple[int, str]] = None
+        if implicit_bridge is not None:
+            implicit_net_id, implicit_name = implicit_bridge
+            if implicit_name is None:
+                implicit_name = host_net.bridge_name(lab_id, int(implicit_net_id))
+            resolved_implicit_bridge = (int(implicit_net_id), implicit_name)
+
+        # Now resolve a bridge name for every pending target.
+        attach_targets: List[Tuple[int, int, int, str]] = []
+        for node_id, interface_index, network_id in pending:
+            bridge = self._resolve_bridge_name(
+                lab_id=lab_id,
+                network_id=network_id,
+                networks=lab_data.get("networks") or {},
+                implicit_bridge=resolved_implicit_bridge,
+            )
+            attach_targets.append((node_id, interface_index, network_id, bridge))
+
+        # Provision the implicit network's bridge exactly once before any
+        # attach call (Codex critic v4 new defect #3). Idempotent: pre-existing
+        # bridge is treated as a no-op.
+        provisioned_implicit_bridge: Optional[str] = None
+        if resolved_implicit_bridge is not None:
+            net_id, bridge_name = resolved_implicit_bridge
+            if any(target[2] == net_id for target in attach_targets):
+                if not host_net.bridge_exists(bridge_name):
+                    host_net.bridge_add(bridge_name)
+                    provisioned_implicit_bridge = bridge_name
+
+        # Attach each target. On the FIRST failure, sweep the bridges + every
+        # already-attached interface so we leave no host-side leftover.
+        attached: List[Tuple[int, int]] = []
+        try:
+            for node_id, interface_index, network_id, bridge in attach_targets:
+                runtime_service.attach_docker_interface(
+                    lab_id,
+                    node_id,
+                    network_id,
+                    interface_index,
+                    bridge_name=bridge,
+                )
+                attached.append((node_id, interface_index))
+        except (NodeRuntimeError, host_net.HostNetError):
+            for node_id, interface_index in attached:
+                host_end = host_net.veth_host_name(lab_id, node_id, interface_index)
+                host_net.try_link_del(host_end)
+                # Best-effort: drop the rolled-back attachment from the
+                # runtime record so subsequent reads stay consistent.
+                runtime = runtime_service._runtime_record(lab_id, node_id)
+                if runtime is not None:
+                    attachments = [
+                        a for a in (runtime.get("interface_attachments") or [])
+                        if int(a.get("interface_index", -1)) != interface_index
+                    ]
+                    runtime["interface_attachments"] = attachments
+                    host_ends = [
+                        h for h in (runtime.get("veth_host_ends") or [])
+                        if h != host_end
+                    ]
+                    runtime["veth_host_ends"] = host_ends
+                    runtime_service._persist_runtime(runtime)
+            if provisioned_implicit_bridge is not None:
+                try:
+                    host_net.bridge_del(provisioned_implicit_bridge)
+                except host_net.HostNetError:
+                    pass
+            raise
+
+    @staticmethod
+    def _resolve_bridge_name(
+        *,
+        lab_id: str,
+        network_id: int,
+        networks: dict,
+        implicit_bridge: Optional[Tuple[int, str]],
+    ) -> str:
+        """Return the host bridge name for a network referenced by a link.
+
+        Resolution order:
+          1. Implicit bridge tuple if it matches this network_id (newly
+             synthesised network from a node↔node create_link call).
+          2. ``networks[str(network_id)].runtime.bridge_name`` if present
+             (US-202 / US-202b populated this on create / migrate).
+          3. Canonical derived name via ``host_net.bridge_name``.
+        """
+        if implicit_bridge is not None and implicit_bridge[0] == network_id:
+            return implicit_bridge[1]
+        record = networks.get(str(network_id))
+        if isinstance(record, dict):
+            runtime_record = record.get("runtime") or {}
+            bridge = runtime_record.get("bridge_name")
+            if isinstance(bridge, str) and bridge:
+                return bridge
+        return host_net.bridge_name(lab_id, network_id)
 
     async def delete_link(self, lab_path: str, link_id: str) -> Tuple[bool, Optional[dict]]:
         """Delete a link. Idempotent: missing link returns ``(True, None)``.

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1275,6 +1275,124 @@ class NodeRuntimeService:
         host_net.link_set_name_in_netns(pid, peer_end, netns_iface)
         host_net.addr_up_in_netns(pid, netns_iface)
 
+    def attach_docker_interface(
+        self,
+        lab_id: str,
+        node_id: int,
+        network_id: int,
+        interface_index: int,
+        *,
+        bridge_name: str | None = None,
+    ) -> dict[str, Any]:
+        """US-204: hot-attach a new interface to an already-running Docker node.
+
+        Symmetric with the initial-attach path used by ``_start_docker_node``
+        (US-203): both invoke the same 6-step ``_attach_docker_interface_initial``
+        helper so host-side iface naming (``nve…d…i…h``) is identical between
+        first-NIC and Nth-NIC attachments — there is no special-case for the
+        first NIC.
+
+        Sequence:
+
+          1. Pre-flight: confirm the runtime record exists, the container is
+             alive, and the kind is ``docker`` (rejects QEMU / stopped nodes
+             with ``NodeRuntimeError``).
+          2. Resolve / verify the target bridge name. Surface a typed
+             ``NodeRuntimeError`` when the bridge is not present on the host
+             (US-202 must have created it).
+          3. Drive the same per-iface attach sequence as initial attach via
+             ``_attach_docker_interface_initial``: ``veth_pair_add`` →
+             ``link_master`` → ``link_up`` → ``link_netns`` →
+             ``link_set_name_in_netns`` → ``addr_up_in_netns``.
+          4. On any failure mid-sequence, sweep the partial host-end veth
+             (``host_net.try_link_del``) and re-raise.
+          5. On success, append the new attachment to the runtime record's
+             ``interface_attachments`` + ``veth_host_ends`` lists and persist.
+
+        Returns the attachment record describing the newly-created host-side
+        objects, suitable for the link router to surface back to the caller.
+        """
+        runtime = self._runtime_record(lab_id, node_id)
+        if runtime is None:
+            raise NodeRuntimeError(
+                f"Cannot hot-attach interface: node {node_id} in lab {lab_id} is "
+                "not running (no runtime record)."
+            )
+        if runtime.get("kind") != "docker":
+            raise NodeRuntimeError(
+                f"Cannot hot-attach docker interface: node {node_id} runtime kind is "
+                f"{runtime.get('kind')!r}, expected 'docker'."
+            )
+
+        pid = runtime.get("pid")
+        if not pid:
+            raise NodeRuntimeError(
+                f"Cannot hot-attach interface: node {node_id} has no resolved "
+                "container PID."
+            )
+
+        # Reject duplicate interface indices on the same node — the host_end
+        # name only encodes (lab, node, iface), so re-attaching the same iface
+        # would collide on ``ip link add``.
+        existing_attachments = runtime.get("interface_attachments") or []
+        for existing in existing_attachments:
+            if int(existing.get("interface_index", -1)) == int(interface_index):
+                raise NodeRuntimeError(
+                    f"interface_index={interface_index} already attached on "
+                    f"node {node_id}; detach before re-attaching."
+                )
+
+        bridge = bridge_name or host_net.bridge_name(lab_id, int(network_id))
+        if not host_net.bridge_exists(bridge):
+            raise NodeRuntimeError(
+                f"Bridge {bridge} for network_id={network_id} is not present on "
+                "the host; provision it via create_network (US-202) before "
+                "hot-attaching interfaces."
+            )
+
+        attachment = {
+            "interface_index": int(interface_index),
+            "network_id": int(network_id),
+            "bridge_name": bridge,
+        }
+
+        provisioned_host_ends: list[str] = []
+        try:
+            self._attach_docker_interface_initial(
+                lab_id=lab_id,
+                node_id=int(node_id),
+                pid=int(pid),
+                attachment=attachment,
+                provisioned_host_ends=provisioned_host_ends,
+            )
+        except Exception:
+            for host_end in provisioned_host_ends:
+                host_net.try_link_del(host_end)
+            raise
+
+        host_end = host_net.veth_host_name(lab_id, int(node_id), int(interface_index))
+        new_attachment = {
+            "interface_index": int(interface_index),
+            "network_id": int(network_id),
+            "bridge_name": bridge,
+            "host_end": host_end,
+        }
+
+        # Persist the new attachment onto the runtime record so stop-time
+        # cleanup sweeps the host-end veth (matches initial-attach contract
+        # at ``_stop_docker_runtime``).
+        with self._lock:
+            attachments_list = list(runtime.get("interface_attachments") or [])
+            attachments_list.append(new_attachment)
+            runtime["interface_attachments"] = attachments_list
+            host_ends = list(runtime.get("veth_host_ends") or [])
+            if host_end not in host_ends:
+                host_ends.append(host_end)
+            runtime["veth_host_ends"] = host_ends
+        self._persist_runtime(runtime)
+
+        return new_attachment
+
     def _docker_force_remove(self, docker_binary: str, container_name: str) -> None:
         """Force-remove a container, swallowing any error (best-effort cleanup)."""
         subprocess.run(

--- a/backend/tests/test_node_runtime.py
+++ b/backend/tests/test_node_runtime.py
@@ -1248,6 +1248,352 @@ def test_iol_and_dynamips_return_unavailable(patched_settings):
         assert "not implemented" in (result["reason"] or "").lower()
 
 
+# ---------------------------------------------------------------------------
+# US-204: hot-attach Docker on links[] create
+# ---------------------------------------------------------------------------
+
+
+def _us204_lab_data() -> dict:
+    """Two-network lab: alpine-a starts with one interface on net 1; the
+    hot-attach tests add a second interface on net 2.
+
+    Bridge names are derived from ``host_net.bridge_name`` so they match
+    what the runtime computes under the active ``_us203_instance_id``
+    fixture (instance_id=test-instance-203 → blake2b → 16-bit suffix).
+    """
+    from app.services import host_net as host_net_module
+
+    bridge_one = host_net_module.bridge_name("lab-204", 1)
+    bridge_two = host_net_module.bridge_name("lab-204", 2)
+    return {
+        "schema": 2,
+        "id": "lab-204",
+        "meta": {"name": "us204"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            "1": {
+                "id": 1,
+                "name": "alpine-a",
+                "type": "docker",
+                "image": "nova-ve-alpine-telnet:latest",
+                "console": "telnet",
+                "cpu": 1,
+                "ram": 256,
+                "ethernet": 2,
+                "interfaces": [
+                    {"index": 0, "name": "eth0", "planned_mac": None, "port_position": None},
+                    {"index": 1, "name": "eth1", "planned_mac": None, "port_position": None},
+                ],
+            }
+        },
+        "networks": {
+            "1": {
+                "id": 1,
+                "name": "lab-link",
+                "type": "linux_bridge",
+                "visibility": True,
+                "implicit": False,
+                "config": {},
+                "runtime": {"bridge_name": bridge_one},
+            },
+            "2": {
+                "id": 2,
+                "name": "lab-mgmt",
+                "type": "linux_bridge",
+                "visibility": True,
+                "implicit": False,
+                "config": {},
+                "runtime": {"bridge_name": bridge_two},
+            },
+        },
+        "links": [
+            {
+                "id": "lnk_001",
+                "from": {"node_id": 1, "interface_index": 0},
+                "to": {"network_id": 1},
+                "style_override": None,
+                "label": "",
+                "color": "",
+                "width": "1",
+                "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+            }
+        ],
+        "defaults": {"link_style": "orthogonal"},
+    }
+
+
+def _us204_docker_run_factory(containers: dict[str, dict[str, object]]):
+    """Returns a fake ``subprocess.run`` that mimics the docker daemon:
+    handles ``docker run``, ``docker inspect``, ``docker stop``, ``docker rm``.
+
+    All four hot-attach tests start one container then mutate that container
+    map across calls.
+    """
+
+    def fake_run(cmd, capture_output=False, text=False, **_kwargs):
+        if os.path.basename(cmd[0]) != "docker":
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        args = cmd[3:] if len(cmd) > 2 and cmd[1] == "--host" else cmd[1:]
+        if args[0] == "run":
+            container_name = args[args.index("--name") + 1]
+            containers[container_name] = {
+                "running": True,
+                "pid": 7000 + len(containers),
+            }
+            return SimpleNamespace(returncode=0, stdout=f"{container_name}-cid\n", stderr="")
+        if args[:2] == ["inspect", "-f"]:
+            template = args[2]
+            container_name = args[3]
+            container = containers.get(container_name)
+            if not container:
+                return SimpleNamespace(returncode=1, stdout="", stderr="missing")
+            if template == "{{.State.Pid}}":
+                return SimpleNamespace(returncode=0, stdout=f"{container['pid']}\n", stderr="")
+            if template == "{{.State.Running}}":
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=("true" if container["running"] else "false") + "\n",
+                    stderr="",
+                )
+        if args[0] == "stop":
+            container_name = args[-1]
+            if container_name in containers:
+                containers[container_name]["running"] = False
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if args[0] == "rm":
+            container_name = args[-1]
+            containers.pop(container_name, None)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return fake_run
+
+
+def _us204_start_alpine_a(
+    monkeypatch,
+    patched_settings,
+    *,
+    include_net2_bridge: bool = True,
+):
+    """Boot alpine-a (node 1) via the US-203 path so we have a live runtime
+    record to hot-attach to. Returns ``(service, lab_data, helper_calls,
+    containers, recorded_calls)``.
+
+    ``include_net2_bridge`` toggles whether net 2's bridge is reported as
+    present on the host — used by the bridge-missing test to drive the
+    pre-flight rejection branch.
+    """
+    from app.services import host_net as host_net_module
+
+    lab_data = _us204_lab_data()
+    bridge_one = host_net_module.bridge_name("lab-204", 1)
+    bridge_two = host_net_module.bridge_name("lab-204", 2)
+    present_bridges = {bridge_one}
+    if include_net2_bridge:
+        present_bridges.add(bridge_two)
+
+    containers: dict[str, dict[str, object]] = {}
+    helper_calls = _us203_helper_mock(monkeypatch, present_bridges=present_bridges)
+
+    _mock_runtime_binaries(monkeypatch)
+    recorded_calls: list[list[str]] = []
+
+    docker_fake = _us204_docker_run_factory(containers)
+
+    def fake_run(cmd, capture_output=False, text=False, **kwargs):
+        recorded_calls.append(cmd)
+        return docker_fake(cmd, capture_output=capture_output, text=text, **kwargs)
+
+    monkeypatch.setattr("app.services.node_runtime_service.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.psutil.Process",
+        lambda pid: SimpleNamespace(create_time=lambda: float(pid)),
+    )
+
+    service = NodeRuntimeService()
+    service.start_node(lab_data, 1)
+    # Reset helper-call recording so tests only see hot-attach activity.
+    for key in helper_calls:
+        helper_calls[key].clear()
+    return service, lab_data, helper_calls, containers, recorded_calls
+
+
+def test_us204_hot_attach_docker_happy_path(monkeypatch, patched_settings, _us203_instance_id):
+    """Hot-attaching a new link to a running container creates a veth pair,
+    masters the host end on the bridge, moves the peer into the container's
+    netns, and renames it to ``eth{interface_index}``. The runtime record
+    is updated so stop-time cleanup sweeps the new host-end veth.
+    """
+    from app.services import host_net as host_net_module
+
+    service, lab_data, helper_calls, _containers, _recorded = _us204_start_alpine_a(
+        monkeypatch, patched_settings
+    )
+    bridge_two = host_net_module.bridge_name("lab-204", 2)
+
+    attachment = service.attach_docker_interface(
+        "lab-204", 1, network_id=2, interface_index=1
+    )
+
+    # The 6-step sequence ran (same one used by initial-attach in US-203).
+    assert helper_calls["veth_pair_add"], "veth pair was not created"
+    host_end, peer_end = helper_calls["veth_pair_add"][0]
+    assert host_end.endswith("h"), f"host-end suffix is wrong: {host_end!r}"
+    assert peer_end.endswith("p"), f"peer-end suffix is wrong: {peer_end!r}"
+    assert helper_calls["link_master"] == [(host_end, bridge_two)]
+    assert helper_calls["link_up"] == [host_end]
+    assert len(helper_calls["link_netns"]) == 1
+    assert helper_calls["link_netns"][0][0] == peer_end
+    assert helper_calls["link_set_name_in_netns"] == [
+        (helper_calls["link_netns"][0][1], peer_end, "eth1"),
+    ]
+    assert helper_calls["addr_up_in_netns"] == [
+        (helper_calls["link_netns"][0][1], "eth1"),
+    ]
+
+    # Returned attachment record carries the new host_end + bridge.
+    assert attachment["interface_index"] == 1
+    assert attachment["network_id"] == 2
+    assert attachment["bridge_name"] == bridge_two
+    assert attachment["host_end"] == host_end
+
+    # The runtime record now lists both attachments and both host-ends so
+    # stop-time cleanup will sweep them.
+    runtime = service._runtime_record("lab-204", 1)
+    assert runtime is not None
+    indices = sorted(int(a["interface_index"]) for a in runtime["interface_attachments"])
+    assert indices == [0, 1]
+    assert host_end in runtime["veth_host_ends"]
+
+
+def test_us204_hot_attach_rejects_when_container_stopped(monkeypatch, patched_settings, _us203_instance_id):
+    """Hot-attach must reject when the target container is not running —
+    no runtime record means no container to attach into.
+    """
+    service, lab_data, helper_calls, containers, _recorded = _us204_start_alpine_a(
+        monkeypatch, patched_settings
+    )
+
+    # Stop the container so its runtime record is purged.
+    service.stop_node(lab_data, 1)
+    helper_calls["veth_pair_add"].clear()
+
+    from app.services.node_runtime_service import NodeRuntimeError
+
+    with pytest.raises(NodeRuntimeError) as exc_info:
+        service.attach_docker_interface("lab-204", 1, network_id=2, interface_index=1)
+
+    assert "not running" in str(exc_info.value).lower() or "no runtime" in str(exc_info.value).lower()
+    # No helper-side state was touched.
+    assert not helper_calls["veth_pair_add"]
+    assert not helper_calls["link_master"]
+
+
+def test_us204_hot_attach_rejects_when_bridge_missing(monkeypatch, patched_settings, _us203_instance_id):
+    """When the target network's bridge is not yet provisioned on the host,
+    hot-attach must surface a typed ``NodeRuntimeError`` instead of failing
+    deeper in the helper sequence.
+    """
+    from app.services import host_net as host_net_module
+
+    # Only network 1's bridge is present; we'll attempt to attach to
+    # network 2 — its bridge is missing.
+    service, _lab_data, helper_calls, _containers, _recorded = _us204_start_alpine_a(
+        monkeypatch, patched_settings, include_net2_bridge=False
+    )
+    bridge_two = host_net_module.bridge_name("lab-204", 2)
+
+    from app.services.node_runtime_service import NodeRuntimeError
+
+    with pytest.raises(NodeRuntimeError) as exc_info:
+        service.attach_docker_interface("lab-204", 1, network_id=2, interface_index=1)
+
+    assert bridge_two in str(exc_info.value)
+    assert "not present" in str(exc_info.value).lower()
+    # No veth was created — the pre-flight bridge check must run BEFORE
+    # any helper call.
+    assert not helper_calls["veth_pair_add"]
+
+
+def test_us204_hot_attach_rolls_back_on_helper_failure(monkeypatch, patched_settings, _us203_instance_id):
+    """If a helper step fails mid-sequence (e.g. ``link_set_name_in_netns``
+    blows up), the partially-created host-end veth is swept and the runtime
+    record is NOT mutated to include the failed attachment.
+    """
+    service, _lab_data, helper_calls, _containers, _recorded = _us204_start_alpine_a(
+        monkeypatch, patched_settings
+    )
+
+    from app.services import host_net as host_net_module
+
+    def fake_link_set_name_in_netns(_pid, _old, _new):
+        raise host_net_module.HostNetEINVAL(
+            "kernel rejected rename", returncode=1, stderr="kernel rejected"
+        )
+
+    monkeypatch.setattr(host_net_module, "link_set_name_in_netns", fake_link_set_name_in_netns)
+
+    with pytest.raises(host_net_module.HostNetEINVAL):
+        service.attach_docker_interface("lab-204", 1, network_id=2, interface_index=1)
+
+    # The partially-created host-end veth was swept by ``try_link_del``.
+    swept = {entry["name"] for entry in helper_calls["link_del"] if entry["fn"] == "try_link_del"}
+    expected_host_end = host_net_module.veth_host_name("lab-204", 1, 1)
+    assert expected_host_end in swept, (
+        f"rollback did not sweep the partial host-end veth {expected_host_end!r}; "
+        f"swept set was {swept!r}"
+    )
+
+    # The runtime record only carries the original (interface_index=0)
+    # attachment; the failed (interface_index=1) attachment was NOT added.
+    runtime = service._runtime_record("lab-204", 1)
+    assert runtime is not None
+    indices = sorted(int(a["interface_index"]) for a in runtime["interface_attachments"])
+    assert indices == [0]
+    assert expected_host_end not in runtime.get("veth_host_ends", [])
+
+
+def test_us204_hot_attach_symmetric_with_initial_attach(monkeypatch, patched_settings, _us203_instance_id):
+    """Both initial and hot attachments must drive the SAME 6-step sequence
+    against the privileged helper, with identical host-end naming. This is
+    the plan's "no special-case for the first NIC" property.
+    """
+    service, _lab_data, helper_calls, _containers, _recorded = _us204_start_alpine_a(
+        monkeypatch, patched_settings
+    )
+
+    # Capture the initial-attach sequence (interface 0 was attached during
+    # ``_us204_start_alpine_a`` BEFORE the helper-call lists were cleared,
+    # so we re-run an attach on a fresh interface and compare verb shapes).
+    service.attach_docker_interface("lab-204", 1, network_id=2, interface_index=1)
+
+    # Verb counts MUST match the initial-attach 6-step sequence exactly.
+    assert len(helper_calls["veth_pair_add"]) == 1
+    assert len(helper_calls["link_master"]) == 1
+    assert len(helper_calls["link_up"]) == 1
+    assert len(helper_calls["link_netns"]) == 1
+    assert len(helper_calls["link_set_name_in_netns"]) == 1
+    assert len(helper_calls["addr_up_in_netns"]) == 1
+
+    # Naming pattern is the same regex shape as initial attach (see US-203
+    # ``_us203_helper_mock`` assertions): host-end suffix ``h``, peer-end
+    # suffix ``p``, renamed in-netns to ``eth{interface_index}``.
+    host_end, peer_end = helper_calls["veth_pair_add"][0]
+    from app.services import host_net as host_net_module
+
+    assert host_end == host_net_module.veth_host_name("lab-204", 1, 1)
+    assert peer_end == host_net_module.veth_peer_name("lab-204", 1, 1)
+    assert host_end.endswith("h")
+    assert peer_end.endswith("p")
+
+    # Verb invocation ORDER matters: the 6-step sequence must run in the
+    # documented order. The mock records each verb in invocation order, so
+    # we can reconstruct the order by comparing list lengths captured
+    # before / after each conceptual step. The simpler check below asserts
+    # the rename uses the renamed-into-netns peer name.
+    assert helper_calls["link_set_name_in_netns"][0][2] == "eth1"
+
+
 @pytest.mark.asyncio
 async def test_live_mac_endpoint_publishes_ws_event(monkeypatch, patched_settings):
     lab_path = patched_settings.LABS_DIR / "live-mac.json"


### PR DESCRIPTION
## Summary

Implements US-204 from `.omc/plans/network-runtime-wiring.md` — hot-attaching a Docker container's new interface when a `links[]` entry is created against a running node.

- Adds `NodeRuntimeService.attach_docker_interface(lab_id, node_id, network_id, interface_index)` — symmetric with US-203's initial attach. Drives the same 6-step `_attach_docker_interface_initial` helper (`veth_pair_add` → `link_master` → `link_up` → `link_netns` → `link_set_name_in_netns` → `addr_up_in_netns`) so host-side iface naming (`nve…d…i…h`) is identical between first-NIC and Nth-NIC attachments — no special-case for the first NIC.
- Wires `LinkService.create_link` to invoke the new method for every concrete node↔network link whose node endpoint is currently running. Implicit networks synthesised by node↔node calls get their bridge provisioned exactly once before any attach call.
- Failure handling: pre-flight rejects when the target bridge is not present; mid-sequence helper failures sweep the partial host-end veth, drop the just-provisioned implicit bridge, and roll back `lab.json` to the pre-write snapshot.
- Adds 5 unit tests covering: happy path, container-stopped rejection, bridge-missing rejection, helper-failure rollback, and symmetry with initial attach.

## Test plan

- [x] `backend/.venv/bin/python -m pytest tests/test_node_runtime.py -k us204 -v` → 5/5 pass
- [x] `backend/.venv/bin/python -m pytest tests/` → 484 pass (was 479 baseline; +5 new)
- [ ] Manual on test VM (`192.168.100.212`): start `alpine-a`, drag-to-connect to a second network in the canvas, verify `nsenter -t \$(docker inspect --format '{{.State.Pid}}' nova-ve-alpinedocker-1) -n ip link` shows `eth1 master nove…n2` and the host-side veth uses the `nve…h` naming pattern.
- [ ] Manual on test VM: hot-attach against a stopped container surfaces a typed error (no veth leaked).
- [ ] Manual on test VM: hot-attach against a non-existent bridge surfaces a typed error before any helper call.

Closes #91
Refs #80