### PR TITLE
hotfix(net): migration backfills node.machine_override='pc' for pre-Wave-7 QEMU nodes (#89 codex HIGH 2)

### DIFF
--- a/backend/tests/test_migrate_runtime_network.py
+++ b/backend/tests/test_migrate_runtime_network.py
@@ -12,6 +12,8 @@ Covers:
   - per-lab rollback on simulated bridge_add failure
   - abort on docker network inspect failure (no docker network rm called)
   - rollback restores old Docker network from captured inspect JSON
+  - stamps node.machine_override='pc' on pre-Wave-7 QEMU nodes
+    (compat discriminator — see plan :397-400)
 """
 
 from __future__ import annotations
@@ -109,10 +111,13 @@ def test_already_migrated_is_noop(instance_id, tmp_path):
         networks={"1": _net(1, bridge_name=bridge)},
     )
 
-    checked, backfilled = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+    checked, backfilled, nodes_stamped = mig.process_lab(
+        lab_path, labs_dir, backup_dir, dry_run=False
+    )
 
     assert checked == 1
     assert backfilled == 0
+    assert nodes_stamped == 0
     # File is untouched (no backup taken since nothing changed).
     assert not backup_dir.exists() or not any(backup_dir.iterdir())
 
@@ -149,10 +154,13 @@ def test_fills_missing_bridge_name(instance_id, tmp_path, monkeypatch):
     )
     monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
 
-    checked, backfilled = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+    checked, backfilled, nodes_stamped = mig.process_lab(
+        lab_path, labs_dir, backup_dir, dry_run=False
+    )
 
     assert checked == 2
     assert backfilled == 2
+    assert nodes_stamped == 0
 
     saved = json.loads(lab_path.read_text())
     expected_1 = host_net.bridge_name("lab-fill", 1)
@@ -189,11 +197,15 @@ def test_idempotent_second_run(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
     monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
 
-    _, backfilled_1 = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+    _, backfilled_1, _ = mig.process_lab(
+        lab_path, labs_dir, backup_dir, dry_run=False
+    )
     assert backfilled_1 == 1
 
     # Second run — should be zero.
-    _, backfilled_2 = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
+    _, backfilled_2, _ = mig.process_lab(
+        lab_path, labs_dir, backup_dir, dry_run=False
+    )
     assert backfilled_2 == 0
 
 
@@ -227,9 +239,12 @@ def test_dry_run_does_not_write(instance_id, tmp_path, monkeypatch):
     )
     monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
 
-    checked, backfilled = mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=True)
+    checked, backfilled, nodes_stamped = mig.process_lab(
+        lab_path, labs_dir, backup_dir, dry_run=True
+    )
 
     assert backfilled == 1
+    assert nodes_stamped == 0
     # File must be unchanged.
     assert lab_path.read_text() == original_text
     # No host changes.
@@ -512,3 +527,102 @@ def test_main_nonexistent_labs_dir(tmp_path):
     """main() exits 1 when labs_dir does not exist."""
     rc = mig.main(["--labs-dir", str(tmp_path / "nonexistent")])
     assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# node.machine_override='pc' backfill (compat discriminator — plan :397-400)
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_stamps_machine_override(instance_id, tmp_path, monkeypatch):
+    """Pre-Wave-7 QEMU nodes get machine_override='pc' stamped.
+
+    Acceptance criteria from .omc/plans/network-runtime-wiring.md:397-400:
+      (a) QEMU nodes lacking machine_override get 'pc' stamped on every one.
+      (b) docker/iol/dynamips nodes are untouched.
+      (c) QEMU nodes already carrying machine_override (e.g. user-set 'q35')
+          are untouched (idempotency contract).
+      (d) Re-running the migration on an already-stamped lab is a no-op.
+    """
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+
+    # Mix of node types covering all four acceptance branches.
+    nodes = {
+        # (a) pre-Wave-7 QEMU nodes — no machine_override key at all.
+        "1": {"id": 1, "name": "vyos-1", "type": "qemu", "status": 0},
+        "2": {"id": 2, "name": "csr-1", "type": "qemu", "status": 0},
+        # (b) non-QEMU nodes must NOT be touched, even if their type lacks the
+        # field (machine_override is QEMU-specific in the spec).
+        "3": {"id": 3, "name": "alpine-a", "type": "docker", "status": 0},
+        "4": {"id": 4, "name": "iol-1", "type": "iol", "status": 0},
+        "5": {"id": 5, "name": "dyn-1", "type": "dynamips", "status": 0},
+        # (c) user-set machine_override='q35' must be preserved.
+        "6": {
+            "id": 6,
+            "name": "vyos-q35",
+            "type": "qemu",
+            "status": 0,
+            "machine_override": "q35",
+        },
+        # An already-'pc' QEMU node — must remain 'pc' (no double-stamp).
+        "7": {
+            "id": 7,
+            "name": "vyos-pc",
+            "type": "qemu",
+            "status": 0,
+            "machine_override": "pc",
+        },
+    }
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-mach",
+        nodes=nodes,
+        networks={"1": _net(1)},
+    )
+
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+
+    checked, backfilled, nodes_stamped = mig.process_lab(
+        lab_path, labs_dir, backup_dir, dry_run=False
+    )
+
+    assert checked == 1
+    assert backfilled == 1
+    # Two pre-Wave-7 QEMU nodes (ids 1 and 2) should have been stamped.
+    assert nodes_stamped == 2
+
+    saved = json.loads(lab_path.read_text())
+    saved_nodes = saved["nodes"]
+
+    # (a) Pre-Wave-7 QEMU nodes — stamped 'pc'.
+    assert saved_nodes["1"]["machine_override"] == "pc"
+    assert saved_nodes["2"]["machine_override"] == "pc"
+
+    # (b) Docker / iol / dynamips nodes — untouched, no machine_override added.
+    assert "machine_override" not in saved_nodes["3"]
+    assert "machine_override" not in saved_nodes["4"]
+    assert "machine_override" not in saved_nodes["5"]
+
+    # (c) User-set values preserved.
+    assert saved_nodes["6"]["machine_override"] == "q35"
+    assert saved_nodes["7"]["machine_override"] == "pc"
+
+    # (d) Re-running the migration is a no-op for nodes (already stamped) AND
+    # for networks (already migrated above).
+    text_after_first = lab_path.read_text()
+    checked2, backfilled2, nodes_stamped2 = mig.process_lab(
+        lab_path, labs_dir, backup_dir, dry_run=False
+    )
+    assert checked2 == 1
+    assert backfilled2 == 0
+    assert nodes_stamped2 == 0
+    # File contents must be identical on a second pass (no spurious rewrite).
+    assert lab_path.read_text() == text_after_first

--- a/scripts/migrate_runtime_network.py
+++ b/scripts/migrate_runtime_network.py
@@ -7,6 +7,15 @@ Backfills ``runtime.bridge_name`` on every network record that is missing
 it.  Networks created by US-202 already have the field; this script is a
 no-op for those labs (idempotent).
 
+In the same read-modify-write cycle, this script also stamps
+``node.machine_override = 'pc'`` on every QEMU node that lacks the field
+(pre-Wave-7 labs — see ``.omc/plans/network-runtime-wiring.md:397-400``).
+This is the load-bearing compatibility discriminator that prevents
+US-301's ``_resolve_qemu_machine()`` resolver from silently pivoting
+legacy labs from ``pc`` to ``q35`` on first restart post-migration.
+Nodes whose ``machine_override`` is already set (e.g. user-chosen
+``'q35'``) are left untouched, preserving idempotency.
+
 For labs created *before* Wave 6 (US-202), networks may have a legacy
 Docker network bound to them (created by the old ``_ensure_docker_network``
 path).  The migration sequence for each such network is:
@@ -345,6 +354,34 @@ def _rollback_lab(
 
 
 # ---------------------------------------------------------------------------
+# Pre-Wave-7 node.machine_override backfill (compat discriminator)
+# ---------------------------------------------------------------------------
+
+
+def _stamp_machine_override(nodes: dict[str, Any]) -> int:
+    """Mutate ``nodes`` in place: stamp ``machine_override='pc'`` on every
+    QEMU node that lacks the field. Returns the count of nodes stamped.
+
+    Only QEMU nodes are touched. Docker/iol/dynamips nodes are left alone.
+    A node is considered "lacking" the field if ``machine_override`` is
+    missing OR explicitly ``None``. Any other value (e.g. user-chosen
+    ``'q35'``) is preserved — that is the idempotency contract required by
+    ``.omc/plans/network-runtime-wiring.md:397-400``.
+    """
+    stamped = 0
+    for _key, node in nodes.items():
+        if not isinstance(node, dict):
+            continue
+        if node.get("type") != "qemu":
+            continue
+        if node.get("machine_override") is not None:
+            continue
+        node["machine_override"] = "pc"
+        stamped += 1
+    return stamped
+
+
+# ---------------------------------------------------------------------------
 # Per-lab processing
 # ---------------------------------------------------------------------------
 
@@ -355,10 +392,13 @@ def process_lab(
     backup_dir: Path,
     *,
     dry_run: bool,
-) -> tuple[int, int]:
+) -> tuple[int, int, int]:
     """Process a single lab file.
 
-    Returns ``(networks_checked, networks_backfilled)``.
+    Returns ``(networks_checked, networks_backfilled, nodes_stamped)``.
+    ``nodes_stamped`` counts QEMU nodes that received
+    ``machine_override='pc'`` in this pass.
+
     Raises on unrecoverable per-lab errors (caller catches and continues).
     """
     try:
@@ -372,11 +412,10 @@ def process_lab(
         data: dict[str, Any] = json.loads(raw)
 
         if not isinstance(data, dict) or data.get("schema") != 2:
-            return 0, 0
+            return 0, 0, 0
 
         networks: dict[str, Any] = data.get("networks") or {}
-        if not networks:
-            return 0, 0
+        nodes: dict[str, Any] = data.get("nodes") or {}
 
         lab_id = str(data.get("id") or lab_id_path)
         checked = 0
@@ -394,9 +433,18 @@ def process_lab(
             if not runtime.get("bridge_name"):
                 to_migrate.append((net_id, network))
 
-        if not to_migrate:
+        # Count pre-Wave-7 QEMU nodes that need machine_override='pc'.
+        nodes_to_stamp = sum(
+            1
+            for n in nodes.values()
+            if isinstance(n, dict)
+            and n.get("type") == "qemu"
+            and n.get("machine_override") is None
+        )
+
+        if not to_migrate and nodes_to_stamp == 0:
             # Already fully migrated — idempotent no-op.
-            return checked, 0
+            return checked, 0, 0
 
         if dry_run:
             for net_id, _net in to_migrate:
@@ -405,7 +453,13 @@ def process_lab(
                     f"[migrate_runtime_network] DRY RUN: {lab_path.name} "
                     f"network {net_id} → would stamp runtime.bridge_name={bridge}"
                 )
-            return checked, len(to_migrate)
+            if nodes_to_stamp:
+                print(
+                    f"[migrate_runtime_network] DRY RUN: {lab_path.name} "
+                    f"would stamp machine_override='pc' on {nodes_to_stamp} "
+                    "QEMU node(s)"
+                )
+            return checked, len(to_migrate), nodes_to_stamp
 
         # Take a backup of the lab.json before any modifications.
         backup_dir.mkdir(parents=True, exist_ok=True)
@@ -455,7 +509,13 @@ def process_lab(
             runtime["bridge_name"] = bridge
             networks[str(net_id)] = network
 
+        # Step 6: Stamp machine_override='pc' on pre-Wave-7 QEMU nodes
+        # (US-202b compat discriminator — see plan :397-400). Done in the
+        # same read-modify-write cycle so we never double-write the file.
+        nodes_stamped = _stamp_machine_override(nodes)
+
         data["networks"] = networks
+        data["nodes"] = nodes
         data.pop("topology", None)
 
         # Atomic write.
@@ -467,7 +527,7 @@ def process_lab(
             tmp_path.unlink(missing_ok=True)
             raise
 
-    return checked, len(to_migrate)
+    return checked, len(to_migrate), nodes_stamped
 
 
 # ---------------------------------------------------------------------------
@@ -538,6 +598,7 @@ def main(argv: list[str] | None = None) -> int:
     lab_files = sorted(labs_dir.rglob("*.json"))
     total_labs = 0
     total_backfilled = 0
+    total_nodes_stamped = 0
     errors = 0
 
     for lab_path in lab_files:
@@ -548,7 +609,7 @@ def main(argv: list[str] | None = None) -> int:
             continue
 
         try:
-            checked, backfilled = process_lab(
+            checked, backfilled, nodes_stamped = process_lab(
                 lab_path, labs_dir, backup_dir, dry_run=dry_run
             )
         except Exception as exc:
@@ -559,17 +620,23 @@ def main(argv: list[str] | None = None) -> int:
             errors += 1
             continue
 
-        if checked == 0:
+        if checked == 0 and nodes_stamped == 0:
             continue
 
         total_labs += 1
         total_backfilled += backfilled
+        total_nodes_stamped += nodes_stamped
 
-        if backfilled > 0:
+        if backfilled > 0 or nodes_stamped > 0:
             action = "would backfill" if dry_run else "backfilled"
+            parts: list[str] = []
+            if backfilled > 0:
+                parts.append(f"runtime.bridge_name on {backfilled} network(s)")
+            if nodes_stamped > 0:
+                parts.append(f"machine_override='pc' on {nodes_stamped} QEMU node(s)")
             print(
                 f"[migrate_runtime_network] {lab_path.name}: {action} "
-                f"runtime.bridge_name on {backfilled} network(s)"
+                + " and ".join(parts)
             )
         else:
             print(
@@ -579,7 +646,8 @@ def main(argv: list[str] | None = None) -> int:
     suffix = " (dry run)" if dry_run else ""
     print(
         f"[migrate_runtime_network] Done{suffix}. "
-        f"labs={total_labs}, networks_backfilled={total_backfilled}, errors={errors}"
+        f"labs={total_labs}, networks_backfilled={total_backfilled}, "
+        f"nodes_stamped={total_nodes_stamped}, errors={errors}"
     )
     if errors and not dry_run:
         print(


### PR DESCRIPTION
## Summary

Codex critic review (`.omc/research/codex-critic-network-runtime-2026-04-28.md`, HIGH 2) flagged a defect chain across PRs #116/#119/#120: the existing-lab q35 compatibility discriminator was never written. PR #119 backfilled `networks[*].runtime.bridge_name` but never touched nodes, so US-301's `_resolve_qemu_machine()` resolver silently pivots legacy labs from machine type `pc` to `q35` on first restart post-migration — violating spec section [`.omc/plans/network-runtime-wiring.md:397-400`](../blob/main/.omc/plans/network-runtime-wiring.md#L397-L400).

This hotfix stamps `node.machine_override = 'pc'` on every pre-Wave-7 QEMU node during the same migration read-modify-write cycle, restoring the load-bearing discriminator.

## Spec linkage

- Codex finding: `.omc/research/codex-critic-network-runtime-2026-04-28.md` HIGH 2 — "The migration never backfills `node.machine_override='pc'` for pre-Wave-7 QEMU nodes."
- Spec: `.omc/plans/network-runtime-wiring.md:397-400` — "Backfill migration (folded into US-202b): the existing migration script `scripts/migrate_runtime_network.py` ALSO stamps `node.machine_override = 'pc'` on every QEMU node in every existing lab.json that was created pre-Wave-7 ... This is the load-bearing discriminator — without it, q35 default would silently override existing labs."

## Changes

- `scripts/migrate_runtime_network.py`
  - New helper `_stamp_machine_override(nodes)` iterates the lab's nodes dict; for every QEMU node where `machine_override` is missing or `None`, stamps `"pc"` and returns the count.
  - `process_lab()` now returns `(networks_checked, networks_backfilled, nodes_stamped)`. The node-stamping pass runs in the same lab.json read-modify-write cycle as the existing network mutation — no double-write, no risk of partial migration.
  - `main()` reports the node count and exits 0 when only nodes (no networks) needed stamping.
  - Idempotency: nodes with an existing `machine_override` (e.g. user-set `'q35'`) are preserved untouched; re-running on an already-stamped lab is an early-return no-op (no spurious file rewrite).
- `backend/tests/test_migrate_runtime_network.py`
  - New `test_migrate_stamps_machine_override` covering all four acceptance branches:
    - (a) pre-Wave-7 QEMU nodes lacking `machine_override` get `"pc"` stamped on every one.
    - (b) docker/iol/dynamips nodes are untouched.
    - (c) QEMU nodes already carrying `machine_override` (e.g. user-set `"q35"`) are preserved.
    - (d) re-running the migration on an already-stamped lab is a no-op (file contents identical).
  - Existing tests updated for the new 3-tuple return from `process_lab()`.

## Scope discipline

This hotfix is intentionally narrow:
- Does NOT touch `bridge_exists()` / `network_service.create_network` / template_service inferred defaults — those are separate codex findings (HIGH 1, HIGH 3) and will be filed as PRs HF2/HF3/HF4.
- Does NOT modify `.omc/plans/network-runtime-wiring.md`.

## Test plan

- [x] Targeted: `cd backend && /Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/test_migrate_runtime_network.py -x --tb=short` -> 13 passed (was 12; +1 new test).
- [x] Full backend suite: `cd backend && /Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/` -> 480 passed, 0 failed (was 479).
- [x] Syntax: `python -m py_compile` on both modified files -> OK.
- [x] No debug code (TODO/HACK/debugger/breakpoint) in either file.
- [ ] Verify on test VM after deploy: dry-run on `/var/lib/nova-ve/labs` reports `machine_override='pc'` on existing pre-Wave-7 QEMU nodes; live run stamps them and a follow-up start does NOT silently pivot to q35.

Refs #89
Refs #80