### PR TITLE
hotfix(qemu): flip inferred QEMU template defaults to machine=q35, hotplug=true (#103 codex HIGH)

### DIFF
--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -21,8 +21,8 @@ def _default_capabilities(template_type: str) -> dict[str, Any]:
     """Return capability defaults inferred from node type (backward-compat for templates without capabilities block)."""
     if template_type == "docker":
         return {"hotplug": True, "max_nics": _DOCKER_MAX_NICS_DEFAULT, "machine": None}
-    # qemu, iol, dynamips default to conservative values
-    return {"hotplug": False, "max_nics": _QEMU_MAX_NICS_HARD_CAP, "machine": "pc"}
+    # qemu, iol, dynamips default to the runtime-capable q35 profile
+    return {"hotplug": True, "max_nics": _QEMU_MAX_NICS_HARD_CAP, "machine": "q35"}
 
 
 def _validate_capabilities(payload: Any, template_type: str, source: str) -> dict[str, Any]:

--- a/backend/tests/test_node_runtime.py
+++ b/backend/tests/test_node_runtime.py
@@ -168,6 +168,38 @@ def _mock_runtime_binaries(monkeypatch):
     )
 
 
+def test_resolve_qemu_machine_uses_inferred_q35_defaults_when_template_omits_capabilities(
+    monkeypatch, patched_settings, tmp_path
+):
+    templates_dir = tmp_path / "templates" / "qemu"
+    templates_dir.mkdir(parents=True)
+    (templates_dir / "legacy.yml").write_text(
+        """type: qemu
+name: Legacy Router
+cpu: 1
+ram: 512
+ethernet: 2
+console_type: telnet
+"""
+    )
+    monkeypatch.setattr(
+        "app.services.template_service.get_settings",
+        lambda: SimpleNamespace(
+            TEMPLATES_DIR=tmp_path / "templates",
+            IMAGES_DIR=patched_settings.IMAGES_DIR,
+        ),
+    )
+
+    service = NodeRuntimeService()
+    machine, max_nics, hotplug_capable = service._resolve_qemu_machine(
+        {"type": "qemu", "template": "legacy"}
+    )
+
+    assert machine == "q35"
+    assert max_nics == 8
+    assert hotplug_capable is True
+
+
 @pytest.fixture()
 def _us203_instance_id(monkeypatch, tmp_path):
     """Seed an instance_id so ``host_net.bridge_name`` does not blow up.

--- a/backend/tests/test_template_capabilities.py
+++ b/backend/tests/test_template_capabilities.py
@@ -29,14 +29,14 @@ def test_default_capabilities_docker():
 
 def test_default_capabilities_qemu():
     caps = _default_capabilities("qemu")
-    assert caps["hotplug"] is False
+    assert caps["hotplug"] is True
     assert caps["max_nics"] == 8
-    assert caps["machine"] == "pc"
+    assert caps["machine"] == "q35"
 
 
 def test_default_capabilities_iol():
     caps = _default_capabilities("iol")
-    assert caps["hotplug"] is False
+    assert caps["hotplug"] is True
     assert caps["max_nics"] == 8
 
 
@@ -47,7 +47,7 @@ def test_default_capabilities_iol():
 
 def test_validate_capabilities_none_returns_defaults_for_qemu():
     caps = _validate_capabilities(None, "qemu", "test.yml")
-    assert caps == {"hotplug": False, "max_nics": 8, "machine": "pc"}
+    assert caps == {"hotplug": True, "max_nics": 8, "machine": "q35"}
 
 
 def test_validate_capabilities_none_returns_defaults_for_docker():
@@ -204,10 +204,10 @@ console_type: telnet
     )
     tmpl = svc.get_template("qemu", "legacy")
     caps = tmpl.capabilities
-    # Inferred defaults: hotplug=False, max_nics=8, machine=pc
-    assert caps["hotplug"] is False
+    # Inferred defaults: hotplug=True, max_nics=8, machine=q35
+    assert caps["hotplug"] is True
     assert caps["max_nics"] == 8
-    assert caps["machine"] == "pc"
+    assert caps["machine"] == "q35"
 
 
 def test_template_invalid_capabilities_raises_on_load(svc):


### PR DESCRIPTION
## Summary
- flip inferred defaults for templates without an explicit capabilities block to hotplug: true, max_nics: 8, machine: q35
- update the template-capabilities assertions that locked the old pc / hotplug=false inference
- add a node-runtime regression proving _resolve_qemu_machine() resolves to q35 when a QEMU template omits capabilities and the node has no machine_override

## Verification
- /Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/test_template_capabilities.py tests/test_node_runtime.py -x --tb=short
- /Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest

## References
- .omc/research/codex-critic-network-runtime-2026-04-28.md (US-305 HIGH)
- .omc/plans/network-runtime-wiring.md:448-449

Refs #103
Refs #80