### PR TITLE
hotfix(net): prove bridge ownership before reuse via fingerprint file (#88 #89 codex HIGH)

### DIFF
--- a/backend/app/routers/networks.py
+++ b/backend/app/routers/networks.py
@@ -19,6 +19,7 @@ from fastapi.responses import JSONResponse
 from app.dependencies import get_current_user
 from app.schemas.network import NetworkCreate, NetworkUpdate
 from app.schemas.user import UserRead
+from app.services.host_net import HostNetBridgeOwnershipError
 from app.services.lab_service import LEGACY_SCHEMA_ERROR
 from app.services.network_service import NetworkServiceError, network_service
 
@@ -86,6 +87,15 @@ async def create_network(
 
     try:
         payload = await network_service.create_network(lab_path, request.model_dump())
+    except HostNetBridgeOwnershipError as exc:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "code": 409,
+                "status": "fail",
+                "message": str(exc),
+            },
+        )
     except NetworkServiceError as exc:
         body: Dict[str, Any] = {
             "code": exc.code,

--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -26,11 +26,14 @@ where NOVA_VE_HELPER_BIN defaults to /opt/nova-ve/bin/nova-ve-net.py.
 """
 
 import hashlib
+import json
 import logging
 import os
 import subprocess
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Literal, Sequence
 
 logger = logging.getLogger("nova-ve")
 
@@ -71,6 +74,10 @@ class HostNetEINVAL(HostNetError):
 
 class HostNetUnknown(HostNetError):
     """Unknown verb or unparseable failure."""
+
+
+class HostNetBridgeOwnershipError(HostNetError):
+    """A bridge name collision failed ownership verification."""
 
 
 # ---------------------------------------------------------------------------
@@ -197,6 +204,8 @@ def veth_peer_name(lab_id: str, node_id: int, iface: int) -> str:
 _HELPER_BIN_DEFAULT = "/opt/nova-ve/bin/nova-ve-net.py"
 _SUDO_BIN_DEFAULT = "/usr/bin/sudo"
 _IP_BIN_DEFAULT = "/sbin/ip"
+_RUNTIME_ROOT_DEFAULT = Path("/var/lib/nova-ve")
+_BRIDGE_FINGERPRINT_DIRNAME = "bridges"
 
 
 def _helper_bin() -> str:
@@ -209,6 +218,20 @@ def _sudo_bin() -> str:
 
 def _ip_bin() -> str:
     return os.environ.get("NOVA_VE_IP_BIN", _IP_BIN_DEFAULT)
+
+
+def _runtime_root() -> Path:
+    override = os.environ.get("NOVA_VE_RUNTIME_ROOT")
+    if override:
+        return Path(override)
+    return _RUNTIME_ROOT_DEFAULT
+
+
+def _bridge_fingerprint_root() -> Path:
+    override = os.environ.get("NOVA_VE_BRIDGE_FINGERPRINT_ROOT")
+    if override:
+        return Path(override)
+    return _runtime_root() / _BRIDGE_FINGERPRINT_DIRNAME
 
 
 def _run(argv: Sequence[str]) -> "subprocess.CompletedProcess[str]":
@@ -275,6 +298,78 @@ def bridge_exists(name: str) -> bool:
     return proc.returncode == 0
 
 
+def bridge_fingerprint_path(name: str) -> Path:
+    """Return the ownership fingerprint path for ``name``."""
+    return _bridge_fingerprint_root() / f"{name}.json"
+
+
+def bridge_fingerprint_read(name: str) -> dict[str, Any] | None:
+    """Return the decoded ownership fingerprint or ``None`` if absent.
+
+    Malformed or unreadable files are surfaced as synthetic dict payloads so
+    callers can fail closed and include the on-disk state in diagnostics.
+    """
+    path = bridge_fingerprint_path(name)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        return {"_error": f"could not read fingerprint: {exc}"}
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {"_error": f"invalid JSON: {exc}", "_raw": raw}
+
+    if not isinstance(payload, dict):
+        return {
+            "_error": f"expected JSON object, found {type(payload).__name__}",
+            "_raw": payload,
+        }
+    return payload
+
+
+def bridge_fingerprint_write(name: str, lab_id: str, network_id: int) -> None:
+    """Atomically persist bridge ownership metadata for ``name``."""
+    path = bridge_fingerprint_path(name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.tmp.{uuid.uuid4().hex}")
+    payload = {
+        "lab_id": str(lab_id),
+        "network_id": int(network_id),
+        "created_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as fd:
+            fd.write(json.dumps(payload, indent=2, sort_keys=True))
+            fd.flush()
+            os.fsync(fd.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def bridge_fingerprint_check(
+    name: str, lab_id: str, network_id: int
+) -> Literal["match", "mismatch", "absent"]:
+    """Compare the stored ownership fingerprint for ``name`` with expectations."""
+    payload = bridge_fingerprint_read(name)
+    if payload is None:
+        return "absent"
+    if payload.get("lab_id") == str(lab_id) and payload.get("network_id") == int(
+        network_id
+    ):
+        return "match"
+    return "mismatch"
+
+
+def bridge_fingerprint_remove(name: str) -> None:
+    """Remove the ownership fingerprint for ``name`` if present."""
+    bridge_fingerprint_path(name).unlink(missing_ok=True)
+
+
 def bridge_add(name: str) -> None:
     """Create a Linux bridge with ``name`` via the privileged helper.
 
@@ -292,6 +387,7 @@ def bridge_del(name: str) -> None:
     Raises :class:`HostNetEINVAL` if the bridge does not exist.
     """
     _invoke_helper("bridge-del", name)
+    bridge_fingerprint_remove(name)
 
 
 def tap_add(name: str) -> None:

--- a/backend/app/services/network_service.py
+++ b/backend/app/services/network_service.py
@@ -11,6 +11,7 @@ the matching Linux bridge via the privileged helper, persisting
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -38,6 +39,15 @@ def _serialize_network(network: dict, count: int) -> dict:
     out = dict(network)
     out["count"] = count
     return out
+
+
+def _bridge_ownership_message(bridge: str, lab_id: str, network_id: int) -> str:
+    actual = host_net.bridge_fingerprint_read(bridge)
+    actual_desc = "absent" if actual is None else json.dumps(actual, sort_keys=True)
+    return (
+        f"Bridge {bridge} ownership check failed: expected lab_id={lab_id!r}, "
+        f"network_id={int(network_id)}; actual fingerprint={actual_desc}"
+    )
 
 
 class NetworkService:
@@ -100,21 +110,41 @@ class NetworkService:
             networks[str(next_id)] = network
             data.pop("topology", None)
             # Persist BEFORE provisioning so on-disk state never leads the
-            # kernel state. If bridge_add then fails we roll the file back.
+            # kernel state. Any provisioning or ownership failure rolls it back.
             LabService.write_lab_json_static(normalized, data)
             try:
-                # Idempotent: pre-existing bridge with the right name is a
-                # no-op (e.g. backend restarted mid-create, or US-202b
-                # backfill already provisioned it).
-                if not host_net.bridge_exists(bridge):
+                if host_net.bridge_exists(bridge):
+                    status = host_net.bridge_fingerprint_check(bridge, lab_id, next_id)
+                    if status != "match":
+                        raise host_net.HostNetBridgeOwnershipError(
+                            _bridge_ownership_message(bridge, lab_id, next_id)
+                        )
+                else:
                     host_net.bridge_add(bridge)
-            except host_net.HostNetError as exc:
+                    try:
+                        host_net.bridge_fingerprint_write(bridge, lab_id, next_id)
+                    except Exception:
+                        try:
+                            host_net.bridge_del(bridge)
+                        except host_net.HostNetError as rollback_exc:
+                            logger.error(
+                                "create_network: bridge fingerprint rollback failed for %s (%s)",
+                                bridge,
+                                rollback_exc,
+                            )
+                        raise
+            except host_net.HostNetBridgeOwnershipError:
+                networks.pop(str(next_id), None)
+                data["networks"] = networks
+                LabService.write_lab_json_static(normalized, data)
+                raise
+            except (host_net.HostNetError, OSError) as exc:
                 # Roll back the JSON write — never leave inconsistent state.
                 networks.pop(str(next_id), None)
                 data["networks"] = networks
                 LabService.write_lab_json_static(normalized, data)
                 logger.error(
-                    "create_network: bridge_add(%s) failed (%s); rolled back lab.json",
+                    "create_network: bridge provisioning failed for %s (%s); rolled back lab.json",
                     bridge,
                     exc,
                 )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,3 +12,11 @@ def _redirect_pids_registry(tmp_path_factory, monkeypatch):
     pids_dir = tmp_path_factory.mktemp("pids-default")
     monkeypatch.setenv("NOVA_VE_PIDS_JSON", str(pids_dir / "pids.json"))
     yield
+
+
+@pytest.fixture(autouse=True)
+def _redirect_bridge_fingerprints(tmp_path_factory, monkeypatch):
+    """Redirect bridge ownership fingerprints away from ``/var/lib/nova-ve``."""
+    fingerprint_dir = tmp_path_factory.mktemp("bridge-fingerprints-default")
+    monkeypatch.setenv("NOVA_VE_BRIDGE_FINGERPRINT_ROOT", str(fingerprint_dir))
+    yield

--- a/backend/tests/test_host_net.py
+++ b/backend/tests/test_host_net.py
@@ -1,19 +1,17 @@
-"""Regression coverage for host_net wrapper drift fixes."""
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for host_net wrapper drift fixes (HF7) and bridge
+ownership fingerprint helpers (HF3)."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 import app.services.host_net as host_net
-
-HF3_FINGERPRINT_HELPERS = (
-    "bridge_fingerprint_write",
-    "bridge_fingerprint_check",
-    "bridge_fingerprint_remove",
-)
-HF3_AVAILABLE = all(hasattr(host_net, name) for name in HF3_FINGERPRINT_HELPERS)
 
 
 @pytest.mark.parametrize(
@@ -140,16 +138,88 @@ def test_get_instance_id_missing_file_raises_clear_error(monkeypatch, tmp_path: 
         host_net.get_instance_id()
 
 
-@pytest.mark.skipif(
-    not HF3_AVAILABLE,
-    reason="HF3 bridge fingerprint helpers are not present on this branch/main",
-)
-def test_bridge_fingerprint_write_check_remove(tmp_path: Path) -> None:
-    fingerprint_path = tmp_path / "bridge.fp"
+# ---------------------------------------------------------------------------
+# Bridge ownership fingerprint helpers (HF3 — #126)
+# ---------------------------------------------------------------------------
 
-    host_net.bridge_fingerprint_write(fingerprint_path, "fp-123")
-    assert host_net.bridge_fingerprint_check(fingerprint_path, "fp-123") is True
-    assert host_net.bridge_fingerprint_check(fingerprint_path, "fp-456") is False
 
-    host_net.bridge_fingerprint_remove(fingerprint_path)
-    assert host_net.bridge_fingerprint_check(fingerprint_path, "fp-123") is False
+def test_bridge_fingerprint_write_check_remove(monkeypatch, tmp_path: Path):
+    fingerprint_root = tmp_path / "fingerprints"
+    monkeypatch.setenv("NOVA_VE_BRIDGE_FINGERPRINT_ROOT", str(fingerprint_root))
+
+    host_net.bridge_fingerprint_write("nove1234n1", "lab-a", 1)
+
+    path = host_net.bridge_fingerprint_path("nove1234n1")
+    assert path == fingerprint_root / "nove1234n1.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["lab_id"] == "lab-a"
+    assert payload["network_id"] == 1
+    assert payload["created_at"]
+    assert host_net.bridge_fingerprint_check("nove1234n1", "lab-a", 1) == "match"
+
+    host_net.bridge_fingerprint_remove("nove1234n1")
+    assert host_net.bridge_fingerprint_check("nove1234n1", "lab-a", 1) == "absent"
+
+
+def test_bridge_fingerprint_path_uses_runtime_root_override(
+    monkeypatch, tmp_path: Path
+):
+    runtime_root = tmp_path / "runtime-root"
+    monkeypatch.delenv("NOVA_VE_BRIDGE_FINGERPRINT_ROOT", raising=False)
+    monkeypatch.setenv("NOVA_VE_RUNTIME_ROOT", str(runtime_root))
+
+    assert host_net.bridge_fingerprint_path("nove1234n2") == (
+        runtime_root / "bridges" / "nove1234n2.json"
+    )
+
+
+def test_bridge_fingerprint_check_detects_mismatch(monkeypatch, tmp_path: Path):
+    fingerprint_root = tmp_path / "fingerprints"
+    monkeypatch.setenv("NOVA_VE_BRIDGE_FINGERPRINT_ROOT", str(fingerprint_root))
+
+    host_net.bridge_fingerprint_write("nove1234n3", "lab-a", 3)
+
+    assert host_net.bridge_fingerprint_check("nove1234n3", "lab-b", 3) == "mismatch"
+    assert host_net.bridge_fingerprint_check("nove1234n3", "lab-a", 4) == "mismatch"
+
+
+def test_bridge_fingerprint_write_is_atomic(monkeypatch, tmp_path: Path):
+    fingerprint_root = tmp_path / "fingerprints"
+    monkeypatch.setenv("NOVA_VE_BRIDGE_FINGERPRINT_ROOT", str(fingerprint_root))
+
+    replace_calls: list[tuple[Path, Path]] = []
+    original_replace = host_net.os.replace
+
+    def fake_replace(src: str | Path, dst: str | Path) -> None:
+        replace_calls.append((Path(src), Path(dst)))
+        original_replace(src, dst)
+
+    monkeypatch.setattr(host_net.os, "replace", fake_replace)
+
+    host_net.bridge_fingerprint_write("nove1234n4", "lab-a", 4)
+
+    assert len(replace_calls) == 1
+    src, dst = replace_calls[0]
+    assert src.parent == fingerprint_root
+    assert ".tmp." in src.name
+    assert dst == fingerprint_root / "nove1234n4.json"
+    assert not src.exists()
+    assert dst.exists()
+
+
+def test_bridge_del_removes_fingerprint(monkeypatch, tmp_path: Path):
+    fingerprint_root = tmp_path / "fingerprints"
+    monkeypatch.setenv("NOVA_VE_BRIDGE_FINGERPRINT_ROOT", str(fingerprint_root))
+    calls: list[tuple[str, str]] = []
+
+    def fake_invoke_helper(verb: str, *args: str):
+        calls.append((verb, *args))
+        return object()
+
+    monkeypatch.setattr(host_net, "_invoke_helper", fake_invoke_helper)
+    host_net.bridge_fingerprint_write("nove1234n5", "lab-a", 5)
+
+    host_net.bridge_del("nove1234n5")
+
+    assert calls == [("bridge-del", "nove1234n5")]
+    assert host_net.bridge_fingerprint_check("nove1234n5", "lab-a", 5) == "absent"

--- a/backend/tests/test_migrate_runtime_network.py
+++ b/backend/tests/test_migrate_runtime_network.py
@@ -9,7 +9,7 @@ Covers:
   - idempotency (second run is a no-op)
   - dry-run does not write any files or touch host state
   - running-node precondition: exits 1 and lists offending labs
-  - per-lab rollback on simulated bridge_add failure
+  - per-lab rollback on bridge ownership verification failure
   - abort on docker network inspect failure (no docker network rm called)
   - rollback restores old Docker network from captured inspect JSON
   - stamps node.machine_override='pc' on pre-Wave-7 QEMU nodes
@@ -147,11 +147,6 @@ def test_fills_missing_bridge_name(instance_id, tmp_path, monkeypatch):
         "_docker_network_inspect",
         lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
     )
-    bridge_add_calls: list[str] = []
-    monkeypatch.setattr(
-        "app.services.host_net.bridge_add",
-        lambda name: bridge_add_calls.append(name),
-    )
     monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
 
     checked, backfilled, nodes_stamped = mig.process_lab(
@@ -167,10 +162,8 @@ def test_fills_missing_bridge_name(instance_id, tmp_path, monkeypatch):
     expected_2 = host_net.bridge_name("lab-fill", 2)
     assert saved["networks"]["1"]["runtime"]["bridge_name"] == expected_1
     assert saved["networks"]["2"]["runtime"]["bridge_name"] == expected_2
-
-    # bridge_add called for each network (since bridge_exists returns False).
-    assert expected_1 in bridge_add_calls
-    assert expected_2 in bridge_add_calls
+    assert host_net.bridge_fingerprint_check(expected_1, "lab-fill", 1) == "absent"
+    assert host_net.bridge_fingerprint_check(expected_2, "lab-fill", 2) == "absent"
 
 
 # ---------------------------------------------------------------------------
@@ -326,17 +319,13 @@ def test_precondition_stopped_node_passes(instance_id, tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Per-lab rollback on bridge_add failure
+# Per-lab abort on bridge ownership collision
 # ---------------------------------------------------------------------------
 
 
-def test_rollback_on_bridge_add_failure(instance_id, tmp_path, monkeypatch):
-    """If bridge_add raises, lab.json is restored from backup.
-
-    Also asserts that test_migrate_runtime_network_rollback_on_host_failure
-    acceptance test: old Docker network is restored from captured inspect JSON.
-    """
-    from app.services import host_net as hn
+def test_migrate_aborts_on_unfingerprinted_bridge(instance_id, tmp_path, monkeypatch):
+    """An existing unfingerprinted bridge aborts the lab migration fail-closed."""
+    from app.services import host_net
 
     labs_dir = tmp_path / "labs"
     labs_dir.mkdir()
@@ -355,24 +344,19 @@ def test_rollback_on_bridge_add_failure(instance_id, tmp_path, monkeypatch):
         "_docker_network_inspect",
         lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
     )
-
-    def boom(name: str) -> None:
-        raise hn.HostNetEEXIST("RTNETLINK: File exists", returncode=1, stderr="exists")
-
-    monkeypatch.setattr("app.services.host_net.bridge_add", boom)
-    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+    bridge = host_net.bridge_name("lab-fail", 1)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: name == bridge)
     monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
 
-    with pytest.raises(RuntimeError, match="migration failed"):
+    with pytest.raises(RuntimeError, match="ownership check failed"):
         mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
 
-    # lab.json must be restored.
     assert lab_path.read_text() == original_text
 
 
-def test_rollback_restores_docker_network(instance_id, tmp_path, monkeypatch):
-    """On bridge_add failure after docker network rm, docker network create is called."""
-    from app.services import host_net as hn
+def test_migrate_aborts_on_mismatched_fingerprint(instance_id, tmp_path, monkeypatch):
+    """A mismatched fingerprint aborts and restores the removed Docker network."""
+    from app.services import host_net
 
     labs_dir = tmp_path / "labs"
     labs_dir.mkdir()
@@ -421,15 +405,12 @@ def test_rollback_restores_docker_network(instance_id, tmp_path, monkeypatch):
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(mig, "_docker_network_create_from_inspect", fake_create)
-
-    def boom(name: str) -> None:
-        raise hn.HostNetEEXIST("RTNETLINK: File exists", returncode=1, stderr="exists")
-
-    monkeypatch.setattr("app.services.host_net.bridge_add", boom)
-    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+    bridge = host_net.bridge_name("lab-fail2", 1)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: name == bridge)
     monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
+    host_net.bridge_fingerprint_write(bridge, "other-lab", 1)
 
-    with pytest.raises(RuntimeError, match="migration failed"):
+    with pytest.raises(RuntimeError, match="ownership check failed"):
         mig.process_lab(lab_path, labs_dir, backup_dir, dry_run=False)
 
     # Docker network was removed.
@@ -491,6 +472,8 @@ def test_migrate_runtime_network_aborts_on_inspect_failure(
 
 def test_main_returns_2_on_error(instance_id, tmp_path, monkeypatch):
     """main() returns 2 when any lab fails migration."""
+    from app.services import host_net
+
     labs_dir = tmp_path / "labs"
     labs_dir.mkdir()
 
@@ -505,13 +488,8 @@ def test_main_returns_2_on_error(instance_id, tmp_path, monkeypatch):
         "_docker_network_inspect",
         lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
     )
-    from app.services import host_net as hn
-
-    def boom(name: str) -> None:
-        raise hn.HostNetEEXIST("exists", returncode=1, stderr="exists")
-
-    monkeypatch.setattr("app.services.host_net.bridge_add", boom)
-    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+    bridge = host_net.bridge_name("lab-err", 1)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: name == bridge)
     monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
 
     rc = mig.main(["--labs-dir", str(labs_dir)])

--- a/backend/tests/test_network_service.py
+++ b/backend/tests/test_network_service.py
@@ -13,9 +13,9 @@ Asserts the contract specified in
     names (collision-resistant cross-host).
   * The bridge name is persisted on the network record under
     ``runtime.bridge_name`` (US-401 schema field, hoisted by US-202).
-  * ``create_network`` is idempotent: when a bridge with the right name
-    already exists (``bridge_exists`` returns True), ``bridge_add`` is
-    NOT invoked.
+  * ``create_network`` is idempotent only when a pre-existing bridge has
+    a matching ownership fingerprint; otherwise the typed ownership
+    exception is raised fail-closed.
   * On ``bridge_add`` failure, the JSON write is rolled back (no leaked
     network record) and a typed ``NetworkServiceError`` with status 409
     is raised.
@@ -140,6 +140,7 @@ async def test_create_network_provisions_bridge(
     assert helper_mocks["bridge_exists"] == [expected_bridge]
     # runtime.bridge_name persisted on the response payload.
     assert payload["runtime"]["bridge_name"] == expected_bridge
+    assert host_net.bridge_fingerprint_check(expected_bridge, "lab-uuid-aaa", 1) == "match"
     # And on disk.
     saved = json.loads((labs_dir / lab_name).read_text())
     assert saved["networks"]["1"]["runtime"]["bridge_name"] == expected_bridge
@@ -198,6 +199,8 @@ async def test_create_network_idempotent_when_bridge_exists(
 ):
     lab_name = _seed_lab(labs_dir, lab_id="idem-lab")
     add_calls: list[str] = []
+    bridge = host_net.bridge_name("idem-lab", 1)
+    host_net.bridge_fingerprint_write(bridge, "idem-lab", 1)
     monkeypatch.setattr(host_net, "bridge_exists", lambda n: True)
     monkeypatch.setattr(
         host_net, "bridge_add", lambda n: add_calls.append(n)
@@ -210,7 +213,29 @@ async def test_create_network_idempotent_when_bridge_exists(
     assert add_calls == []
     # The runtime.bridge_name is still stamped — caller must be able to
     # tear down the bridge later.
-    assert payload["runtime"]["bridge_name"] == host_net.bridge_name("idem-lab", 1)
+    assert payload["runtime"]["bridge_name"] == bridge
+
+
+@pytest.mark.asyncio
+async def test_create_network_raises_on_bridge_ownership_mismatch(
+    instance_id, settings, monkeypatch, stub_publish, labs_dir
+):
+    lab_name = _seed_lab(labs_dir, lab_id="mismatch-lab")
+    bridge = host_net.bridge_name("mismatch-lab", 1)
+    host_net.bridge_fingerprint_write(bridge, "other-lab", 1)
+
+    monkeypatch.setattr(host_net, "bridge_exists", lambda n: True)
+    monkeypatch.setattr(host_net, "bridge_add", lambda n: None)
+    monkeypatch.setattr(host_net, "bridge_del", lambda n: None)
+
+    with pytest.raises(host_net.HostNetBridgeOwnershipError) as excinfo:
+        await NetworkService().create_network(lab_name, {"name": "lan"})
+
+    assert bridge in str(excinfo.value)
+    assert "mismatch-lab" in str(excinfo.value)
+    assert "other-lab" in str(excinfo.value)
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"] == {}
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/migrate_runtime_network.py
+++ b/scripts/migrate_runtime_network.py
@@ -24,7 +24,10 @@ path).  The migration sequence for each such network is:
   2. Capture ``docker network inspect`` JSON for rollback (fail-closed: abort
      if inspect fails or JSON is unparseable).
   3. ``docker network rm`` the old Docker network.
-  4. ``host_net.bridge_add`` the new ``nove…n…`` bridge.
+  4. If a Linux bridge with the canonical ``nove…n…`` name already exists,
+     verify its ownership fingerprint matches the expected ``lab_id`` and
+     ``network_id``. Unfingerprinted or mismatched bridges abort the lab
+     migration fail-closed.
   5. Write back ``runtime.bridge_name`` to lab.json (atomic).
 
 On per-lab failure the in-memory journal is used to roll back host-side
@@ -259,11 +262,16 @@ def _migrate_network(
                         )
                     journal.docker_net_removed = True
 
-    if not dry_run:
-        # Step 4: Provision the new Linux bridge (idempotent).
-        if not host_net.bridge_exists(bridge):
-            host_net.bridge_add(bridge)
-            journal.bridge_added = True
+    if not dry_run and host_net.bridge_exists(bridge):
+        status = host_net.bridge_fingerprint_check(bridge, lab_id, network_id)
+        if status != "match":
+            actual = host_net.bridge_fingerprint_read(bridge)
+            actual_desc = "absent" if actual is None else json.dumps(actual, sort_keys=True)
+            raise RuntimeError(
+                "bridge ownership check failed for "
+                f"{bridge}: expected lab_id={lab_id!r}, network_id={network_id}; "
+                f"actual fingerprint={actual_desc}"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add bridge ownership fingerprint files under the nova-ve runtime root and require a matching fingerprint before reusing an existing canonical bridge name
- fail closed in `create_network` and the runtime migration when a pre-existing bridge has no fingerprint or a mismatched lab/network fingerprint, and return HTTP 409 for API callers
- clean up fingerprint files on bridge teardown and extend host-net, network-service, and migration tests with tmp-root isolation

## Context
Addresses the codex critic findings in `.omc/research/codex-critic-network-runtime-2026-04-28.md` for `US-202 HIGH` and `US-202b HIGH 3`.

Implements the fail-closed collision handling required by `.omc/plans/network-runtime-wiring.md:237-246`.

Refs #88
Refs #89
Refs #80