### PR TITLE
hotfix(net): migration aborts on docker network inspect daemon failure (#89 codex HIGH)

### DIFF
--- a/backend/tests/test_migrate_runtime_network.py
+++ b/backend/tests/test_migrate_runtime_network.py
@@ -91,6 +91,15 @@ def _net(net_id: int, *, bridge_name: str | None = None) -> dict[str, Any]:
     return n
 
 
+def _missing_network_inspect_result(name: str) -> SimpleNamespace:
+    """Simulate Docker's 'network absent' inspect failure."""
+    return SimpleNamespace(
+        returncode=1,
+        stdout="",
+        stderr=f"Error: No such network: {name}",
+    )
+
+
 # ---------------------------------------------------------------------------
 # No-op on already-migrated lab
 # ---------------------------------------------------------------------------
@@ -145,7 +154,7 @@ def test_fills_missing_bridge_name(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr(
         mig,
         "_docker_network_inspect",
-        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+        _missing_network_inspect_result,
     )
     bridge_add_calls: list[str] = []
     monkeypatch.setattr(
@@ -192,7 +201,7 @@ def test_idempotent_second_run(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr(
         mig,
         "_docker_network_inspect",
-        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+        _missing_network_inspect_result,
     )
     monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
     monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
@@ -231,7 +240,7 @@ def test_dry_run_does_not_write(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr(
         mig,
         "_docker_network_inspect",
-        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+        _missing_network_inspect_result,
     )
     monkeypatch.setattr(
         "app.services.host_net.bridge_add",
@@ -268,7 +277,7 @@ def test_main_dry_run_does_not_write(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr(
         mig,
         "_docker_network_inspect",
-        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+        _missing_network_inspect_result,
     )
     monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
     monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
@@ -316,7 +325,7 @@ def test_precondition_stopped_node_passes(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr(
         mig,
         "_docker_network_inspect",
-        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+        _missing_network_inspect_result,
     )
     monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
     monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
@@ -353,7 +362,7 @@ def test_rollback_on_bridge_add_failure(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr(
         mig,
         "_docker_network_inspect",
-        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+        _missing_network_inspect_result,
     )
 
     def boom(name: str) -> None:
@@ -484,6 +493,95 @@ def test_migrate_runtime_network_aborts_on_inspect_failure(
     assert rm_calls == []
 
 
+def test_migrate_aborts_on_inspect_daemon_failure(
+    instance_id, tmp_path, monkeypatch, capsys
+):
+    """Non-absence inspect failures abort the lab and return a non-zero exit."""
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+
+    net = _net(1)
+    net["config"] = {"docker_network": "nova-ve-lab-daemon-fail-Net1"}
+    _make_lab(
+        labs_dir,
+        lab_id="lab-daemon-fail",
+        networks={"1": net},
+    )
+
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        lambda name: SimpleNamespace(
+            returncode=125,
+            stdout="",
+            stderr="Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?",
+        ),
+    )
+
+    rm_calls: list[str] = []
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_rm",
+        lambda name: rm_calls.append(name) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+    monkeypatch.setattr("app.services.host_net.bridge_del", lambda name: None)
+
+    rc = mig.main(["--labs-dir", str(labs_dir)])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert rm_calls == []
+    assert "could not capture network state for rollback; refusing to proceed" in captured.err
+    assert (
+        "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. "
+        "Is the docker daemon running?"
+    ) in captured.err
+
+
+def test_migrate_continues_on_no_such_network_inspect_error(
+    instance_id, tmp_path, monkeypatch
+):
+    """Exit 1 with Docker's 'No such network' stderr is treated as absent."""
+    from app.services import host_net
+
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+
+    lab_path = _make_lab(
+        labs_dir,
+        lab_id="lab-no-such-network",
+        networks={"1": _net(1)},
+    )
+
+    monkeypatch.setattr(
+        mig,
+        "_docker_network_inspect",
+        _missing_network_inspect_result,
+    )
+
+    bridge_add_calls: list[str] = []
+    monkeypatch.setattr(
+        "app.services.host_net.bridge_add",
+        lambda name: bridge_add_calls.append(name),
+    )
+    monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)
+
+    checked, backfilled, nodes_stamped = mig.process_lab(
+        lab_path, labs_dir, backup_dir, dry_run=False
+    )
+
+    saved = json.loads(lab_path.read_text())
+    expected = host_net.bridge_name("lab-no-such-network", 1)
+    assert checked == 1
+    assert backfilled == 1
+    assert nodes_stamped == 0
+    assert saved["networks"]["1"]["runtime"]["bridge_name"] == expected
+    assert bridge_add_calls == [expected]
+
+
 # ---------------------------------------------------------------------------
 # Non-zero exit from main() when errors occur
 # ---------------------------------------------------------------------------
@@ -503,7 +601,7 @@ def test_main_returns_2_on_error(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr(
         mig,
         "_docker_network_inspect",
-        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+        _missing_network_inspect_result,
     )
     from app.services import host_net as hn
 
@@ -585,7 +683,7 @@ def test_migrate_stamps_machine_override(instance_id, tmp_path, monkeypatch):
     monkeypatch.setattr(
         mig,
         "_docker_network_inspect",
-        lambda name: SimpleNamespace(returncode=1, stdout="", stderr=""),
+        _missing_network_inspect_result,
     )
     monkeypatch.setattr("app.services.host_net.bridge_add", lambda name: None)
     monkeypatch.setattr("app.services.host_net.bridge_exists", lambda name: False)

--- a/scripts/migrate_runtime_network.py
+++ b/scripts/migrate_runtime_network.py
@@ -185,6 +185,15 @@ class _NetworkJournalEntry:
         self.bridge_added: bool = False
 
 
+class DockerNetworkInspectError(RuntimeError):
+    """Raised when docker network inspect cannot safely provide rollback state."""
+
+
+def _is_missing_docker_network(stderr: str) -> bool:
+    """Return True when docker reports the network does not exist."""
+    return "Error: No such network" in stderr
+
+
 def _get_docker_net_name(network: dict[str, Any], lab_id: str) -> str | None:
     """Derive the likely legacy Docker network name from a network record.
 
@@ -226,8 +235,22 @@ def _migrate_network(
         # Step 1: Assert no containers attached.
         inspect_proc = _docker_network_inspect(docker_net)
         if inspect_proc.returncode != 0:
-            # Network does not exist — nothing to clean up on the Docker side.
-            docker_net = None
+            inspect_stderr = inspect_proc.stderr.rstrip("\n")
+            if (
+                inspect_proc.returncode == 1
+                and _is_missing_docker_network(inspect_stderr)
+            ):
+                # Network does not exist — nothing to clean up on the Docker side.
+                docker_net = None
+            else:
+                detail = inspect_stderr or (
+                    f"docker network inspect '{docker_net}' exited "
+                    f"{inspect_proc.returncode} with no stderr"
+                )
+                raise DockerNetworkInspectError(
+                    "could not capture network state for rollback; refusing to proceed\n"
+                    f"{detail}"
+                )
         else:
             try:
                 inspect_data = json.loads(inspect_proc.stdout)


### PR DESCRIPTION
## Summary
- fail-close the migration when `docker network inspect` returns a non-absence non-zero exit
- preserve the explicit `Error: No such network` exit-1 path as the only safe continue case
- add regression coverage for daemon-failure aborts and no-such-network continues

## References
- Codex finding: `.omc/research/codex-critic-network-runtime-2026-04-28.md` (US-202b HIGH 1)
- Spec: `.omc/plans/network-runtime-wiring.md:255,259`
- Refs #89
- Refs #80

## Verification
- `/Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/test_migrate_runtime_network.py -x --tb=short`
- `/Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest`