### PR TITLE
hotfix(net): host_net.py wrapper drift fixes + test_host_net.py (#87 codex LOW + 3 new drift findings)

### DIFF
--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -11,13 +11,14 @@ lab_hash is a 16-bit value derived from blake2b(instance_id + ":" + lab_id).
 Using blake2b (not Python's built-in hash()) because hash() is salted per-process since Python 3.3.
 
 Instance ID is read from:
+  $NOVA_VE_INSTANCE_ID_FILE
   $NOVA_VE_INSTANCE_DIR/instance_id  (default dir: /etc/nova-ve)
 
-Precedence rules (file-wins with explicit env override):
-  1. If the file exists and is non-empty → use file value (authoritative).
-  2. If NOVA_VE_INSTANCE_ID is set AND NOVA_VE_INSTANCE_ID_OVERRIDE_OK=1 → use env value
-     (WARNING logged on every call).
-  3. Otherwise → raise HostNetInstanceIdMissing.
+Precedence rules:
+  1. If NOVA_VE_INSTANCE_ID_FILE is set → use that file path.
+  2. Else if NOVA_VE_INSTANCE_DIR is set → use $DIR/instance_id.
+  3. Else → use /etc/nova-ve/instance_id.
+  4. Missing or empty file → raise HostNetInstanceIdMissing.
 
 Privileged helper (US-201) is invoked via:
   sudo $NOVA_VE_HELPER_BIN <verb> [args...]
@@ -78,45 +79,45 @@ class HostNetUnknown(HostNetError):
 
 _INSTANCE_DIR_DEFAULT = "/etc/nova-ve"
 _INSTANCE_FILE_NAME = "instance_id"
+_INSTANCE_ID_FILE_ENV = "NOVA_VE_INSTANCE_ID_FILE"
+_INSTANCE_ID_DIR_ENV = "NOVA_VE_INSTANCE_DIR"
 
 
 def _instance_id_file() -> Path:
-    """Return the path to the instance_id file, honouring NOVA_VE_INSTANCE_DIR."""
-    instance_dir = os.environ.get("NOVA_VE_INSTANCE_DIR", _INSTANCE_DIR_DEFAULT)
+    """Return the instance_id path using file override, dir override, then default."""
+    instance_file = os.environ.get(_INSTANCE_ID_FILE_ENV, "").strip()
+    if instance_file:
+        return Path(instance_file)
+
+    instance_dir = os.environ.get(_INSTANCE_ID_DIR_ENV, _INSTANCE_DIR_DEFAULT)
     return Path(instance_dir) / _INSTANCE_FILE_NAME
 
 
 def get_instance_id() -> str:
-    """Return the instance ID string, applying the file-wins precedence rules.
+    """Return the instance ID string from the resolved instance-id file.
 
     Raises HostNetInstanceIdMissing if the ID cannot be resolved.
     """
     id_file = _instance_id_file()
-
-    # --- Try the file first (authoritative when present and non-empty) ----
-    if id_file.exists():
+    try:
         value = id_file.read_text(encoding="ascii").strip()
-        if value:
-            return value
-        # File exists but is empty — treat as missing.
+    except FileNotFoundError as exc:
+        raise HostNetInstanceIdMissing(
+            f"Instance ID file '{id_file}' is missing. Set {_INSTANCE_ID_FILE_ENV} to a "
+            f"readable file, set {_INSTANCE_ID_DIR_ENV} to a directory containing "
+            f"'{_INSTANCE_FILE_NAME}', or provision '{_INSTANCE_DIR_DEFAULT}/{_INSTANCE_FILE_NAME}'."
+        ) from exc
+    except OSError as exc:
+        raise HostNetInstanceIdMissing(
+            f"Instance ID file '{id_file}' could not be read: {exc}"
+        ) from exc
 
-    # --- Env-var override (only with explicit OVERRIDE_OK flag) -----------
-    env_id = os.environ.get("NOVA_VE_INSTANCE_ID", "").strip()
-    override_ok = os.environ.get("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", "").strip() == "1"
+    if value:
+        return value
 
-    if env_id and override_ok:
-        logger.warning(
-            "WARNING: using NOVA_VE_INSTANCE_ID env override (file ignored); "
-            "persist via deploy script for production"
-        )
-        return env_id
-
-    # --- Neither source is usable — fail hard ----------------------------
     raise HostNetInstanceIdMissing(
-        f"Instance ID file '{id_file}' is missing or empty and no valid env override "
-        "is configured (set both NOVA_VE_INSTANCE_ID and NOVA_VE_INSTANCE_ID_OVERRIDE_OK=1 "
-        "for a temporary override, or run deploy/scripts/provision-ubuntu-2604.sh). "
-        "Cannot derive collision-resistant bridge names without a per-host instance ID."
+        f"Instance ID file '{id_file}' is empty. Populate it with a non-empty host ID "
+        f"or point {_INSTANCE_ID_FILE_ENV} at a valid override file."
     )
 
 
@@ -224,7 +225,7 @@ def _run(argv: Sequence[str]) -> "subprocess.CompletedProcess[str]":
     )
 
 
-def _classify_helper_failure(
+def _classify_helper_error(
     stderr: str, returncode: int
 ) -> HostNetError:
     """Map helper exit code + stderr to a typed exception."""
@@ -235,11 +236,18 @@ def _classify_helper_failure(
         return HostNetUnknown(msg, returncode=returncode, stderr=stderr)
     # exit 1 — underlying ``ip`` invocation failed.
     lower = stderr.lower()
-    if "exists" in lower or "file exists" in lower:
+    if "file exists" in lower:
         return HostNetEEXIST(msg, returncode=returncode, stderr=stderr)
-    if "does not exist" in lower or "cannot find" in lower or "no such" in lower:
+    if (
+        "invalid argument" in lower
+        or "does not exist" in lower
+        or "no such" in lower
+    ):
         return HostNetEINVAL(msg, returncode=returncode, stderr=stderr)
-    return HostNetEINVAL(msg, returncode=returncode, stderr=stderr)
+    return HostNetUnknown(msg, returncode=returncode, stderr=stderr)
+
+
+_classify_helper_failure = _classify_helper_error
 
 
 def _invoke_helper(verb: str, *args: str) -> "subprocess.CompletedProcess[str]":
@@ -247,7 +255,7 @@ def _invoke_helper(verb: str, *args: str) -> "subprocess.CompletedProcess[str]":
     argv = [_sudo_bin(), "-n", _helper_bin(), verb, *args]
     proc = _run(argv)
     if proc.returncode != 0:
-        raise _classify_helper_failure(proc.stderr or "", proc.returncode)
+        raise _classify_helper_error(proc.stderr or "", proc.returncode)
     return proc
 
 
@@ -284,6 +292,16 @@ def bridge_del(name: str) -> None:
     Raises :class:`HostNetEINVAL` if the bridge does not exist.
     """
     _invoke_helper("bridge-del", name)
+
+
+def tap_add(name: str) -> None:
+    """Create a TAP interface via the privileged helper."""
+    _invoke_helper("tap-add", name)
+
+
+def tap_del(name: str) -> None:
+    """Delete a TAP interface via the privileged helper."""
+    _invoke_helper("tap-del", name)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_host_net.py
+++ b/backend/tests/test_host_net.py
@@ -1,0 +1,155 @@
+"""Regression coverage for host_net wrapper drift fixes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import app.services.host_net as host_net
+
+HF3_FINGERPRINT_HELPERS = (
+    "bridge_fingerprint_write",
+    "bridge_fingerprint_check",
+    "bridge_fingerprint_remove",
+)
+HF3_AVAILABLE = all(hasattr(host_net, name) for name in HF3_FINGERPRINT_HELPERS)
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected_type"),
+    [
+        ("RTNETLINK answers: File exists\n", host_net.HostNetEEXIST),
+        ("RTNETLINK answers: Invalid argument\n", host_net.HostNetEINVAL),
+        ("operation not permitted\n", host_net.HostNetUnknown),
+    ],
+)
+def test_classify_helper_error_matches_contract(
+    stderr: str, expected_type: type[host_net.HostNetError]
+) -> None:
+    exc = host_net._classify_helper_error(stderr, 1)
+
+    assert isinstance(exc, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("wrapper_name", "args", "expected_argv"),
+    [
+        ("bridge_add", ("novec0de1n7",), ("bridge-add", "novec0de1n7")),
+        ("bridge_del", ("novec0de1n7",), ("bridge-del", "novec0de1n7")),
+        ("tap_add", ("nvec0de1d2i3",), ("tap-add", "nvec0de1d2i3")),
+        ("tap_del", ("nvec0de1d2i3",), ("tap-del", "nvec0de1d2i3")),
+        (
+            "veth_pair_add",
+            ("nvec0de1d2i3h", "nvec0de1d2i3p"),
+            ("veth-pair-add", "nvec0de1d2i3h", "nvec0de1d2i3p"),
+        ),
+        (
+            "link_master",
+            ("nvec0de1d2i3h", "novec0de1n7"),
+            ("link-master", "nvec0de1d2i3h", "novec0de1n7"),
+        ),
+        (
+            "link_set_nomaster",
+            ("nvec0de1d2i3h",),
+            ("link-set-nomaster", "nvec0de1d2i3h"),
+        ),
+        ("link_netns", ("nvec0de1d2i3p", 4242), ("link-netns", "nvec0de1d2i3p", "4242")),
+        ("link_up", ("nvec0de1d2i3h",), ("link-up", "nvec0de1d2i3h")),
+        (
+            "link_set_name_in_netns",
+            (4242, "nvec0de1d2i3p", "eth3"),
+            ("link-set-name-in-netns", "4242", "nvec0de1d2i3p", "eth3"),
+        ),
+        ("addr_up_in_netns", (4242, "eth3"), ("addr-up-in-netns", "4242", "eth3")),
+        ("link_del", ("nvec0de1d2i3h",), ("tap-del", "nvec0de1d2i3h")),
+        ("try_link_del", ("nvec0de1d2i3h",), ("tap-del", "nvec0de1d2i3h")),
+    ],
+)
+def test_public_wrapper_verbs_shape_expected_helper_argv(
+    monkeypatch,
+    wrapper_name: str,
+    args: tuple[object, ...],
+    expected_argv: tuple[str, ...],
+) -> None:
+    recorded: list[tuple[str, ...]] = []
+
+    def fake_invoke_helper(verb: str, *invoke_args: str) -> None:
+        recorded.append((verb, *invoke_args))
+
+    monkeypatch.setattr(host_net, "_invoke_helper", fake_invoke_helper)
+
+    getattr(host_net, wrapper_name)(*args)
+
+    assert recorded == [expected_argv]
+
+
+def test_name_helpers_stay_within_linux_interface_ceiling(monkeypatch) -> None:
+    monkeypatch.setattr(host_net, "get_instance_id", lambda: "instance-for-hf7")
+
+    assert len(host_net.bridge_name("lab-us-201", 99999)) <= 14
+    assert len(host_net.tap_name("lab-us-201", 999, 99)) <= 14
+    assert len(host_net.veth_host_name("lab-us-201", 99, 9)) <= 14
+    assert len(host_net.veth_peer_name("lab-us-201", 99, 9)) <= 14
+
+
+def test_get_instance_id_prefers_file_override_over_dir(monkeypatch, tmp_path: Path) -> None:
+    dir_root = tmp_path / "instance-dir"
+    dir_root.mkdir()
+    (dir_root / "instance_id").write_text("dir-instance-id\n", encoding="ascii")
+
+    instance_file = tmp_path / "instance-id-file"
+    instance_file.write_text("file-instance-id\n", encoding="ascii")
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_FILE", str(instance_file))
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(dir_root))
+
+    assert host_net.get_instance_id() == "file-instance-id"
+
+
+def test_get_instance_id_uses_directory_override(monkeypatch, tmp_path: Path) -> None:
+    dir_root = tmp_path / "instance-dir"
+    dir_root.mkdir()
+    (dir_root / "instance_id").write_text("dir-instance-id\n", encoding="ascii")
+
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_FILE", raising=False)
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(dir_root))
+
+    assert host_net.get_instance_id() == "dir-instance-id"
+
+
+def test_get_instance_id_uses_default_path_when_env_unset(monkeypatch, tmp_path: Path) -> None:
+    default_root = tmp_path / "etc-nova-ve"
+    default_root.mkdir()
+    (default_root / "instance_id").write_text("default-instance-id\n", encoding="ascii")
+
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_FILE", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_DIR", raising=False)
+    monkeypatch.setattr(host_net, "_INSTANCE_DIR_DEFAULT", str(default_root))
+
+    assert host_net.get_instance_id() == "default-instance-id"
+
+
+def test_get_instance_id_missing_file_raises_clear_error(monkeypatch, tmp_path: Path) -> None:
+    missing_file = tmp_path / "missing-instance-id"
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_FILE", str(missing_file))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_DIR", raising=False)
+
+    with pytest.raises(host_net.HostNetInstanceIdMissing, match=str(missing_file)):
+        host_net.get_instance_id()
+
+
+@pytest.mark.skipif(
+    not HF3_AVAILABLE,
+    reason="HF3 bridge fingerprint helpers are not present on this branch/main",
+)
+def test_bridge_fingerprint_write_check_remove(tmp_path: Path) -> None:
+    fingerprint_path = tmp_path / "bridge.fp"
+
+    host_net.bridge_fingerprint_write(fingerprint_path, "fp-123")
+    assert host_net.bridge_fingerprint_check(fingerprint_path, "fp-123") is True
+    assert host_net.bridge_fingerprint_check(fingerprint_path, "fp-456") is False
+
+    host_net.bridge_fingerprint_remove(fingerprint_path)
+    assert host_net.bridge_fingerprint_check(fingerprint_path, "fp-123") is False

--- a/backend/tests/test_instance_id.py
+++ b/backend/tests/test_instance_id.py
@@ -1,274 +1,108 @@
 # Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-"""
-Regression tests for US-100: per-instance ID provisioning.
 
-Covers:
-  - First-run (file missing) + env override → returns env value with WARNING
-  - Second-run (file present) → loads from file (deterministic)
-  - File present + env var set (no override flag) → file wins, no warning
-  - File missing + no env → raises HostNetInstanceIdMissing
-  - File missing + env-only (no OVERRIDE_OK) → raises HostNetInstanceIdMissing
-  - _lab_hash is deterministic across calls
-  - _lab_hash returns a 16-bit value (0 ≤ x ≤ 0xFFFF)
-  - bridge_name fits the 14-char budget for edge-case network_id=99999
-  - tap_name fits the 14-char budget for edge-case node_id=999, iface=99
-"""
+"""Regression tests for instance-id file resolution and naming helpers."""
 
-import importlib
-import logging
-import os
+from __future__ import annotations
+
+import re
 
 import pytest
 
 import app.services.host_net as host_net
-from app.services.host_net import (
-    HostNetInstanceIdMissing,
-    _lab_hash,
-    bridge_name,
-    get_instance_id,
-    tap_name,
-)
+from app.services.host_net import _lab_hash
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _reload_and_patch(monkeypatch, tmp_path, instance_dir=None, env_id=None, override_ok=None):
-    """Patch NOVA_VE_INSTANCE_DIR and optional env vars, then reload the module."""
-    if instance_dir is not None:
-        monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    else:
-        monkeypatch.delenv("NOVA_VE_INSTANCE_DIR", raising=False)
-
-    if env_id is not None:
-        monkeypatch.setenv("NOVA_VE_INSTANCE_ID", env_id)
-    else:
-        monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
-
-    if override_ok is not None:
-        monkeypatch.setenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", override_ok)
-    else:
-        monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-
-    importlib.reload(host_net)
-
-
-# ---------------------------------------------------------------------------
-# get_instance_id — file-based resolution
-# ---------------------------------------------------------------------------
-
-
-def test_file_present_returns_file_value(monkeypatch, tmp_path):
-    """File present and non-empty → returns file value."""
-    instance_dir = tmp_path / "etc-nova-ve"
+def test_file_override_wins(monkeypatch, tmp_path) -> None:
+    instance_dir = tmp_path / "dir"
     instance_dir.mkdir()
-    (instance_dir / "instance_id").write_text("test-uuid-1234\n")
+    (instance_dir / "instance_id").write_text("dir-instance\n", encoding="ascii")
+    instance_file = tmp_path / "instance-id-file"
+    instance_file.write_text("file-instance\n", encoding="ascii")
 
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_FILE", str(instance_file))
     monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
 
-    result = host_net.get_instance_id()
-    assert result == "test-uuid-1234"
+    assert host_net.get_instance_id() == "file-instance"
 
 
-def test_file_present_second_run_is_identical(monkeypatch, tmp_path):
-    """Second call with same file → same value (idempotent load)."""
-    instance_dir = tmp_path / "etc-nova-ve"
+def test_directory_override_is_used_when_file_override_unset(monkeypatch, tmp_path) -> None:
+    instance_dir = tmp_path / "dir"
     instance_dir.mkdir()
-    (instance_dir / "instance_id").write_text("stable-uuid-abcd")
+    (instance_dir / "instance_id").write_text("dir-instance\n", encoding="ascii")
 
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_FILE", raising=False)
     monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
 
-    assert host_net.get_instance_id() == host_net.get_instance_id()
+    assert host_net.get_instance_id() == "dir-instance"
 
 
-def test_file_missing_no_env_raises(monkeypatch, tmp_path):
-    """File missing + no env vars → raises HostNetInstanceIdMissing."""
-    instance_dir = tmp_path / "no-such-dir"
+def test_default_path_is_used_when_env_unset(monkeypatch, tmp_path) -> None:
+    default_dir = tmp_path / "etc-nova-ve"
+    default_dir.mkdir()
+    (default_dir / "instance_id").write_text("default-instance\n", encoding="ascii")
 
-    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_FILE", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_DIR", raising=False)
+    monkeypatch.setattr(host_net, "_INSTANCE_DIR_DEFAULT", str(default_dir))
 
-    with pytest.raises(host_net.HostNetInstanceIdMissing):
+    assert host_net.get_instance_id() == "default-instance"
+
+
+def test_missing_instance_file_raises(monkeypatch, tmp_path) -> None:
+    missing_file = tmp_path / "missing-instance-id"
+
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_FILE", str(missing_file))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_DIR", raising=False)
+
+    with pytest.raises(host_net.HostNetInstanceIdMissing, match=str(missing_file)):
         host_net.get_instance_id()
 
 
-def test_file_missing_env_only_no_override_flag_raises(monkeypatch, tmp_path):
-    """Env var alone (no OVERRIDE_OK=1) → still raises, even if NOVA_VE_INSTANCE_ID set."""
-    instance_dir = tmp_path / "no-such-dir"
+def test_empty_instance_file_raises(monkeypatch, tmp_path) -> None:
+    instance_file = tmp_path / "instance-id-file"
+    instance_file.write_text("   \n", encoding="ascii")
 
-    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.setenv("NOVA_VE_INSTANCE_ID", "some-env-uuid")
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
+    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_FILE", str(instance_file))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_DIR", raising=False)
 
-    with pytest.raises(host_net.HostNetInstanceIdMissing):
+    with pytest.raises(host_net.HostNetInstanceIdMissing, match="empty"):
         host_net.get_instance_id()
 
 
-def test_file_missing_env_with_override_flag_honored(monkeypatch, tmp_path, caplog):
-    """Env var + OVERRIDE_OK=1 (no file) → honored, WARNING emitted."""
-    instance_dir = tmp_path / "no-such-dir"
-
-    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.setenv("NOVA_VE_INSTANCE_ID", "override-uuid-5678")
-    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", "1")
-    importlib.reload(host_net)
-
-    with caplog.at_level(logging.WARNING, logger="nova-ve"):
-        result = host_net.get_instance_id()
-
-    assert result == "override-uuid-5678"
-    assert any("WARNING" in r.message for r in caplog.records)
+def test_lab_hash_is_deterministic() -> None:
+    assert _lab_hash("lab-abc", "inst-xyz") == _lab_hash("lab-abc", "inst-xyz")
 
 
-def test_file_present_env_set_no_override_flag_file_wins_no_warning(
-    monkeypatch, tmp_path, caplog
-):
-    """File present + env var set (no OVERRIDE_OK) → file wins, no WARNING logged."""
-    instance_dir = tmp_path / "etc-nova-ve"
-    instance_dir.mkdir()
-    (instance_dir / "instance_id").write_text("file-uuid-wins")
-
-    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.setenv("NOVA_VE_INSTANCE_ID", "env-uuid-ignored")
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
-
-    with caplog.at_level(logging.WARNING, logger="nova-ve"):
-        result = host_net.get_instance_id()
-
-    assert result == "file-uuid-wins"
-    assert not any("WARNING" in r.message for r in caplog.records)
+def test_lab_hash_changes_when_instance_changes() -> None:
+    assert _lab_hash("same-lab", "instance-A") != _lab_hash("same-lab", "instance-B")
 
 
-def test_file_empty_falls_through_to_env_override(monkeypatch, tmp_path):
-    """Empty file + env override + OVERRIDE_OK=1 → env value used."""
-    instance_dir = tmp_path / "etc-nova-ve"
-    instance_dir.mkdir()
-    (instance_dir / "instance_id").write_text("   \n")
-
-    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.setenv("NOVA_VE_INSTANCE_ID", "env-uuid-fallback")
-    monkeypatch.setenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", "1")
-    importlib.reload(host_net)
-
-    result = host_net.get_instance_id()
-    assert result == "env-uuid-fallback"
-
-
-# ---------------------------------------------------------------------------
-# _lab_hash — determinism and bit-width
-# ---------------------------------------------------------------------------
-
-
-def test_lab_hash_is_deterministic():
-    """Same inputs always produce the same hash."""
-    h1 = _lab_hash("lab-abc", "inst-xyz")
-    h2 = _lab_hash("lab-abc", "inst-xyz")
-    assert h1 == h2
-
-
-def test_lab_hash_different_instance_ids_produce_different_hashes():
-    """Different instance IDs → different hashes (collision resistance)."""
-    h1 = _lab_hash("same-lab", "instance-A")
-    h2 = _lab_hash("same-lab", "instance-B")
-    assert h1 != h2
-
-
-def test_lab_hash_different_lab_ids_produce_different_hashes():
-    """Different lab IDs on the same instance → different hashes."""
-    h1 = _lab_hash("lab-1", "same-instance")
-    h2 = _lab_hash("lab-2", "same-instance")
-    assert h1 != h2
-
-
-def test_lab_hash_fits_16_bits():
-    """Hash value is always in [0, 0xFFFF]."""
-    for lab_id, instance_id in [
-        ("lab-abc", "inst-xyz"),
-        ("x" * 64, "y" * 64),
-        ("", ""),
-    ]:
+def test_lab_hash_fits_16_bits() -> None:
+    for lab_id, instance_id in [("lab-abc", "inst-xyz"), ("x" * 64, "y" * 64), ("", "")]:
         h = _lab_hash(lab_id, instance_id)
-        assert 0 <= h <= 0xFFFF, f"hash {h} out of 16-bit range"
+        assert 0 <= h <= 0xFFFF
 
 
-# ---------------------------------------------------------------------------
-# bridge_name / tap_name — IFNAMSIZ budget
-# ---------------------------------------------------------------------------
-
-
-def test_bridge_name_max_network_id_fits_14_chars(monkeypatch, tmp_path):
-    """bridge_name with network_id=99999 must be ≤14 chars."""
-    instance_dir = tmp_path / "etc-nova-ve"
+def test_bridge_name_fits_14_chars(monkeypatch, tmp_path) -> None:
+    instance_dir = tmp_path / "dir"
     instance_dir.mkdir()
-    (instance_dir / "instance_id").write_text("test-instance-id")
-
+    (instance_dir / "instance_id").write_text("test-instance-id\n", encoding="ascii")
     monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
 
     name = host_net.bridge_name("some-lab-id", 99999)
-    assert len(name) <= 14, f"bridge_name too long: {name!r} ({len(name)} chars)"
-    assert name.startswith("nove")
+
+    assert len(name) <= 14
+    assert re.fullmatch(r"nove[0-9a-f]{4}n[0-9]+", name)
 
 
-def test_tap_name_max_node_iface_fits_14_chars(monkeypatch, tmp_path):
-    """tap_name with node_id=999, iface=99 must be ≤14 chars."""
-    instance_dir = tmp_path / "etc-nova-ve"
+def test_tap_name_fits_14_chars(monkeypatch, tmp_path) -> None:
+    instance_dir = tmp_path / "dir"
     instance_dir.mkdir()
-    (instance_dir / "instance_id").write_text("test-instance-id")
-
+    (instance_dir / "instance_id").write_text("test-instance-id\n", encoding="ascii")
     monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
 
     name = host_net.tap_name("some-lab-id", 999, 99)
-    assert len(name) <= 14, f"tap_name too long: {name!r} ({len(name)} chars)"
+
+    assert len(name) <= 14
     assert name.startswith("nve")
-
-
-def test_bridge_name_format(monkeypatch, tmp_path):
-    """bridge_name produces the expected prefix+hash+suffix structure."""
-    instance_dir = tmp_path / "etc-nova-ve"
-    instance_dir.mkdir()
-    (instance_dir / "instance_id").write_text("fixed-instance")
-
-    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
-
-    name = host_net.bridge_name("my-lab", 7)
-    # nove + 4 hex chars + n + network_id
-    import re
-    assert re.fullmatch(r"nove[0-9a-f]{4}n[0-9]+", name), f"unexpected format: {name!r}"
-
-
-def test_tap_name_format(monkeypatch, tmp_path):
-    """tap_name produces the expected prefix+hash+suffix structure."""
-    instance_dir = tmp_path / "etc-nova-ve"
-    instance_dir.mkdir()
-    (instance_dir / "instance_id").write_text("fixed-instance")
-
-    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
-    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
-    importlib.reload(host_net)
-
-    name = host_net.tap_name("my-lab", 3, 1)
-    import re
-    assert re.fullmatch(r"nve[0-9a-f]{4}d[0-9]+i[0-9]+", name), f"unexpected format: {name!r}"


### PR DESCRIPTION
## Summary
- add missing TAP wrapper verbs in `backend/app/services/host_net.py:297` and `backend/app/services/host_net.py:302` so the backend exposes the helper's `tap-add` / `tap-del` contract
- fix helper error classification in `backend/app/services/host_net.py:228` so `File exists` maps to `HostNetEEXIST`, `Invalid argument` / `does not exist` / `No such` map to `HostNetEINVAL`, and all other stderr falls through to `HostNetUnknown`
- update instance-id resolution in `backend/app/services/host_net.py:96` to honor `NOVA_VE_INSTANCE_ID_FILE`, then `NOVA_VE_INSTANCE_DIR`, then `/etc/nova-ve/instance_id`, with fail-hard missing/empty-file errors
- add wrapper contract coverage in `backend/tests/test_host_net.py:27` and align the existing instance-id regression surface in `backend/tests/test_instance_id.py:14`

## Why
The codex critic follow-up for US-201 marked the missing host_net wrapper test surface as a LOW gap in `.omc/research/codex-critic-network-runtime-2026-04-28.md`, and the first HF7 test pass surfaced three additional backend drifts that prevented the wrapper contract from matching the spec.

## Spec References
- `.omc/research/codex-critic-network-runtime-2026-04-28.md` — US-201 LOW follow-up on missing backend wrapper/test coverage
- `.omc/plans/network-runtime-wiring.md:194-202` — instance-id resolution contract
- `.omc/plans/network-runtime-wiring.md:229-232` — backend `host_net.py` wrapper + test surface contract

## Verification
- `/Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/test_host_net.py -x --tb=short`
- `/Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/`
- `/Users/fahad/code/nova-ve/backend/.venv/bin/python -m compileall app tests`

Refs #87
Refs #80
