### PR TITLE
hotfix(scripts): dedup_links writes lab JSON via LabService canonical write path (#83 codex LOW)

### DIFF
--- a/backend/tests/test_dedup_links.py
+++ b/backend/tests/test_dedup_links.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# File lives at backend/tests/test_dedup_links.py -> parents[2] = repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import dedup_links  # noqa: E402
+
+
+def _make_link(
+    link_id: str,
+    from_ep: dict[str, Any],
+    to_ep: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "id": link_id,
+        "from": from_ep,
+        "to": to_ep,
+        "style_override": None,
+        "label": "",
+        "color": "",
+        "width": "1",
+        "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+    }
+
+
+def _seed_lab(
+    labs_dir: Path,
+    *,
+    name: str = "lab.json",
+    links: list[dict[str, Any]] | None = None,
+) -> Path:
+    payload: dict[str, Any] = {
+        "schema": 2,
+        "id": name.removesuffix(".json"),
+        "meta": {"name": name},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {},
+        "networks": {},
+        "links": links or [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    lab_path = labs_dir / name
+    lab_path.write_text(json.dumps(payload), encoding="utf-8")
+    return lab_path
+
+
+def test_process_lab_uses_labservice_write_surface(tmp_path, monkeypatch):
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+    lab_path = _seed_lab(
+        labs_dir,
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+            _make_link("lnk_002", ep_b, ep_a),
+        ],
+    )
+
+    writes: list[str] = []
+    original_write = dedup_links.LabService.write_lab_json_static
+
+    def spy(filename: str, data: dict[str, Any]) -> None:
+        writes.append(filename)
+        original_write(filename, data)
+
+    monkeypatch.setattr(
+        dedup_links.LabService,
+        "write_lab_json_static",
+        staticmethod(spy),
+    )
+
+    before, removed = dedup_links.process_lab(lab_path, labs_dir, dry_run=False)
+
+    assert before == 2
+    assert removed == 1
+    assert writes == ["lab.json"]
+
+
+def test_process_lab_second_run_is_noop_and_skips_write(tmp_path, monkeypatch):
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    ep_a = {"node_id": 1, "interface_index": 0}
+    ep_b = {"network_id": 5}
+    lab_path = _seed_lab(
+        labs_dir,
+        links=[
+            _make_link("lnk_001", ep_a, ep_b),
+            _make_link("lnk_002", ep_b, ep_a),
+        ],
+    )
+
+    writes: list[str] = []
+    original_write = dedup_links.LabService.write_lab_json_static
+
+    def spy(filename: str, data: dict[str, Any]) -> None:
+        writes.append(filename)
+        original_write(filename, data)
+
+    monkeypatch.setattr(
+        dedup_links.LabService,
+        "write_lab_json_static",
+        staticmethod(spy),
+    )
+
+    before_first, removed_first = dedup_links.process_lab(lab_path, labs_dir, dry_run=False)
+    before_second, removed_second = dedup_links.process_lab(lab_path, labs_dir, dry_run=False)
+
+    assert before_first == 2
+    assert removed_first == 1
+    assert before_second == 1
+    assert removed_second == 0
+    assert writes == ["lab.json"]

--- a/scripts/dedup_links.py
+++ b/scripts/dedup_links.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -41,8 +40,10 @@ for _p in (_BACKEND_DIR, _REPO_ROOT):
     if str(_p) not in sys.path:
         sys.path.insert(0, str(_p))
 
-# Import only the pure helpers — no database/ORM imports triggered.
+# Import the canonical dedup helper, lock, and lab JSON write surface.
+from app.config import get_settings  # noqa: E402
 from app.services.link_utils import _link_pair_key  # noqa: E402
+from app.services.lab_service import LabService  # noqa: E402
 from app.services.lab_lock import lab_lock  # noqa: E402
 
 
@@ -120,15 +121,13 @@ def process_lab(
         data["links"] = deduped
         # Remove synthesized legacy shim so write does not regenerate links[].
         data.pop("topology", None)
-
-        # Atomic write: write to .tmp then rename.
-        tmp_path = lab_path.with_suffix(".json.tmp")
+        settings = get_settings()
+        original_labs_dir = settings.LABS_DIR
+        settings.LABS_DIR = labs_dir
         try:
-            tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-            os.replace(tmp_path, lab_path)
-        except Exception:
-            tmp_path.unlink(missing_ok=True)
-            raise
+            LabService.write_lab_json_static(lab_id, data)
+        finally:
+            settings.LABS_DIR = original_labs_dir
 
     return before, removed
 


### PR DESCRIPTION
## Summary
- route `scripts/dedup_links.py` writes through `LabService.write_lab_json_static` instead of the script-local tmp+replace path
- preserve `--labs-dir` behavior by temporarily scoping `LABS_DIR` to the script target during the canonical write
- add focused regression coverage in `backend/tests/test_dedup_links.py` for LabService invocation and no-op reruns

## Verification
- `/Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/test_dedup_links.py -x --tb=short`
- `/Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/`

This addresses the codex critic US-103 LOW finding at `.omc/research/codex-critic-network-runtime-2026-04-28.md:35-36` and the LabService write-path requirement in `.omc/plans/network-runtime-wiring.md:152-158`.

Refs #83
Refs #80