### PR TITLE
hotfix(ui): NodeConfigModal naming-scheme control + Port.svelte formatter wiring + template seeds (#82 codex MEDIUM)

### DIFF
--- a/backend/templates/qemu/csr.yml
+++ b/backend/templates/qemu/csr.yml
@@ -11,3 +11,5 @@ capabilities:
   hotplug: true
   max_nics: 8
   machine: q35
+interface_naming:
+  format: "GigabitEthernet0/0/{n}"

--- a/backend/templates/qemu/vyos.yml
+++ b/backend/templates/qemu/vyos.yml
@@ -12,3 +12,5 @@ capabilities:
   hotplug: true
   max_nics: 8
   machine: q35
+interface_naming:
+  format: "eth{n}"

--- a/frontend/src/lib/components/canvas/NodeConfigModal.svelte
+++ b/frontend/src/lib/components/canvas/NodeConfigModal.svelte
@@ -35,6 +35,7 @@
     console: NodeData['console'];
     delay: number;
     extras: ExtrasMap;
+    interface_naming_scheme: string | null;
   };
 
   type EditSubmitPayload = {
@@ -47,6 +48,7 @@
     console: NodeData['console'];
     delay: number;
     extras: ExtrasMap;
+    interface_naming_scheme: string | null;
   };
 
   const dispatch = createEventDispatcher<{
@@ -59,6 +61,17 @@
     { key: 'docker', label: 'Docker', icon: Container },
     { key: 'iol', label: 'IOL', icon: Network },
     { key: 'dynamips', label: 'Dynamips', icon: HardDrive },
+  ];
+  const DEFAULT_INTERFACE_NAMING = '';
+  const COMMON_INTERFACE_NAMING_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+    { value: DEFAULT_INTERFACE_NAMING, label: 'Default' },
+    { value: 'GigabitEthernet0/0/{n}', label: 'GigabitEthernet0/0/{n}' },
+    { value: 'eth{n}', label: 'eth{n}' },
+    { value: 'Port{n}', label: 'Port{n}' },
+  ];
+  const DOCKER_INTERFACE_NAMING_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+    { value: DEFAULT_INTERFACE_NAMING, label: 'Default' },
+    { value: 'eth{n}', label: 'eth{n}' },
   ];
 
   let selectedType: NodeTypeKey = 'qemu';
@@ -75,6 +88,7 @@
   let consoleMode: NodeData['console'] = 'telnet';
   let delay = 0;
   let extras: ExtrasMap = {};
+  let interfaceNamingScheme = DEFAULT_INTERFACE_NAMING;
   let dirty: Record<string, boolean> = {};
   let lastSignature = '';
 
@@ -108,6 +122,14 @@
 
   function extrasSchemaFor(template: NodeCatalogTemplate | undefined): NodeCatalogExtraField[] {
     return template?.extras_schema ?? [];
+  }
+
+  function interfaceNamingOptionsFor(type: NodeTypeKey): ReadonlyArray<{ value: string; label: string }> {
+    return type === 'docker' ? DOCKER_INTERFACE_NAMING_OPTIONS : COMMON_INTERFACE_NAMING_OPTIONS;
+  }
+
+  function normalizedInterfaceNamingScheme(): string | null {
+    return interfaceNamingScheme || null;
   }
 
   function defaultExtrasFromTemplate(template: NodeCatalogTemplate | undefined): ExtrasMap {
@@ -152,6 +174,7 @@
       ethernet = node.ethernet;
       consoleMode = node.console;
       delay = node.delay ?? 0;
+      interfaceNamingScheme = node.interface_naming_scheme ?? DEFAULT_INTERFACE_NAMING;
       const baseExtras = defaultExtrasFromTemplate(matchingTemplate);
       const persistedExtras = ((node as unknown as { extras?: ExtrasMap }).extras ?? {}) as ExtrasMap;
       extras = { ...baseExtras, ...persistedExtras };
@@ -165,6 +188,7 @@
     name = '';
     count = 1;
     placement = 'grid';
+    interfaceNamingScheme = DEFAULT_INTERFACE_NAMING;
     resetDirty();
     applyTemplateDefaults(templateForId(templateValue), { force: true });
   }
@@ -293,6 +317,7 @@
           console: consoleMode,
           delay,
           extras,
+          interface_naming_scheme: normalizedInterfaceNamingScheme(),
         },
       });
       return;
@@ -319,6 +344,7 @@
         console: consoleMode,
         delay,
         extras,
+        interface_naming_scheme: normalizedInterfaceNamingScheme(),
       },
     });
   }
@@ -329,6 +355,10 @@
 
   $: selectedTemplate = templateForId(selectedTemplateId);
   $: visibleTemplates = catalog ? templatesForType(selectedType) : [];
+  $: availableInterfaceNamingOptions = interfaceNamingOptionsFor(selectedType);
+  $: if (!availableInterfaceNamingOptions.some((option) => option.value === interfaceNamingScheme)) {
+    interfaceNamingScheme = DEFAULT_INTERFACE_NAMING;
+  }
   $: signature = `${open}:${mode}:${catalog?.templates.length ?? 0}:${node?.id ?? 'create'}:${node?.status ?? 0}`;
   $: if (open && catalog && signature !== lastSignature) {
     lastSignature = signature;
@@ -537,6 +567,21 @@
                   disabled={isStoppedOnly('delay')}
                   class="w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-1.5 text-sm text-slate-100 disabled:text-slate-500"
                 />
+              </label>
+              <label class="block">
+                <div class="mb-1 text-[10px] uppercase tracking-[0.05em] text-slate-500">Interface naming</div>
+                <select
+                  bind:value={interfaceNamingScheme}
+                  on:change={() => markDirty('interfaceNamingScheme')}
+                  class="w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-1.5 text-sm text-slate-100"
+                >
+                  {#each availableInterfaceNamingOptions as option}
+                    <option value={option.value}>{option.label}</option>
+                  {/each}
+                </select>
+                <div class="mt-1 text-[11px] text-slate-500">
+                  Default keeps template or platform naming. Set an override to render ports from the selected format.
+                </div>
               </label>
               {#if mode === 'create'}
                 <label class="block">

--- a/frontend/src/lib/components/canvas/Port.svelte
+++ b/frontend/src/lib/components/canvas/Port.svelte
@@ -2,8 +2,10 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  import { Handle, Position, useStore } from '@xyflow/svelte';
+  import { createEventDispatcher, getContext, onDestroy } from 'svelte';
+  import type { Readable } from 'svelte/store';
+  import { Handle, Position, useNodesData, useStore } from '@xyflow/svelte';
+  import { formatInterfaceName } from '$lib/services/interfaceNaming';
   import type { LiveMacState, NodeInterface, PortPosition } from '$lib/types';
   import { dragLinkStore, getDragLinkSnapshot } from '$lib/stores/dragLink';
   import { togglePortInfo } from '$lib/stores/portInfo';
@@ -22,6 +24,7 @@
   export let isSource = false;
   export let highlighted = false;
   export let liveMac: LiveMacState | undefined = undefined;
+  export let interfaceNamingScheme: string | null | undefined = undefined;
 
   const dispatch = createEventDispatcher<{
     'port:mousedown': { event: MouseEvent; nodeId: number; interfaceIndex: number; port: PortPosition };
@@ -43,6 +46,8 @@
   // mouseup. ``clickStartCoords`` doubles as a "did we receive mousedown" flag.
   let clickStartTs = 0;
   let clickStartCoords: { x: number; y: number } | null = null;
+  let currentNodeData: { interface_naming_scheme?: string | null } | null = null;
+  let unsubscribeCurrentNode: (() => void) | null = null;
 
   $: stylePosition = (() => {
     const offsetPct = `${(position.offset * 100).toFixed(2)}%`;
@@ -79,12 +84,31 @@
   // component tree. Outside that context (e.g. unit tests) the Handle calls
   // useStore() and throws; the guard makes Port test-safe in isolation.
   let insideFlow = false;
+  const flowNodeId = getContext<string | undefined>('svelteflow__node_id');
+  let currentNodeStore: Readable<{ data: { interface_naming_scheme?: string | null } } | null> | null = null;
   try {
     useStore();
     insideFlow = true;
+    if (flowNodeId) {
+      currentNodeStore = useNodesData(flowNodeId) as Readable<{
+        data: { interface_naming_scheme?: string | null };
+      } | null>;
+    }
   } catch {
     insideFlow = false;
   }
+  if (currentNodeStore) {
+    unsubscribeCurrentNode = currentNodeStore.subscribe((value) => {
+      currentNodeData = value?.data ?? null;
+    });
+  }
+
+  $: resolvedInterfaceNamingScheme =
+    interfaceNamingScheme !== undefined
+      ? interfaceNamingScheme
+      : currentNodeData?.interface_naming_scheme;
+  $: renderedInterfaceName =
+    formatInterfaceName(resolvedInterfaceNamingScheme, interfaceIndex) || interfaceData.name;
 
   $: xyPosition = (() => {
     switch (position.side) {
@@ -126,7 +150,7 @@
         nodeId,
         interfaceIndex,
         port: position,
-        interfaceName: interfaceData.name,
+        interfaceName: renderedInterfaceName,
         plannedMac: interfaceData.planned_mac ?? null,
       },
       nearTarget: true,
@@ -165,7 +189,7 @@
           nodeId,
           interfaceIndex,
           port: position,
-          interfaceName: interfaceData.name,
+          interfaceName: renderedInterfaceName,
           plannedMac: interfaceData.planned_mac ?? null,
         },
         pointer: { x: event.clientX, y: event.clientY },
@@ -198,7 +222,7 @@
           nodeId,
           interfaceIndex,
           anchorRect: rect,
-          interfaceName: interfaceData.name,
+          interfaceName: renderedInterfaceName,
           plannedMac: interfaceData.planned_mac ?? null,
         });
         return;
@@ -224,7 +248,7 @@
         nodeId,
         interfaceIndex,
         port: position,
-        interfaceName: interfaceData.name,
+        interfaceName: renderedInterfaceName,
         plannedMac: interfaceData.planned_mac ?? null,
       },
       nearTarget: true,
@@ -234,6 +258,10 @@
       targetReachable: true,
     });
   }
+
+  onDestroy(() => {
+    unsubscribeCurrentNode?.();
+  });
 </script>
 
 <div
@@ -246,7 +274,7 @@
   data-port-live-state={liveMac?.state ?? ''}
   role="button"
   tabindex="-1"
-  aria-label={`Port ${interfaceData.name}`}
+  aria-label={`Port ${renderedInterfaceName}`}
   on:mousedown={handleMouseDown}
   on:mouseup={handleMouseUp}
   on:mouseenter={handleMouseEnter}
@@ -282,7 +310,7 @@
   {/if}
   {#if showTooltip}
     <PortTooltip
-      interfaceName={interfaceData.name}
+      interfaceName={renderedInterfaceName}
       plannedMac={interfaceData.planned_mac ?? undefined}
       liveMac={liveMac}
       placement={tooltipPlacement}

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -204,6 +204,7 @@ export interface NodeData {
   extras?: Record<string, unknown>;
   /** Optional runtime/template capabilities echoed by newer backend responses. */
   capabilities?: TemplateCapabilities;
+  interface_naming_scheme?: string | null;
 }
 
 export interface NodeCatalogImage {

--- a/frontend/tests/NodeConfigModal.test.ts
+++ b/frontend/tests/NodeConfigModal.test.ts
@@ -16,11 +16,12 @@
  * a canonical Svelte 5 testing pattern (flushSync or rerender).
  */
 
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
 import { tick } from 'svelte';
 import NodeConfigModal from '$lib/components/canvas/NodeConfigModal.svelte';
-import type { NodeCatalog, NodeCatalogTemplate, TemplateCapabilities } from '$lib/types';
+import NodeConfigModalHarness from './NodeConfigModalHarness.svelte';
+import type { NodeCatalog, NodeCatalogTemplate, NodeData, TemplateCapabilities } from '$lib/types';
 
 function makeTemplate(caps?: TemplateCapabilities): NodeCatalogTemplate {
   return {
@@ -55,6 +56,27 @@ function makeCatalog(template: NodeCatalogTemplate): NodeCatalog {
     create_fields: [],
     edit_fields: [],
     runtime_editability: { always: [], stopped_only: [], immutable: [] },
+  };
+}
+
+function makeNode(overrides: Partial<NodeData> = {}): NodeData {
+  return {
+    id: 7,
+    name: 'vyos-1',
+    type: 'qemu',
+    template: 'vyos',
+    image: 'vyos-1.4',
+    console: 'telnet',
+    status: 0,
+    delay: 0,
+    cpu: 1,
+    ram: 1024,
+    ethernet: 4,
+    left: 100,
+    top: 120,
+    icon: 'Router.png',
+    interfaces: [],
+    ...overrides,
   };
 }
 
@@ -97,5 +119,58 @@ describe('NodeConfigModal capabilities banner — static paths', () => {
     expect(qemu.machine).toBe('q35');
     expect(docker.machine).toBeNull();
     expect(legacy.hotplug).toBe(false);
+  });
+
+  it('dispatches interface_naming_scheme in create payloads', async () => {
+    const catalog = makeCatalog(makeTemplate());
+    render(NodeConfigModalHarness, {
+      props: { open: true, mode: 'create', catalog, node: null },
+    });
+
+    await tick();
+    await fireEvent.change(screen.getByRole('combobox', { name: /interface naming/i }), {
+      target: { value: 'Port{n}' },
+    });
+    const createForm = screen.getByRole('dialog').querySelector('form');
+    expect(createForm).not.toBeNull();
+    await fireEvent.submit(createForm as HTMLFormElement);
+    await tick();
+
+    expect(screen.getByTestId('submit-payload').textContent).toBeTruthy();
+    expect(JSON.parse(screen.getByTestId('submit-payload').textContent ?? 'null')).toEqual(
+      expect.objectContaining({
+        mode: 'create',
+        payload: expect.objectContaining({
+          interface_naming_scheme: 'Port{n}',
+        }),
+      }),
+    );
+  });
+
+  it('dispatches interface_naming_scheme in edit payloads', async () => {
+    const catalog = makeCatalog(makeTemplate());
+    const node = makeNode({ interface_naming_scheme: 'eth{n}' });
+    render(NodeConfigModalHarness, {
+      props: { open: true, mode: 'edit', catalog, node },
+    });
+
+    await tick();
+    await fireEvent.change(screen.getByRole('combobox', { name: /interface naming/i }), {
+      target: { value: '' },
+    });
+    const editForm = screen.getByRole('dialog').querySelector('form');
+    expect(editForm).not.toBeNull();
+    await fireEvent.submit(editForm as HTMLFormElement);
+    await tick();
+
+    expect(screen.getByTestId('submit-payload').textContent).toBeTruthy();
+    expect(JSON.parse(screen.getByTestId('submit-payload').textContent ?? 'null')).toEqual(
+      expect.objectContaining({
+        mode: 'edit',
+        payload: expect.objectContaining({
+          interface_naming_scheme: null,
+        }),
+      }),
+    );
   });
 });

--- a/frontend/tests/NodeConfigModalHarness.svelte
+++ b/frontend/tests/NodeConfigModalHarness.svelte
@@ -1,0 +1,21 @@
+<!-- Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<script lang="ts">
+  import NodeConfigModal from '$lib/components/canvas/NodeConfigModal.svelte';
+  import type { NodeCatalog, NodeData } from '$lib/types';
+
+  export let open = true;
+  export let mode: 'create' | 'edit' = 'create';
+  export let catalog: NodeCatalog;
+  export let node: NodeData | null = null;
+
+  let submitPayload = '';
+
+  function handleSubmit(event: CustomEvent) {
+    submitPayload = JSON.stringify(event.detail);
+  }
+</script>
+
+<NodeConfigModal {open} {mode} {catalog} {node} on:submit={handleSubmit} />
+<output data-testid="submit-payload">{submitPayload}</output>

--- a/frontend/tests/Port.test.ts
+++ b/frontend/tests/Port.test.ts
@@ -289,4 +289,54 @@ describe('Port (US-079)', () => {
     const handleLeft = root.querySelector('[data-testid="port-handle"]') as HTMLElement;
     expect(handleLeft.className).not.toContain('port-handle-hover');
   });
+
+  it('formats interface names from interfaceNamingScheme when one is set', () => {
+    render(Port, {
+      props: {
+        interfaceData: baseInterface,
+        position: basePosition,
+        nodeId: 7,
+        interfaceIndex: 0,
+        interfaceNamingScheme: 'GigabitEthernet0/0/{n}',
+      },
+    });
+
+    const root = findPortRoot();
+    expect(root.getAttribute('aria-label')).toBe('Port GigabitEthernet0/0/0');
+
+    dispatchMouse(root, 'mousedown', { x: 100, y: 200 });
+    dispatchMouse(root, 'mouseup', { x: 100, y: 200 });
+
+    const stored = get(selectedPortInfoStore);
+    expect(stored).not.toBeNull();
+    expect(stored?.kind).toBe('interface');
+    if (stored?.kind === 'interface') {
+      expect(stored.interfaceName).toBe('GigabitEthernet0/0/0');
+    }
+  });
+
+  it('falls back to the literal interface name when interfaceNamingScheme is null', () => {
+    render(Port, {
+      props: {
+        interfaceData: baseInterface,
+        position: basePosition,
+        nodeId: 7,
+        interfaceIndex: 0,
+        interfaceNamingScheme: null,
+      },
+    });
+
+    const root = findPortRoot();
+    expect(root.getAttribute('aria-label')).toBe('Port eth0');
+
+    dispatchMouse(root, 'mousedown', { x: 100, y: 200 });
+    dispatchMouse(root, 'mouseup', { x: 100, y: 200 });
+
+    const stored = get(selectedPortInfoStore);
+    expect(stored).not.toBeNull();
+    expect(stored?.kind).toBe('interface');
+    if (stored?.kind === 'interface') {
+      expect(stored.interfaceName).toBe('eth0');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- wire `interface_naming_scheme` through `NodeConfigModal` create and edit submits
- render port names through `formatInterfaceName(...)` with raw-name fallback when no scheme is set
- seed `backend/templates/qemu/vyos.yml` and `backend/templates/qemu/csr.yml` with additive `interface_naming.format` defaults
- add Vitest coverage for modal submit payloads and Port formatting/fallback behavior

## Context
- Codex finding: `.omc/research/codex-critic-network-runtime-2026-04-28.md` (US-105 MEDIUM + LOW template seeds)
- Spec: `.omc/plans/network-runtime-wiring.md:184-188`

## Verification
- `cd frontend && npm test`
- `cd frontend && npm run check`
- `cd backend && .venv/bin/python -m pytest tests/test_template_capabilities.py`

Refs #82
Refs #80