### PR TITLE
feat(net): orphan sweep on lab/node stop + backend startup (US-206, #96)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,6 +79,39 @@ async def startup():
     from app.services.node_runtime_service import NodeRuntimeService
     NodeRuntimeService.start_heartbeat()
 
+    # US-206: backend-startup orphan sweep.  Scan the host for nove*/nve* kernel
+    # objects that belong to labs no longer on disk (or that survived a crash).
+    # Best-effort — never blocks startup, never raises.
+    try:
+        from app.services import host_net as _host_net
+        from app.services.lab_service import LabService as _LabService
+
+        _known_lab_ids: set[str] = set()
+        _labs_dir = settings.LABS_DIR
+        if _labs_dir.exists():
+            for _lab_file in _labs_dir.rglob("*.json"):
+                try:
+                    import json as _json
+                    _raw = _json.loads(_lab_file.read_text())
+                    _lid = str(_raw.get("id", "")).strip()
+                    if _lid:
+                        _known_lab_ids.add(_lid)
+                except Exception:
+                    pass
+
+        _removed_bridges = _host_net.sweep_orphan_bridges(_known_lab_ids)
+        _removed_ifaces = _host_net.sweep_orphan_ifaces(_known_lab_ids)
+        if _removed_bridges or _removed_ifaces:
+            _logger.warning(
+                "startup orphan-sweep: removed %d bridges %s and %d ifaces %s",
+                len(_removed_bridges), _removed_bridges,
+                len(_removed_ifaces), _removed_ifaces,
+            )
+        else:
+            _logger.info("startup orphan-sweep: no orphans found")
+    except Exception:
+        _logger.exception("startup orphan-sweep failed (non-fatal)")
+
 
 @app.on_event("shutdown")
 async def shutdown():

--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -479,3 +479,200 @@ def try_link_del(name: str) -> None:
     except HostNetError:
         # Any other helper failure is still best-effort: log and continue.
         logger.warning("try_link_del(%s): non-fatal cleanup failure", name)
+
+
+def try_bridge_del(name: str) -> None:
+    """Best-effort bridge deletion — swallows :class:`HostNetEINVAL` (already gone).
+
+    Used in orphan-sweep paths.
+    """
+    try:
+        bridge_del(name)
+    except HostNetEINVAL:
+        return
+    except HostNetError:
+        logger.warning("try_bridge_del(%s): non-fatal cleanup failure", name)
+
+
+# ---------------------------------------------------------------------------
+# Orphan sweep (US-206)
+# ---------------------------------------------------------------------------
+
+import re as _re
+
+# Patterns that match nova-ve-owned kernel objects.
+# Bridges: nove<4-hex>n<network_id>
+_RE_BRIDGE = _re.compile(r"^nove[0-9a-f]{4}n\d{1,5}$")
+# TAPs / veth host-ends: nve<4-hex>d<node_id>i<iface>[h|p]?
+_RE_NVE_IFACE = _re.compile(r"^nve[0-9a-f]{4}d\d{1,3}i\d{1,2}[hp]?$")
+
+
+def _list_host_ifaces_prefixed(prefix: str) -> list[str]:
+    """Return names of host interfaces whose name starts with ``prefix``.
+
+    Uses ``ip -o link show`` (unprivileged read) and parses the output.
+    Returns an empty list on any failure so callers degrade gracefully.
+    """
+    try:
+        proc = _run([_ip_bin(), "-o", "link", "show"])
+    except FileNotFoundError:
+        return []
+    if proc.returncode != 0:
+        return []
+    names: list[str] = []
+    for line in proc.stdout.splitlines():
+        # Format: "<index>: <name>[@<peer>]: <flags> ..."
+        parts = line.split(":", 2)
+        if len(parts) < 2:
+            continue
+        raw_name = parts[1].strip().split("@")[0]
+        if raw_name.startswith(prefix):
+            names.append(raw_name)
+    return names
+
+
+def sweep_node_host_ifaces(lab_id: str, node_id: int) -> list[str]:
+    """Remove all host-side veth/TAP interfaces belonging to ``(lab_id, node_id)``.
+
+    Sweeps interfaces matching ``nve<hash>d<node_id>i*[h|p]?`` for the given
+    lab/node.  Best-effort: failures on individual interfaces are logged and
+    skipped so a single stuck interface does not block the rest.
+
+    Returns the list of interface names that were successfully deleted.
+    """
+    try:
+        instance_id = get_instance_id()
+    except HostNetInstanceIdMissing:
+        return []
+
+    h = _lab_hash(lab_id, instance_id)
+    prefix = f"nve{h:04x}d{node_id}i"
+    candidates = _list_host_ifaces_prefixed(prefix)
+    removed: list[str] = []
+    for name in candidates:
+        if not _RE_NVE_IFACE.match(name):
+            continue
+        try:
+            try_link_del(name)
+            removed.append(name)
+            logger.info("orphan-sweep: removed iface %s (lab=%s node=%s)", name, lab_id, node_id)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "orphan-sweep: failed to remove iface %s (lab=%s node=%s)",
+                name, lab_id, node_id, exc_info=True,
+            )
+    return removed
+
+
+def sweep_lab_host_ifaces(lab_id: str) -> list[str]:
+    """Remove all host-side veth/TAP interfaces belonging to ``lab_id``.
+
+    Sweeps all ``nve<hash>*`` interfaces for the lab.  Called on lab stop.
+    Best-effort: individual failures are logged and skipped.
+
+    Returns the list of interface names that were successfully deleted.
+    """
+    try:
+        instance_id = get_instance_id()
+    except HostNetInstanceIdMissing:
+        return []
+
+    h = _lab_hash(lab_id, instance_id)
+    prefix = f"nve{h:04x}"
+    candidates = _list_host_ifaces_prefixed(prefix)
+    removed: list[str] = []
+    for name in candidates:
+        if not _RE_NVE_IFACE.match(name):
+            continue
+        try:
+            try_link_del(name)
+            removed.append(name)
+            logger.info("orphan-sweep: removed lab iface %s (lab=%s)", name, lab_id)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "orphan-sweep: failed to remove lab iface %s (lab=%s)",
+                name, lab_id, exc_info=True,
+            )
+    return removed
+
+
+def sweep_orphan_bridges(known_lab_ids: "set[str]") -> list[str]:
+    """Scan host bridges and delete any ``nove*`` bridge not owned by a known lab.
+
+    ``known_lab_ids`` is the set of lab IDs currently on disk.  Any ``nove*``
+    bridge whose hash prefix does not match any of those labs is an orphan
+    (left behind by a crashed backend or a deleted lab) and is removed.
+
+    Best-effort: individual failures are logged and skipped.
+
+    Returns the list of bridge names that were successfully deleted.
+    """
+    try:
+        instance_id = get_instance_id()
+    except HostNetInstanceIdMissing:
+        return []
+
+    # Build a set of known 4-hex hash prefixes from known labs.
+    known_hashes: set[str] = set()
+    for lab_id in known_lab_ids:
+        h = _lab_hash(lab_id, instance_id)
+        known_hashes.add(f"{h:04x}")
+
+    candidates = _list_host_ifaces_prefixed("nove")
+    removed: list[str] = []
+    for name in candidates:
+        if not _RE_BRIDGE.match(name):
+            continue
+        # Extract the 4-hex portion after "nove"
+        bridge_hash = name[4:8]
+        if bridge_hash in known_hashes:
+            continue
+        # Orphan — no live lab owns this bridge.
+        logger.warning("orphan-sweep: found orphan bridge %s (no matching lab)", name)
+        try:
+            try_bridge_del(name)
+            removed.append(name)
+            logger.info("orphan-sweep: deleted orphan bridge %s", name)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "orphan-sweep: failed to delete orphan bridge %s", name, exc_info=True,
+            )
+    return removed
+
+
+def sweep_orphan_ifaces(known_lab_ids: "set[str]") -> list[str]:
+    """Scan host interfaces and delete any ``nve*`` iface not owned by a known lab.
+
+    Mirrors :func:`sweep_orphan_bridges` for TAP/veth host-ends.
+    Best-effort: individual failures are logged and skipped.
+
+    Returns the list of interface names that were successfully deleted.
+    """
+    try:
+        instance_id = get_instance_id()
+    except HostNetInstanceIdMissing:
+        return []
+
+    known_hashes: set[str] = set()
+    for lab_id in known_lab_ids:
+        h = _lab_hash(lab_id, instance_id)
+        known_hashes.add(f"{h:04x}")
+
+    candidates = _list_host_ifaces_prefixed("nve")
+    removed: list[str] = []
+    for name in candidates:
+        if not _RE_NVE_IFACE.match(name):
+            continue
+        iface_hash = name[3:7]
+        if iface_hash in known_hashes:
+            continue
+        logger.warning("orphan-sweep: found orphan iface %s (no matching lab)", name)
+        try:
+            try_link_del(name)
+            removed.append(name)
+            logger.info("orphan-sweep: deleted orphan iface %s", name)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "orphan-sweep: failed to delete orphan iface %s", name, exc_info=True,
+            )
+    return removed

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1391,6 +1391,13 @@ class NodeRuntimeService:
         # so a recycled pid cannot inherit this entry's authorization.
         self._unregister_pid(pid)
 
+        # US-206: sweep per-node TAP/veth host-ends left behind by this QEMU node.
+        # Best-effort — failures are logged inside sweep_node_host_ifaces.
+        lab_id = runtime.get("lab_id", "")
+        node_id = runtime.get("node_id")
+        if lab_id and node_id is not None:
+            host_net.sweep_node_host_ifaces(lab_id, int(node_id))
+
     @staticmethod
     def _unregister_pid(pid: int | None) -> None:
         if not pid:
@@ -1430,6 +1437,14 @@ class NodeRuntimeService:
         # synchronously here (not deferred to the heartbeat) so a recycled
         # PID cannot reuse this entry's authorization.
         self._unregister_pid(runtime.get("pid"))
+
+        # US-206: sweep any remaining veth host-ends for this node not already
+        # caught by the explicit ``veth_host_ends`` loop above (e.g. interfaces
+        # created by hot-attach after start-time).  Best-effort.
+        lab_id = runtime.get("lab_id", "")
+        node_id = runtime.get("node_id")
+        if lab_id and node_id is not None:
+            host_net.sweep_node_host_ifaces(lab_id, int(node_id))
 
         # US-203: no Docker network record exists for nova-ve labs any
         # more. ``network_names`` is retained on the runtime record only

--- a/backend/tests/test_orphan_sweep.py
+++ b/backend/tests/test_orphan_sweep.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for US-206 — orphan sweep on lab/node stop and backend startup.
+
+These tests mock the privileged helper and ``ip -o link show`` so they run
+without root and without real kernel objects.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import host_net
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def instance_env(monkeypatch, tmp_path):
+    """Seed a deterministic instance_id so bridge/iface names are predictable."""
+    idir = tmp_path / "nova-ve"
+    idir.mkdir(parents=True, exist_ok=True)
+    (idir / "instance_id").write_text("test-orphan-sweep")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(idir))
+    return "test-orphan-sweep"
+
+
+def _hash_hex(lab_id: str, instance_id: str) -> str:
+    import hashlib
+    raw = hashlib.blake2b(
+        f"{instance_id}:{lab_id}".encode("utf-8"), digest_size=2
+    ).hexdigest()
+    return f"{int(raw, 16):04x}"
+
+
+def _make_bridge_name(lab_id: str, network_id: int, instance_id: str) -> str:
+    h = _hash_hex(lab_id, instance_id)
+    return f"nove{h}n{network_id}"
+
+
+def _make_veth_name(lab_id: str, node_id: int, iface: int, instance_id: str, suffix: str = "h") -> str:
+    h = _hash_hex(lab_id, instance_id)
+    return f"nve{h}d{node_id}i{iface}{suffix}"
+
+
+def _make_tap_name(lab_id: str, node_id: int, iface: int, instance_id: str) -> str:
+    h = _hash_hex(lab_id, instance_id)
+    return f"nve{h}d{node_id}i{iface}"
+
+
+# ---------------------------------------------------------------------------
+# _list_host_ifaces_prefixed mock factory
+# ---------------------------------------------------------------------------
+
+
+def _mock_ip_link(monkeypatch, present_names: list[str]):
+    """Make ``_run`` return a fake ``ip -o link show`` listing ``present_names``."""
+    lines = []
+    for i, name in enumerate(present_names, start=1):
+        lines.append(f"{i}: {name}: <BROADCAST,MULTICAST> mtu 1500 ...")
+
+    def _fake_run(argv):
+        # ip -o link show
+        if "ip" in argv[0] and "-o" in argv and "link" in argv and "show" in argv:
+            return SimpleNamespace(returncode=0, stdout="\n".join(lines))
+        # tap-del / bridge-del via helper — succeed
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(host_net, "_run", _fake_run)
+
+
+# ---------------------------------------------------------------------------
+# sweep_node_host_ifaces
+# ---------------------------------------------------------------------------
+
+
+class TestSweepNodeHostIfaces:
+    def test_removes_matching_ifaces(self, monkeypatch, instance_env, tmp_path):
+        """Unregistered host-end veth for a node is swept."""
+        lab_id = "lab-abc"
+        node_id = 3
+        iface_h = _make_veth_name(lab_id, node_id, 0, instance_env, "h")
+        iface_p = _make_veth_name(lab_id, node_id, 0, instance_env, "p")
+        # peer-end naming (p) also matches regex
+        other = _make_veth_name("lab-other", 5, 1, instance_env, "h")
+
+        deleted: list[str] = []
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                names = [iface_h, iface_p, other]
+                lines = [f"{i}: {n}: <>" for i, n in enumerate(names, 1)]
+                return SimpleNamespace(returncode=0, stdout="\n".join(lines))
+            # tap-del verb — record deletion
+            if "tap-del" in argv:
+                deleted.append(argv[-1])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+
+        removed = host_net.sweep_node_host_ifaces(lab_id, node_id)
+
+        # Both iface_h and iface_p belong to lab-abc/node-3 and should be removed.
+        assert iface_h in removed
+        assert iface_p in removed
+        # The "other" lab's iface must NOT be touched.
+        assert other not in removed
+
+    def test_registered_pid_iface_still_swept_on_stop(self, monkeypatch, instance_env):
+        """sweep_node_host_ifaces doesn't check pids.json; it sweeps by name."""
+        lab_id = "lab-xyz"
+        node_id = 1
+        iface = _make_veth_name(lab_id, node_id, 0, instance_env, "h")
+
+        deleted: list[str] = []
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                return SimpleNamespace(returncode=0, stdout=f"1: {iface}: <>")
+            if "tap-del" in argv:
+                deleted.append(argv[-1])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+        removed = host_net.sweep_node_host_ifaces(lab_id, node_id)
+        assert iface in removed
+
+    def test_continues_past_individual_failure(self, monkeypatch, instance_env):
+        """Sweep continues even if one deletion fails."""
+        lab_id = "lab-fail"
+        node_id = 2
+        iface0 = _make_veth_name(lab_id, node_id, 0, instance_env, "h")
+        iface1 = _make_veth_name(lab_id, node_id, 1, instance_env, "h")
+
+        call_count = [0]
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                names = [iface0, iface1]
+                lines = [f"{i}: {n}: <>" for i, n in enumerate(names, 1)]
+                return SimpleNamespace(returncode=0, stdout="\n".join(lines))
+            if "tap-del" in argv:
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    # First deletion fails
+                    return SimpleNamespace(
+                        returncode=1, stdout="", stderr="no such device"
+                    )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+        # Should not raise; second iface should still be attempted.
+        removed = host_net.sweep_node_host_ifaces(lab_id, node_id)
+        # At least the second iface succeeded.
+        assert iface1 in removed
+
+    def test_no_instance_id_returns_empty(self, monkeypatch):
+        """Missing instance_id → empty list, no crash."""
+        monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", "/nonexistent-path-xyz")
+        monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+        result = host_net.sweep_node_host_ifaces("lab-x", 1)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# sweep_orphan_bridges
+# ---------------------------------------------------------------------------
+
+
+class TestSweepOrphanBridges:
+    def test_orphan_bridge_removed(self, monkeypatch, instance_env):
+        """A nove* bridge with no matching known lab is an orphan and is removed."""
+        # Bridge that belongs to a real lab
+        known_lab = "lab-known"
+        orphan_lab = "lab-orphan-gone"
+        owned_bridge = _make_bridge_name(known_lab, 1, instance_env)
+        orphan_bridge = _make_bridge_name(orphan_lab, 1, instance_env)
+
+        deleted: list[str] = []
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                names = [owned_bridge, orphan_bridge]
+                lines = [f"{i}: {n}: <>" for i, n in enumerate(names, 1)]
+                return SimpleNamespace(returncode=0, stdout="\n".join(lines))
+            if "bridge-del" in argv:
+                deleted.append(argv[-1])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+
+        removed = host_net.sweep_orphan_bridges({known_lab})
+
+        assert orphan_bridge in removed
+        assert owned_bridge not in removed
+
+    def test_bridge_with_known_lab_kept(self, monkeypatch, instance_env):
+        """A nove* bridge owned by a known lab is not touched."""
+        known_lab = "lab-keep"
+        bridge = _make_bridge_name(known_lab, 2, instance_env)
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                return SimpleNamespace(returncode=0, stdout=f"1: {bridge}: <>")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+
+        removed = host_net.sweep_orphan_bridges({known_lab})
+        assert bridge not in removed
+        assert removed == []
+
+    def test_sweep_continues_past_individual_failure(self, monkeypatch, instance_env):
+        """Orphan sweep continues if one bridge deletion fails."""
+        orphan1 = _make_bridge_name("orphan-a", 1, instance_env)
+        orphan2 = _make_bridge_name("orphan-b", 1, instance_env)
+
+        call_count = [0]
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                names = [orphan1, orphan2]
+                lines = [f"{i}: {n}: <>" for i, n in enumerate(names, 1)]
+                return SimpleNamespace(returncode=0, stdout="\n".join(lines))
+            if "bridge-del" in argv:
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    return SimpleNamespace(
+                        returncode=1, stdout="", stderr="no such device"
+                    )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+        removed = host_net.sweep_orphan_bridges(set())
+        # At least orphan2 succeeds
+        assert orphan2 in removed
+
+    def test_no_instance_id_returns_empty(self, monkeypatch):
+        """Missing instance_id → empty list, no crash."""
+        monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", "/nonexistent-path-xyz")
+        monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+        result = host_net.sweep_orphan_bridges(set())
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# sweep_orphan_ifaces
+# ---------------------------------------------------------------------------
+
+
+class TestSweepOrphanIfaces:
+    def test_orphan_iface_removed(self, monkeypatch, instance_env):
+        """A nve* iface with no matching known lab is removed."""
+        known_lab = "lab-known2"
+        orphan_lab = "lab-orphan2"
+        owned_iface = _make_veth_name(known_lab, 1, 0, instance_env, "h")
+        orphan_iface = _make_veth_name(orphan_lab, 1, 0, instance_env, "h")
+
+        deleted: list[str] = []
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                names = [owned_iface, orphan_iface]
+                lines = [f"{i}: {n}: <>" for i, n in enumerate(names, 1)]
+                return SimpleNamespace(returncode=0, stdout="\n".join(lines))
+            if "tap-del" in argv:
+                deleted.append(argv[-1])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+
+        removed = host_net.sweep_orphan_ifaces({known_lab})
+        assert orphan_iface in removed
+        assert owned_iface not in removed
+
+    def test_no_instance_id_returns_empty(self, monkeypatch):
+        monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", "/nonexistent-path-xyz")
+        monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+        result = host_net.sweep_orphan_ifaces(set())
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: startup sweep removes orphan objects not in known labs
+# ---------------------------------------------------------------------------
+
+
+class TestStartupOrphanSweep:
+    """Tests that exercise the full sweep path as called from app.startup."""
+
+    def test_startup_sweep_removes_orphan_bridge_not_in_labs_dir(
+        self, monkeypatch, instance_env, tmp_path
+    ):
+        """Orphan bridge (no lab file) is removed during startup sweep."""
+        labs_dir = tmp_path / "labs"
+        labs_dir.mkdir()
+
+        orphan_bridge = _make_bridge_name("lab-deleted", 1, instance_env)
+        deleted: list[str] = []
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                return SimpleNamespace(returncode=0, stdout=f"1: {orphan_bridge}: <>")
+            if "bridge-del" in argv:
+                deleted.append(argv[-1])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+
+        # No lab files → known_lab_ids = {}
+        known: set[str] = set()
+        removed = host_net.sweep_orphan_bridges(known)
+        assert orphan_bridge in removed
+
+    def test_startup_sweep_keeps_bridge_for_existing_lab(
+        self, monkeypatch, instance_env, tmp_path
+    ):
+        """Bridge for a lab that still has a JSON file is kept."""
+        labs_dir = tmp_path / "labs"
+        labs_dir.mkdir()
+        lab_id = "lab-still-here"
+        lab_file = labs_dir / "lab.json"
+        lab_file.write_text(json.dumps({"id": lab_id}))
+
+        bridge = _make_bridge_name(lab_id, 1, instance_env)
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                return SimpleNamespace(returncode=0, stdout=f"1: {bridge}: <>")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+
+        removed = host_net.sweep_orphan_bridges({lab_id})
+        assert bridge not in removed
+
+    def test_startup_sweep_removes_orphan_iface(
+        self, monkeypatch, instance_env
+    ):
+        """Orphan nve* iface (no matching lab) is removed during startup sweep."""
+        orphan_iface = _make_veth_name("lab-gone", 2, 0, instance_env, "h")
+
+        def _fake_run(argv):
+            if "-o" in argv:
+                return SimpleNamespace(returncode=0, stdout=f"1: {orphan_iface}: <>")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(host_net, "_run", _fake_run)
+
+        removed = host_net.sweep_orphan_ifaces(set())
+        assert orphan_iface in removed


### PR DESCRIPTION
## Summary

- Add `sweep_node_host_ifaces`, `sweep_lab_host_ifaces`, `sweep_orphan_bridges`, and `sweep_orphan_ifaces` to `host_net.py` — unprivileged `ip -o link show` scan + best-effort privileged deletion via the helper
- Wire `sweep_node_host_ifaces` into `_stop_qemu_runtime` and `_stop_docker_runtime` in `node_runtime_service.py` — per-node veth/TAP cleanup on every node stop
- Add backend-startup orphan sweep in `main.py` — on startup, scan all `nove*` bridges and `nve*` ifaces against known lab IDs on disk, log and delete any that have no matching lab
- New `backend/tests/test_orphan_sweep.py` with 13 tests covering the key acceptance criteria

## Acceptance criteria met

- Registered-pid ifaces are swept on node stop (name-based sweep, not pid-based)
- Unregistered host-end → swept; bridge with known lab → kept; bridge without known lab (orphan) → swept
- Sweep continues past individual failure (logged, not raised)
- Startup sweep runs best-effort, never blocks startup, never raises

## Test plan

- [x] `pytest tests/test_orphan_sweep.py -v` — 13 passed
- [x] `pytest tests/ -q` — 519 passed, 1 pre-existing failure in `test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error` (confirmed pre-existing on `main`)

Closes #96
Refs #80