### PR TITLE
feat(net): container IPAM via used_ips free-list (US-204c, #93)

### DIFF
--- a/backend/app/schemas/network.py
+++ b/backend/app/schemas/network.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -15,6 +15,39 @@ NetworkType = Literal[
     "private", "private2", "private3",
     "nat0",
 ]
+
+
+class NetworkConfig(BaseModel):
+    """User-supplied network configuration.
+
+    US-204c: the optional ``cidr`` enables L3 IPAM from a free-list of
+    used IPs (``runtime.used_ips``). When ``cidr`` is unset the network is
+    L2-only. IPv6 CIDRs are rejected at create-network time per the
+    deferred-IPv6 §5 plan entry.
+    """
+
+    cidr: Optional[str] = None
+    gateway: Optional[str] = None
+    dhcp: bool = False
+
+
+class NetworkRuntime(BaseModel):
+    """Runtime/host-side state for a network record.
+
+    Persisted under ``networks[i].runtime`` in lab.json. Owned by
+    ``network_service`` (bridge name from US-202; IPAM free-list from
+    US-204c). The IPAM free-list is intentionally NOT a monotonic
+    counter — see plan §US-204c "IPAM data model (free-list, NOT a
+    counter)" for why.
+    """
+
+    bridge_name: Optional[str] = None
+    driver: Optional[str] = None
+    used_ips: List[str] = Field(default_factory=list)
+    # First host offset usable for allocation (skips network address and
+    # the conventional .1 gateway reservation). Operators may bump this
+    # if they need additional reserved low addresses.
+    first_offset: int = 2
 
 
 class NetworkBase(BaseModel):
@@ -40,6 +73,7 @@ class NetworkBase(BaseModel):
     implicit: bool = False
     smart: int = -1
     config: Dict[str, Any] = Field(default_factory=dict)
+    runtime: Dict[str, Any] = Field(default_factory=dict)
 
 
 class NetworkRead(NetworkBase):
@@ -56,6 +90,7 @@ class NetworkCreate(BaseModel):
     type: NetworkType = "linux_bridge"
     left: int = 0
     top: int = 0
+    config: Optional[NetworkConfig] = None
 
 
 class NetworkUpdate(BaseModel):

--- a/backend/app/services/network_service.py
+++ b/backend/app/services/network_service.py
@@ -7,10 +7,17 @@ US-063 + US-064 — JSON-side mutations under the per-lab flock.
 US-202 — ``create_network`` / ``delete_network`` provision and tear down
 the matching Linux bridge via the privileged helper, persisting
 ``runtime.bridge_name`` on the network record.
+US-204c — Container interface IP bringup. ``create_network`` validates
+the optional ``config.cidr`` (IPv4 only) and seeds
+``runtime.used_ips: list[str]`` and ``runtime.first_offset: int``.
+``_allocate_ip``/``_release_ip`` mutate the free-list under ``lab_lock``;
+nsenter-based IP application happens OUTSIDE the lock by callers per the
+plan §US-204c "Lock-hold-time discipline".
 """
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 from typing import Any, Dict, List, Optional, Tuple
@@ -25,6 +32,12 @@ from app.services.ws_hub import ws_hub
 logger = logging.getLogger("nova-ve")
 
 
+# US-204c: free-list IPAM defaults. ``first_offset=2`` skips .0 (network)
+# and .1 (conventional gateway reservation). The broadcast address is
+# excluded explicitly inside ``_allocate_ip``.
+DEFAULT_FIRST_OFFSET = 2
+
+
 class NetworkServiceError(Exception):
     """Generic exception for network-service contract violations."""
 
@@ -33,6 +46,37 @@ class NetworkServiceError(Exception):
         self.code = code
         self.message = message
         self.extra = extra or {}
+
+
+def _is_ipv4(value: str) -> bool:
+    try:
+        ipaddress.IPv4Address(value)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def _validate_cidr(cidr: Any) -> ipaddress.IPv4Network:
+    """Validate a user-supplied CIDR string.
+
+    IPv4 only — IPv6 raises 422 with explicit pointer to plan §5
+    "deferred-IPv6". Empty/None inputs raise; callers must gate on the
+    presence of ``config.cidr`` before calling.
+    """
+    if not isinstance(cidr, str) or not cidr.strip():
+        raise NetworkServiceError(422, "config.cidr must be a non-empty string")
+    try:
+        net = ipaddress.ip_network(cidr.strip(), strict=True)
+    except (ValueError, TypeError) as exc:
+        raise NetworkServiceError(
+            422, f"config.cidr is not a valid CIDR: {exc}"
+        ) from exc
+    if isinstance(net, ipaddress.IPv6Network):
+        raise NetworkServiceError(
+            422,
+            "IPv6 CIDR not yet supported (see plan §5 deferred-IPv6)",
+        )
+    return net
 
 
 def _serialize_network(network: dict, count: int) -> dict:
@@ -80,6 +124,16 @@ class NetworkService:
         normalized = _normalize_relative_lab_path(lab_path)
         labs_dir = get_settings().LABS_DIR
 
+        # US-204c: validate CIDR (if any) before touching the lab lock so
+        # invalid input cannot create partial state. ``config`` is the
+        # user-supplied shape from ``NetworkCreate``/``NetworkConfig``.
+        raw_config = request.get("config") or {}
+        if not isinstance(raw_config, dict):
+            raw_config = {}
+        cidr_value = raw_config.get("cidr")
+        if cidr_value:
+            _validate_cidr(cidr_value)
+
         with lab_lock(normalized, labs_dir):
             data = LabService.read_lab_json_static(normalized)
             lab_id = str(data.get("id") or normalized)
@@ -104,8 +158,15 @@ class NetworkService:
                 "visibility": True,
                 "implicit": False,
                 "smart": -1,
-                "config": {},
-                "runtime": {"bridge_name": bridge},
+                "config": dict(raw_config),
+                "runtime": {
+                    "bridge_name": bridge,
+                    # US-204c: seed an empty free-list. Counter-based
+                    # allocation would exhaust a /24 in 250 cycles even
+                    # with one container; the free-list does not.
+                    "used_ips": [],
+                    "first_offset": DEFAULT_FIRST_OFFSET,
+                },
             }
             networks[str(next_id)] = network
             data.pop("topology", None)
@@ -215,6 +276,130 @@ class NetworkService:
 
         await ws_hub.publish(normalized, "network_deleted", {"network": removed})
         return removed
+
+    # ------------------------------------------------------------------
+    # US-204c — IPAM free-list allocator
+    # ------------------------------------------------------------------
+
+    def _allocate_ip(self, lab_path: str, network_id: int) -> str:
+        """Reserve and return the lowest free IP from ``network.config.cidr``.
+
+        Walks the CIDR's host range starting at ``runtime.first_offset``,
+        skipping the network/broadcast addresses and any IP already in
+        ``runtime.used_ips``. The chosen address is appended to
+        ``used_ips`` (kept sorted by integer value) and persisted under
+        the per-lab flock. Callers MUST execute ``nsenter ip addr add``
+        OUTSIDE the lock and call ``_release_ip`` on failure (plan
+        §US-204c "Lock-hold-time discipline" / "Rollback semantics").
+
+        Raises:
+            NetworkServiceError(404): the network does not exist.
+            NetworkServiceError(422): the network has no ``config.cidr``,
+                or the CIDR cannot be parsed.
+            NetworkServiceError(409): the subnet has no free addresses.
+        """
+        normalized = _normalize_relative_lab_path(lab_path)
+        labs_dir = get_settings().LABS_DIR
+
+        with lab_lock(normalized, labs_dir):
+            data = LabService.read_lab_json_static(normalized)
+            networks = data.get("networks", {}) or {}
+            network = networks.get(str(network_id))
+            if not isinstance(network, dict):
+                raise NetworkServiceError(404, "Network does not exist.")
+            config = network.get("config") or {}
+            cidr_value = config.get("cidr") if isinstance(config, dict) else None
+            if not cidr_value:
+                raise NetworkServiceError(
+                    422,
+                    "Network has no config.cidr; allocate_ip not applicable.",
+                    extra={"network_id": int(network_id)},
+                )
+            net = _validate_cidr(cidr_value)
+
+            runtime = network.setdefault("runtime", {})
+            used_raw = runtime.get("used_ips") or []
+            # Defensive: tolerate persisted garbage (None, non-string)
+            # and keep only addresses that parse and live in the CIDR.
+            used: set = set()
+            for entry in used_raw:
+                if not isinstance(entry, str):
+                    continue
+                try:
+                    addr = ipaddress.IPv4Address(entry)
+                except ValueError:
+                    continue
+                if addr in net:
+                    used.add(addr)
+
+            first_offset = int(runtime.get("first_offset") or DEFAULT_FIRST_OFFSET)
+            if first_offset < 1:
+                first_offset = 1
+            network_addr = net.network_address
+            broadcast_addr = net.broadcast_address
+            start_int = int(network_addr) + first_offset
+            end_int = int(broadcast_addr) - 1  # exclusive of broadcast
+
+            chosen: Optional[ipaddress.IPv4Address] = None
+            for candidate_int in range(start_int, end_int + 1):
+                candidate = ipaddress.IPv4Address(candidate_int)
+                if candidate in used:
+                    continue
+                chosen = candidate
+                break
+
+            if chosen is None:
+                raise NetworkServiceError(
+                    409,
+                    "subnet exhausted, please widen CIDR",
+                    extra={"network_id": int(network_id), "cidr": str(net)},
+                )
+
+            used.add(chosen)
+            runtime["used_ips"] = sorted(
+                (str(addr) for addr in used),
+                key=lambda s: int(ipaddress.IPv4Address(s)),
+            )
+            runtime.setdefault("first_offset", first_offset)
+            networks[str(network_id)] = network
+            data["networks"] = networks
+            data.pop("topology", None)
+            LabService.write_lab_json_static(normalized, data)
+
+        return str(chosen)
+
+    def _release_ip(self, lab_path: str, network_id: int, ip: str) -> bool:
+        """Remove ``ip`` from ``runtime.used_ips``; return True if removed.
+
+        No-op (returns False) when the network or IP is absent —
+        idempotent so detach paths can call this without a pre-check.
+        """
+        normalized = _normalize_relative_lab_path(lab_path)
+        labs_dir = get_settings().LABS_DIR
+
+        with lab_lock(normalized, labs_dir):
+            data = LabService.read_lab_json_static(normalized)
+            networks = data.get("networks", {}) or {}
+            network = networks.get(str(network_id))
+            if not isinstance(network, dict):
+                return False
+            runtime = network.get("runtime") or {}
+            used = list(runtime.get("used_ips") or [])
+            if ip not in used:
+                return False
+            used.remove(ip)
+            runtime["used_ips"] = sorted(
+                used,
+                key=lambda s: int(ipaddress.IPv4Address(s))
+                if _is_ipv4(s)
+                else 0,
+            )
+            network["runtime"] = runtime
+            networks[str(network_id)] = network
+            data["networks"] = networks
+            data.pop("topology", None)
+            LabService.write_lab_json_static(normalized, data)
+            return True
 
     async def patch_network(
         self,

--- a/backend/tests/test_network_service.py
+++ b/backend/tests/test_network_service.py
@@ -339,3 +339,222 @@ async def test_delete_network_tolerates_already_absent_bridge(
     # No exception — the network record is gone either way.
     removed = await NetworkService().delete_network(lab_name, 1)
     assert removed["id"] == 1
+
+
+# ---------------------------------------------------------------------------
+# US-204c — IPAM free-list (used_ips, NOT a counter)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_network_seeds_empty_used_ips_freelist(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """``runtime.used_ips`` and ``runtime.first_offset`` are persisted on
+    create_network. Empty list (NOT a counter) is the seed value per
+    plan §US-204c "IPAM data model (free-list, NOT a counter)"."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-seed-lab")
+
+    payload = await NetworkService().create_network(
+        lab_name, {"name": "lan", "config": {"cidr": "10.99.1.0/24"}}
+    )
+
+    assert payload["runtime"]["used_ips"] == []
+    assert payload["runtime"]["first_offset"] == 2
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"]["1"]["runtime"]["used_ips"] == []
+    assert saved["networks"]["1"]["runtime"]["first_offset"] == 2
+    assert saved["networks"]["1"]["config"]["cidr"] == "10.99.1.0/24"
+
+
+@pytest.mark.asyncio
+async def test_create_network_rejects_invalid_cidr(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """Invalid CIDR strings raise 422 BEFORE any kernel work happens."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-bad-cidr")
+
+    with pytest.raises(NetworkServiceError) as excinfo:
+        await NetworkService().create_network(
+            lab_name, {"name": "lan", "config": {"cidr": "not-a-cidr"}}
+        )
+    assert excinfo.value.code == 422
+    # No bridge work happened — validation gates BEFORE the lab lock.
+    assert helper_mocks["bridge_add"] == []
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"] == {}
+
+
+@pytest.mark.asyncio
+async def test_create_network_rejects_ipv6_cidr(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """IPv6 CIDRs raise 422 with the deferred-IPv6 §5 pointer."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-ipv6")
+
+    with pytest.raises(NetworkServiceError) as excinfo:
+        await NetworkService().create_network(
+            lab_name, {"name": "lan", "config": {"cidr": "fd00::/64"}}
+        )
+    assert excinfo.value.code == 422
+    assert "IPv6" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_allocate_ip_returns_lowest_free_address(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """Allocator picks the lowest-numbered free host IP (skipping .0
+    network and .1 reserved per ``first_offset=2``)."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-low")
+    await NetworkService().create_network(
+        lab_name, {"name": "lan", "config": {"cidr": "10.99.1.0/24"}}
+    )
+    svc = NetworkService()
+
+    first = svc._allocate_ip(lab_name, 1)
+    second = svc._allocate_ip(lab_name, 1)
+    third = svc._allocate_ip(lab_name, 1)
+
+    # first_offset=2 → first allocation is .2, then .3, then .4.
+    assert first == "10.99.1.2"
+    assert second == "10.99.1.3"
+    assert third == "10.99.1.4"
+
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"]["1"]["runtime"]["used_ips"] == [
+        "10.99.1.2",
+        "10.99.1.3",
+        "10.99.1.4",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_release_ip_makes_address_reusable(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """After release, the SAME address is the next allocation result —
+    proves the free-list does not leak (the bug a counter would have)."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-release")
+    await NetworkService().create_network(
+        lab_name, {"name": "lan", "config": {"cidr": "10.99.1.0/24"}}
+    )
+    svc = NetworkService()
+
+    a = svc._allocate_ip(lab_name, 1)  # .2
+    b = svc._allocate_ip(lab_name, 1)  # .3
+    assert a == "10.99.1.2" and b == "10.99.1.3"
+
+    # Release the lower one; next allocation must reuse it.
+    assert svc._release_ip(lab_name, 1, a) is True
+    next_alloc = svc._allocate_ip(lab_name, 1)
+    assert next_alloc == "10.99.1.2"
+
+    # Releasing an absent IP is a no-op (idempotent for detach paths).
+    assert svc._release_ip(lab_name, 1, "10.99.1.99") is False
+
+
+@pytest.mark.asyncio
+async def test_allocate_ip_thrashes_freelist_returns_to_baseline(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """50 attach/detach cycles leave ``used_ips`` empty — the very leak
+    a monotonic counter would create over /24 (250 cycles → exhausted)."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-thrash")
+    await NetworkService().create_network(
+        lab_name, {"name": "lan", "config": {"cidr": "10.99.1.0/24"}}
+    )
+    svc = NetworkService()
+
+    for _ in range(50):
+        ip = svc._allocate_ip(lab_name, 1)
+        assert svc._release_ip(lab_name, 1, ip) is True
+
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"]["1"]["runtime"]["used_ips"] == []
+
+
+@pytest.mark.asyncio
+async def test_allocate_ip_exhausts_small_cidr_with_typed_error(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """A /30 has hosts {.1, .2}; with first_offset=2 only .2 is usable —
+    second allocation raises 409 ``subnet exhausted``."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-exhaust")
+    await NetworkService().create_network(
+        lab_name, {"name": "lan", "config": {"cidr": "10.99.2.0/30"}}
+    )
+    svc = NetworkService()
+
+    only_addr = svc._allocate_ip(lab_name, 1)
+    assert only_addr == "10.99.2.2"
+
+    with pytest.raises(NetworkServiceError) as excinfo:
+        svc._allocate_ip(lab_name, 1)
+    assert excinfo.value.code == 409
+    assert "exhausted" in excinfo.value.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_allocate_ip_rejects_network_without_cidr(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """Networks without ``config.cidr`` are L2-only — calling
+    _allocate_ip raises 422 (caller should gate on cidr presence)."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-no-cidr")
+    # No config -> L2-only.
+    await NetworkService().create_network(lab_name, {"name": "lan"})
+    svc = NetworkService()
+
+    with pytest.raises(NetworkServiceError) as excinfo:
+        svc._allocate_ip(lab_name, 1)
+    assert excinfo.value.code == 422
+    assert "config.cidr" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_allocate_ip_persists_used_ips_into_lab_json(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """Each allocation writes ``used_ips`` to lab.json under the lab
+    flock — survives backend restart per plan §US-204c reconciliation."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-persist")
+    await NetworkService().create_network(
+        lab_name, {"name": "lan", "config": {"cidr": "10.99.3.0/29"}}
+    )
+    svc = NetworkService()
+
+    svc._allocate_ip(lab_name, 1)
+    svc._allocate_ip(lab_name, 1)
+
+    # Re-read directly from disk — no in-memory caching is allowed to
+    # mask a missing write.
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"]["1"]["runtime"]["used_ips"] == [
+        "10.99.3.2",
+        "10.99.3.3",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_allocate_ip_skips_externally_reserved_addresses(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """Pre-existing entries in ``used_ips`` are honoured — allocator
+    walks past them to the next free address, supporting reservations
+    written by reconciliation or import."""
+    lab_name = _seed_lab(labs_dir, lab_id="ipam-reserved")
+    await NetworkService().create_network(
+        lab_name, {"name": "lan", "config": {"cidr": "10.99.4.0/24"}}
+    )
+    # Manually pre-populate the free-list (e.g. backend-startup
+    # reconciliation re-baselining live container IPs).
+    raw = json.loads((labs_dir / lab_name).read_text())
+    raw["networks"]["1"]["runtime"]["used_ips"] = ["10.99.4.2", "10.99.4.3"]
+    (labs_dir / lab_name).write_text(json.dumps(raw))
+
+    svc = NetworkService()
+    chosen = svc._allocate_ip(lab_name, 1)
+
+    # First free is .4 — .2 and .3 were both reserved.
+    assert chosen == "10.99.4.4"


### PR DESCRIPTION
## Summary
- Adds the free-list IP allocator that pairs with US-204's L2 hot-attach: `network.runtime.used_ips: list[str]` (NOT a counter — counter allocation would exhaust a /24 in 250 cycles even with one container) plus `runtime.first_offset: int = 2` (skips .0 network and .1 gateway).
- New `NetworkService._allocate_ip(lab_path, network_id) -> str` and `_release_ip(lab_path, network_id, ip)` mutate the free-list under the per-lab `lab_lock` (IP application via `nsenter` is meant to run OUTSIDE the lock per plan §US-204c "Lock-hold-time discipline" — this PR provides the JSON-side primitive only).
- CIDR validated BEFORE the lab lock: invalid → 422, IPv6 → 422 with deferred-IPv6 §5 pointer, exhausted → 409 "subnet exhausted, please widen CIDR".
- Schema gains `NetworkConfig` (`cidr`/`gateway`/`dhcp`) and `NetworkRuntime` (`bridge_name`/`driver`/`used_ips`/`first_offset`); `NetworkBase` exposes `runtime`; `NetworkCreate` accepts an optional `config`.

## Test plan
- [x] `pytest tests/test_network_service.py` — 19 passed (10 new + 9 existing).
- [x] Full backend suite: 527 passed, 1 pre-existing unrelated failure (`test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error`, also fails on a clean `origin/main` checkout — not introduced by this PR).
- [x] New tests cover: lowest-free allocation, release-then-reuse, 50-cycle thrash returning to baseline, `/30` exhaustion → 409, persistence into `lab.json`, externally-reserved entries are honoured, no-CIDR network → 422, invalid/IPv6 CIDR rejected at create.
- [ ] Manual test-VM smoke (`docker exec ... ping ...`) deferred until US-205 wires `_release_ip` into the detach path.

Plan: `.omc/plans/network-runtime-wiring.md` §US-204c.

Refs #80
Closes #93