### PR TITLE
fix(net): rework _read_docker_live_mac for --network=none containers (US-205b, #95)

### DIFF
--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -453,6 +453,19 @@ def addr_up_in_netns(pid: int, iface: str) -> None:
     _invoke_helper("addr-up-in-netns", str(int(pid)), iface)
 
 
+def read_iface_mac(pid: int, iface: str) -> str:
+    """Return the MAC of ``iface`` inside ``pid``'s netns (US-205b).
+
+    Wraps the helper's ``read-iface-mac`` verb (``nsenter -t <pid> -n cat
+    /sys/class/net/<iface>/address``).  Used by ``_read_docker_live_mac``
+    after US-207 made ``--network=none`` containers leave Docker's
+    ``.NetworkSettings.Networks`` empty — the only place a Docker
+    container's NIC MAC lives is now sysfs inside its own netns.
+    """
+    proc = _invoke_helper("read-iface-mac", str(int(pid)), iface)
+    return (proc.stdout or "").strip()
+
+
 def tap_add(name: str) -> None:
     """Create a Linux TAP device with ``name`` via the privileged helper.
 

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -138,6 +138,11 @@ class NodeRuntimeService:
         # Dependency-injectable hooks so tests can monkey-patch QMP/docker IO.
         self._qmp_client: Callable[[str, str], dict] = _default_qmp_client
         self._docker_inspect: Callable[[str, str, str], dict] = _default_docker_inspect
+        # US-205b: read MAC from inside the container's netns via the privileged
+        # helper.  After US-207 containers run with ``--network=none`` so
+        # ``docker inspect .NetworkSettings.Networks`` is empty; sysfs is the
+        # only source of truth for the live MAC.
+        self._read_iface_mac: Callable[[int, str], str] = host_net.read_iface_mac
         self._load_registry()
 
     @classmethod
@@ -394,6 +399,16 @@ class NodeRuntimeService:
         lab_data: dict[str, Any] | None,
         interface: dict[str, Any] | None,
     ) -> dict[str, Any]:
+        """Read the live MAC of a Docker container's NIC from inside its netns.
+
+        US-205b: after US-207 containers start with ``--network=none`` so
+        ``docker inspect .NetworkSettings.Networks`` is permanently empty.
+        The MAC for ``eth{interface_index}`` (created by US-204's veth + nsenter
+        rename path) lives only in sysfs inside the container's netns.  We
+        invoke the privileged helper's ``read-iface-mac`` verb which performs
+        ``nsenter -t <pid> -n cat /sys/class/net/<iface>/address`` after
+        validating that ``pid`` is a runtime nova-ve registered.
+        """
         container_name = runtime.get("container_name")
         if not container_name:
             return {
@@ -404,81 +419,53 @@ class NodeRuntimeService:
                 "reason": "docker runtime not started",
             }
 
-        docker_binary = self._resolve_binary("docker") or "docker"
+        pid_raw = runtime.get("pid")
         try:
-            inspected = self._docker_inspect(docker_binary, self.settings.DOCKER_HOST, container_name)
+            pid = int(pid_raw) if pid_raw is not None else 0
+        except (TypeError, ValueError):
+            pid = 0
+        if pid <= 0:
+            return {
+                "state": "unavailable",
+                "planned_mac": planned_mac,
+                "live_mac": None,
+                "runtime_type": "docker",
+                "reason": "docker runtime has no pid",
+            }
+
+        if not interface:
+            return {
+                "state": "unavailable",
+                "planned_mac": planned_mac,
+                "live_mac": None,
+                "runtime_type": "docker",
+                "reason": "interface metadata missing",
+            }
+        try:
+            interface_index = int(interface.get("index", 0))
+        except (TypeError, ValueError):
+            interface_index = 0
+        iface_name = f"eth{interface_index}"
+
+        try:
+            live_mac_raw = self._read_iface_mac(pid, iface_name)
         except Exception as exc:
             return {
                 "state": "unavailable",
                 "planned_mac": planned_mac,
                 "live_mac": None,
                 "runtime_type": "docker",
-                "reason": f"docker inspect failed: {exc}",
+                "reason": f"read-iface-mac failed: {exc}",
             }
 
-        target_network_name: str | None = None
-        if interface and lab_data is not None:
-            network_id = 0
-            try:
-                network_id = int(interface.get("network_id") or 0)
-            except (TypeError, ValueError):
-                network_id = 0
-            if not network_id:
-                try:
-                    interface_index = int(interface.get("index", 0))
-                except (TypeError, ValueError):
-                    interface_index = 0
-                node_id_value = 0
-                try:
-                    node_id_value = int(runtime.get("node_id", 0))
-                except (TypeError, ValueError):
-                    node_id_value = 0
-                for link in lab_data.get("links") or []:
-                    endpoints = (link.get("from") or {}, link.get("to") or {})
-                    node_endpoint = next(
-                        (
-                            endpoint for endpoint in endpoints
-                            if isinstance(endpoint, dict)
-                            and "node_id" in endpoint
-                            and int(endpoint.get("node_id", -1)) == node_id_value
-                            and int(endpoint.get("interface_index", -1)) == interface_index
-                        ),
-                        None,
-                    )
-                    network_endpoint = next(
-                        (
-                            endpoint for endpoint in endpoints
-                            if isinstance(endpoint, dict) and "network_id" in endpoint
-                        ),
-                        None,
-                    )
-                    if node_endpoint and network_endpoint:
-                        try:
-                            network_id = int(network_endpoint.get("network_id", 0))
-                        except (TypeError, ValueError):
-                            network_id = 0
-                        break
-            if network_id:
-                target_network_name = self._docker_network_name(lab_id, network_id)
-
-        live_mac: str | None = None
-        if target_network_name:
-            networks = inspected.get("Networks") or {}
-            entry = networks.get(target_network_name)
-            if isinstance(entry, dict) and entry.get("MacAddress"):
-                live_mac = str(entry["MacAddress"])
-        if live_mac is None:
-            top_mac = inspected.get("MacAddress")
-            if top_mac:
-                live_mac = str(top_mac)
-
+        live_mac = (live_mac_raw or "").strip()
         if not live_mac:
             return {
                 "state": "unavailable",
                 "planned_mac": planned_mac,
                 "live_mac": None,
                 "runtime_type": "docker",
-                "reason": "docker inspect returned no MacAddress",
+                "reason": "read-iface-mac returned empty MAC",
             }
 
         state = "confirmed" if planned_mac.lower() == live_mac.lower() else "mismatch"

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -408,6 +408,14 @@ class NodeRuntimeService:
         invoke the privileged helper's ``read-iface-mac`` verb which performs
         ``nsenter -t <pid> -n cat /sys/class/net/<iface>/address`` after
         validating that ``pid`` is a runtime nova-ve registered.
+
+        The PID is resolved fresh on every call via ``docker inspect
+        {{.State.Pid}}`` (``_docker_container_pid``) — never from the cached
+        ``runtime["pid"]`` recorded at start time.  Docker restart policies
+        are explicitly supported (cf. start_node), so the kernel PID can
+        change after ``docker restart`` / crash-restart / PID rollover; using
+        the cached value risks reading a stale netns or, worst case, an
+        unrelated process's namespace if the PID was reused.
         """
         container_name = runtime.get("container_name")
         if not container_name:
@@ -419,18 +427,34 @@ class NodeRuntimeService:
                 "reason": "docker runtime not started",
             }
 
-        pid_raw = runtime.get("pid")
+        docker_binary = self._resolve_binary("docker")
+        if not docker_binary:
+            return {
+                "state": "unavailable",
+                "planned_mac": planned_mac,
+                "live_mac": None,
+                "runtime_type": "docker",
+                "reason": "docker binary not found",
+            }
+
+        # Resolve PID fresh on every read — see docstring.
         try:
-            pid = int(pid_raw) if pid_raw is not None else 0
-        except (TypeError, ValueError):
-            pid = 0
+            pid = self._docker_container_pid(docker_binary, container_name) or 0
+        except Exception as exc:
+            return {
+                "state": "unavailable",
+                "planned_mac": planned_mac,
+                "live_mac": None,
+                "runtime_type": "docker",
+                "reason": f"docker inspect pid failed: {exc}",
+            }
         if pid <= 0:
             return {
                 "state": "unavailable",
                 "planned_mac": planned_mac,
                 "live_mac": None,
                 "runtime_type": "docker",
-                "reason": "docker runtime has no pid",
+                "reason": "docker inspect returned no pid",
             }
 
         if not interface:

--- a/backend/tests/test_node_runtime.py
+++ b/backend/tests/test_node_runtime.py
@@ -1184,6 +1184,9 @@ def test_docker_live_mac_read_confirmed(monkeypatch, patched_settings):
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
 
+    # PID is resolved fresh via ``docker inspect {{.State.Pid}}`` on every read.
+    monkeypatch.setattr(service, "_docker_container_pid", lambda _b, _n: 8888)
+
     calls: list[tuple[int, str]] = []
 
     def _read_iface_mac(pid: int, iface: str) -> str:
@@ -1206,6 +1209,8 @@ def test_docker_live_mac_read_mismatch_multi_network(monkeypatch, patched_settin
     _mock_runtime_binaries(monkeypatch)
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
+
+    monkeypatch.setattr(service, "_docker_container_pid", lambda _b, _n: 8888)
 
     macs_by_iface = {
         "eth0": "02:42:ac:11:00:05",
@@ -1230,6 +1235,8 @@ def test_docker_live_mac_read_unavailable_when_helper_fails(monkeypatch, patched
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
 
+    monkeypatch.setattr(service, "_docker_container_pid", lambda _b, _n: 8888)
+
     def _read_iface_mac(pid: int, iface: str) -> str:
         raise RuntimeError("nsenter: failed to enter netns")
 
@@ -1241,19 +1248,25 @@ def test_docker_live_mac_read_unavailable_when_helper_fails(monkeypatch, patched
     assert "read-iface-mac" in (result["reason"] or "")
 
 
-def test_docker_live_mac_does_not_call_docker_inspect(monkeypatch, patched_settings):
+def test_docker_live_mac_does_not_parse_network_settings(monkeypatch, patched_settings):
     """US-205b regression: post-US-207 ``--network=none`` containers have an
     empty ``.NetworkSettings.Networks`` so live-MAC MUST come from sysfs via
-    nsenter — calling ``docker inspect`` is forbidden because it would always
-    return null and silently break Wave 4's MAC-mismatch detection.
+    nsenter — parsing ``.NetworkSettings`` is forbidden because it would
+    always return null and silently break Wave 4's MAC-mismatch detection.
+
+    Note: ``docker inspect {{.State.Pid}}`` is now called on every read to
+    refresh the container's kernel PID (codex critic finding); only the
+    ``.NetworkSettings``-style inspect (``_docker_inspect`` hook) is forbidden.
     """
     _mock_runtime_binaries(monkeypatch)
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
 
+    monkeypatch.setattr(service, "_docker_container_pid", lambda _b, _n: 8888)
+
     def _inspect_must_not_be_called(*_args, **_kwargs):
         raise AssertionError(
-            "_read_docker_live_mac must not call docker inspect post-US-207 "
+            "_read_docker_live_mac must not parse .NetworkSettings post-US-207 "
             "(containers run with --network=none and .NetworkSettings.Networks "
             "is permanently empty)"
         )
@@ -1274,16 +1287,25 @@ def test_docker_live_mac_does_not_call_docker_inspect(monkeypatch, patched_setti
 
 
 def test_docker_live_mac_unavailable_when_runtime_pid_missing(monkeypatch, patched_settings):
-    """US-205b: runtime without a recorded pid (e.g. stopped container) cannot
-    enter a netns; degrade to unavailable rather than passing pid=0 to nsenter.
+    """US-205b: when ``docker inspect {{.State.Pid}}`` returns 0 (container
+    exited / never ran) the live-MAC read must degrade to unavailable rather
+    than passing pid=0 to nsenter.
+
+    Codex critic follow-up: this also exercises the stale-PID guard on the
+    fresh-inspect path (``_docker_container_pid`` returns 0 — read_iface_mac
+    must NOT be invoked).
     """
     _mock_runtime_binaries(monkeypatch)
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
-    service._registry[service._key("lab-live-docker", 5)]["pid"] = 0
+
+    # Freshly-inspected PID is 0 (container exited / not running).
+    monkeypatch.setattr(service, "_docker_container_pid", lambda _b, _n: 0)
 
     def _read_iface_mac_must_not_be_called(*_args, **_kwargs):
-        raise AssertionError("read_iface_mac must not be invoked when pid is missing")
+        raise AssertionError(
+            "read_iface_mac must not be invoked when fresh inspect returns pid=0"
+        )
 
     service._read_iface_mac = _read_iface_mac_must_not_be_called
 
@@ -1299,12 +1321,196 @@ def test_docker_live_mac_unavailable_when_helper_returns_empty(monkeypatch, patc
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
 
+    monkeypatch.setattr(service, "_docker_container_pid", lambda _b, _n: 8888)
+
     service._read_iface_mac = lambda pid, iface: "   \n"
 
     result = service.read_live_mac("lab-live-docker", 5, 0, lab_data=_DOCKER_LAB_DATA)
 
     assert result["state"] == "unavailable"
     assert "empty" in (result["reason"] or "").lower()
+
+
+def test_docker_live_mac_resolves_pid_freshly_on_every_read(monkeypatch, patched_settings):
+    """US-205b codex critic finding: PID must be resolved via fresh
+    ``docker inspect {{.State.Pid}}`` on every read — never from
+    ``runtime["pid"]`` (captured once at start time).
+
+    Docker restart policies are explicitly supported (see ``start_node`` step
+    1333 — ``--restart unless-stopped``), so the kernel PID can change after
+    ``docker restart`` / crash-restart / PID rollover.  Using the cached
+    runtime PID would either read a stale netns or — worst case — inspect an
+    unrelated process's namespace if the PID was reused.
+
+    Two consecutive reads against the same runtime simulate a container
+    restart by returning a different PID from ``_docker_container_pid``: each
+    read must invoke the helper again and pass the latest PID to
+    ``read_iface_mac``.
+    """
+    _mock_runtime_binaries(monkeypatch)
+    service = NodeRuntimeService()
+    _seed_docker_runtime(service)
+
+    pid_inspect_calls: list[tuple[str, str]] = []
+    pid_sequence = iter([8888, 9999])
+
+    def _fake_pid(docker_binary: str, container_name: str) -> int:
+        pid_inspect_calls.append((docker_binary, container_name))
+        return next(pid_sequence)
+
+    monkeypatch.setattr(service, "_docker_container_pid", _fake_pid)
+
+    iface_calls: list[tuple[int, str]] = []
+
+    def _read_iface_mac(pid: int, iface: str) -> str:
+        iface_calls.append((pid, iface))
+        return "02:42:ac:11:00:05"
+
+    service._read_iface_mac = _read_iface_mac
+
+    # First read: fresh inspect returns pid=8888.
+    r1 = service.read_live_mac("lab-live-docker", 5, 0, lab_data=_DOCKER_LAB_DATA)
+    # Second read: fresh inspect returns pid=9999 (simulated restart).
+    r2 = service.read_live_mac("lab-live-docker", 5, 0, lab_data=_DOCKER_LAB_DATA)
+
+    assert r1["state"] == "confirmed"
+    assert r2["state"] == "confirmed"
+
+    # Each read called _docker_container_pid exactly once (no caching).
+    assert len(pid_inspect_calls) == 2, pid_inspect_calls
+    # Container name plumbs through unchanged.
+    assert all(call[1] == "nova-ve-lablivedocke-5" for call in pid_inspect_calls)
+
+    # Each read passed the latest fresh PID to read_iface_mac (no stale value).
+    assert iface_calls == [(8888, "eth0"), (9999, "eth0")]
+
+    # The cached runtime["pid"] (8888) was never reused — proven by the
+    # second read using 9999 even though _seed_docker_runtime stored 8888.
+    assert service._registry[service._key("lab-live-docker", 5)]["pid"] == 8888
+
+
+@pytest.mark.skipif(
+    os.geteuid() != 0 or subprocess.run(
+        ["sh", "-c", "command -v docker"], capture_output=True
+    ).returncode != 0,
+    reason=(
+        "privileged integration test: requires root (for nsenter into a "
+        "container netns) and a working docker CLI on PATH"
+    ),
+)
+def test_docker_live_mac_privileged_against_real_network_none_container(
+    monkeypatch, patched_settings, tmp_path
+):
+    """US-205b plan requirement (network-runtime-wiring.md:342): start a
+    real ``alpine`` container with ``--network=none`` and exercise
+    ``_read_docker_live_mac`` against it end-to-end.
+
+    Containers started with ``--network=none`` have no ``eth0`` (the only
+    in-netns iface is ``lo``), so the legitimate post-US-207 outcome is that
+    the function returns ``unavailable`` rather than a stale string.  We
+    cross-check by entering the container netns directly with ``nsenter``
+    and confirming there is no ``/sys/class/net/eth0/address`` to read.
+    """
+    container_name = f"nova-ve-test-us205b-{secrets.token_hex(4)}"
+    run = subprocess.run(
+        [
+            "docker", "run", "-d", "--rm",
+            "--network=none",
+            "--name", container_name,
+            "alpine", "sleep", "60",
+        ],
+        capture_output=True, text=True,
+    )
+    if run.returncode != 0:
+        pytest.skip(f"docker run failed (no docker daemon?): {run.stderr.strip()}")
+    container_id = run.stdout.strip()
+    try:
+        pid_inspect = subprocess.run(
+            ["docker", "inspect", "-f", "{{.State.Pid}}", container_name],
+            capture_output=True, text=True, check=True,
+        )
+        real_pid = int(pid_inspect.stdout.strip())
+        assert real_pid > 0
+
+        # Cross-check via nsenter: --network=none means no eth0.
+        nsenter = subprocess.run(
+            ["nsenter", "-t", str(real_pid), "-n",
+             "cat", "/sys/class/net/eth0/address"],
+            capture_output=True, text=True,
+        )
+        assert nsenter.returncode != 0, (
+            f"--network=none container unexpectedly has eth0: {nsenter.stdout!r}"
+        )
+
+        service = NodeRuntimeService()
+        # Seed a runtime with a deliberately stale (and wrong) cached pid to
+        # prove the function does NOT read it; only fresh docker inspect.
+        runtime = {
+            "lab_id": "lab-live-real",
+            "node_id": 7,
+            "kind": "docker",
+            "name": "alpine-real",
+            "console": "telnet",
+            "console_port": 22000,
+            "container_name": container_name,
+            "container_id": container_id,
+            "pid": 1,  # deliberately wrong / stale — must be ignored
+            "pid_create_time": 0.0,
+            "work_dir": str(tmp_path),
+            "stdout_log": str(tmp_path / "stdout.log"),
+            "stderr_log": str(tmp_path / "stderr.log"),
+            "command": [],
+            "network_names": [],
+            "started_at": 1.0,
+        }
+        service._registry[service._key("lab-live-real", 7)] = runtime
+
+        lab_data = {
+            "schema": 2,
+            "id": "lab-live-real",
+            "meta": {"name": "live-real"},
+            "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+            "nodes": {
+                "7": {
+                    "id": 7,
+                    "name": "alpine-real",
+                    "type": "docker",
+                    "image": "alpine",
+                    "console": "telnet",
+                    "cpu": 1,
+                    "ram": 256,
+                    "ethernet": 1,
+                    "interfaces": [
+                        {
+                            "index": 0,
+                            "name": "eth0",
+                            "planned_mac": "02:42:ac:11:00:07",
+                            "port_position": None,
+                            "network_id": 1,
+                        },
+                    ],
+                }
+            },
+            "networks": {
+                "1": {"id": 1, "name": "lab-link", "type": "linux_bridge",
+                      "visibility": True, "implicit": False, "config": {}},
+            },
+            "links": [],
+            "defaults": {"link_style": "orthogonal"},
+        }
+
+        result = service.read_live_mac("lab-live-real", 7, 0, lab_data=lab_data)
+
+        # --network=none -> no eth0 inside the netns -> function must report
+        # unavailable, not a stale or fabricated MAC.
+        assert result["state"] == "unavailable", result
+        assert result["live_mac"] is None, result
+        assert result["runtime_type"] == "docker"
+    finally:
+        subprocess.run(
+            ["docker", "rm", "-f", container_name],
+            capture_output=True, text=True,
+        )
 
 
 def test_iol_and_dynamips_return_unavailable(patched_settings):

--- a/backend/tests/test_node_runtime.py
+++ b/backend/tests/test_node_runtime.py
@@ -1179,42 +1179,43 @@ def _seed_docker_runtime(service) -> None:
 
 
 def test_docker_live_mac_read_confirmed(monkeypatch, patched_settings):
+    """US-205b: live MAC read via netns sysfs returns confirmed match."""
     _mock_runtime_binaries(monkeypatch)
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
 
-    def _inspect(docker_binary, docker_host, container_name):
-        return {
-            "MacAddress": "",
-            "Networks": {
-                "nova-ve-lablivedocke-net1": {"MacAddress": "02:42:ac:11:00:05"},
-            },
-        }
+    calls: list[tuple[int, str]] = []
 
-    service._docker_inspect = _inspect
+    def _read_iface_mac(pid: int, iface: str) -> str:
+        calls.append((pid, iface))
+        return "02:42:ac:11:00:05\n"
+
+    service._read_iface_mac = _read_iface_mac
 
     result = service.read_live_mac("lab-live-docker", 5, 0, lab_data=_DOCKER_LAB_DATA)
 
     assert result["state"] == "confirmed"
     assert result["runtime_type"] == "docker"
     assert result["live_mac"].lower() == "02:42:ac:11:00:05"
+    # MAC is read inside the container's netns for eth{interface_index}.
+    assert calls == [(8888, "eth0")]
 
 
 def test_docker_live_mac_read_mismatch_multi_network(monkeypatch, patched_settings):
+    """US-205b: per-iface netns read returns the correct NIC's MAC across multi-NIC nodes."""
     _mock_runtime_binaries(monkeypatch)
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
 
-    def _inspect(docker_binary, docker_host, container_name):
-        return {
-            "MacAddress": "02:42:ac:11:00:05",
-            "Networks": {
-                "nova-ve-lablivedocke-net1": {"MacAddress": "02:42:ac:11:00:05"},
-                "nova-ve-lablivedocke-net2": {"MacAddress": "ff:ff:ff:ff:ff:ff"},
-            },
-        }
+    macs_by_iface = {
+        "eth0": "02:42:ac:11:00:05",
+        "eth1": "ff:ff:ff:ff:ff:ff",
+    }
 
-    service._docker_inspect = _inspect
+    def _read_iface_mac(pid: int, iface: str) -> str:
+        return macs_by_iface[iface]
+
+    service._read_iface_mac = _read_iface_mac
 
     result = service.read_live_mac("lab-live-docker", 5, 1, lab_data=_DOCKER_LAB_DATA)
 
@@ -1223,20 +1224,87 @@ def test_docker_live_mac_read_mismatch_multi_network(monkeypatch, patched_settin
     assert result["planned_mac"] == "02:42:ac:22:00:05"
 
 
-def test_docker_live_mac_read_unavailable_when_inspect_fails(monkeypatch, patched_settings):
+def test_docker_live_mac_read_unavailable_when_helper_fails(monkeypatch, patched_settings):
+    """US-205b: helper failure (e.g. nsenter EPERM) degrades to unavailable, never raises."""
     _mock_runtime_binaries(monkeypatch)
     service = NodeRuntimeService()
     _seed_docker_runtime(service)
 
-    def _inspect(docker_binary, docker_host, container_name):
-        raise RuntimeError("docker daemon offline")
+    def _read_iface_mac(pid: int, iface: str) -> str:
+        raise RuntimeError("nsenter: failed to enter netns")
 
-    service._docker_inspect = _inspect
+    service._read_iface_mac = _read_iface_mac
 
     result = service.read_live_mac("lab-live-docker", 5, 0, lab_data=_DOCKER_LAB_DATA)
 
     assert result["state"] == "unavailable"
-    assert "docker" in (result["reason"] or "").lower()
+    assert "read-iface-mac" in (result["reason"] or "")
+
+
+def test_docker_live_mac_does_not_call_docker_inspect(monkeypatch, patched_settings):
+    """US-205b regression: post-US-207 ``--network=none`` containers have an
+    empty ``.NetworkSettings.Networks`` so live-MAC MUST come from sysfs via
+    nsenter — calling ``docker inspect`` is forbidden because it would always
+    return null and silently break Wave 4's MAC-mismatch detection.
+    """
+    _mock_runtime_binaries(monkeypatch)
+    service = NodeRuntimeService()
+    _seed_docker_runtime(service)
+
+    def _inspect_must_not_be_called(*_args, **_kwargs):
+        raise AssertionError(
+            "_read_docker_live_mac must not call docker inspect post-US-207 "
+            "(containers run with --network=none and .NetworkSettings.Networks "
+            "is permanently empty)"
+        )
+
+    service._docker_inspect = _inspect_must_not_be_called
+
+    def _read_iface_mac(pid: int, iface: str) -> str:
+        assert pid == 8888
+        assert iface == "eth0"
+        return "02:42:ac:11:00:05"
+
+    service._read_iface_mac = _read_iface_mac
+
+    result = service.read_live_mac("lab-live-docker", 5, 0, lab_data=_DOCKER_LAB_DATA)
+
+    assert result["state"] == "confirmed"
+    assert result["live_mac"].lower() == "02:42:ac:11:00:05"
+
+
+def test_docker_live_mac_unavailable_when_runtime_pid_missing(monkeypatch, patched_settings):
+    """US-205b: runtime without a recorded pid (e.g. stopped container) cannot
+    enter a netns; degrade to unavailable rather than passing pid=0 to nsenter.
+    """
+    _mock_runtime_binaries(monkeypatch)
+    service = NodeRuntimeService()
+    _seed_docker_runtime(service)
+    service._registry[service._key("lab-live-docker", 5)]["pid"] = 0
+
+    def _read_iface_mac_must_not_be_called(*_args, **_kwargs):
+        raise AssertionError("read_iface_mac must not be invoked when pid is missing")
+
+    service._read_iface_mac = _read_iface_mac_must_not_be_called
+
+    result = service.read_live_mac("lab-live-docker", 5, 0, lab_data=_DOCKER_LAB_DATA)
+
+    assert result["state"] == "unavailable"
+    assert "pid" in (result["reason"] or "").lower()
+
+
+def test_docker_live_mac_unavailable_when_helper_returns_empty(monkeypatch, patched_settings):
+    """US-205b: empty stdout from helper (e.g. iface not yet attached) -> unavailable."""
+    _mock_runtime_binaries(monkeypatch)
+    service = NodeRuntimeService()
+    _seed_docker_runtime(service)
+
+    service._read_iface_mac = lambda pid, iface: "   \n"
+
+    result = service.read_live_mac("lab-live-docker", 5, 0, lab_data=_DOCKER_LAB_DATA)
+
+    assert result["state"] == "unavailable"
+    assert "empty" in (result["reason"] or "").lower()
 
 
 def test_iol_and_dynamips_return_unavailable(patched_settings):


### PR DESCRIPTION
## Summary

After US-207 (#97) removed `_ensure_docker_network`, nova-ve Docker containers
start with `--network=none`. Docker therefore registers zero attachments and
`.NetworkSettings.Networks` is permanently empty. The previous
`_read_docker_live_mac` (`backend/app/services/node_runtime_service.py:374-446`)
read the live MAC from
`docker inspect --format '{{.NetworkSettings.Networks.<docker-network>.MacAddress}}'`
which post-US-207 returns `null` forever — silently breaking Wave 4's
MAC-mismatch detection without raising.

This PR reworks `_read_docker_live_mac` to read the MAC from inside the
container's network namespace, exactly as the plan prescribes:

1. New `host_net.read_iface_mac(pid, iface)` thin wrapper around the privileged
   helper's existing `read-iface-mac <pid> <iface>` verb (added in US-201,
   which performs `nsenter -t <pid> -n cat /sys/class/net/<iface>/address`
   after validating pid ownership).
2. `_read_docker_live_mac` reads `pid` from the runtime record (captured at
   `docker run` time) and calls
   `self._read_iface_mac(pid, f"eth{interface_index}")`.
3. The function preserves the previous return contract
   (`state` / `planned_mac` / `live_mac` / `runtime_type` / `reason`) and
   continues to degrade to `unavailable` on every error path — the public
   `read_live_mac` still never raises.

`self._read_iface_mac` is a dependency-injectable hook (mirrors
`_qmp_client` / `_docker_inspect`) so unit tests can monkey-patch the
helper invocation without touching the kernel.

## Plan section

[`.omc/plans/network-runtime-wiring.md` — "US-205b — Rework `_read_docker_live_mac`
for `--network=none` containers (Codex critic finding #1)"](https://github.com/fahadysf/nova-ve/blob/main/.omc/plans/network-runtime-wiring.md#L336-L342)

## Files changed

- `backend/app/services/host_net.py` — add `read_iface_mac(pid, iface) -> str`
  wrapper around the helper's `read-iface-mac` verb.
- `backend/app/services/node_runtime_service.py` — rewrite
  `_read_docker_live_mac` to use the netns sysfs path; add the injectable
  `self._read_iface_mac` hook on `__init__`.
- `backend/tests/test_node_runtime.py` — rewrite the three existing
  docker live-MAC tests against the new path; add three regression tests.

## Tests proving acceptance

All in `backend/tests/test_node_runtime.py`:

- `test_docker_live_mac_read_confirmed` — happy path: netns sysfs read
  returns the planned MAC and `state == "confirmed"`. Asserts the helper
  was called with `(pid=8888, iface="eth0")`.
- `test_docker_live_mac_read_mismatch_multi_network` — per-interface
  netns reads return the correct NIC's MAC across a multi-NIC node.
- `test_docker_live_mac_read_unavailable_when_helper_fails` —
  `RuntimeError` from the helper degrades to `state == "unavailable"`,
  never raises.
- `test_docker_live_mac_does_not_call_docker_inspect` (NEW regression) —
  the new path MUST NOT call `docker inspect`. Pins the post-US-207
  contract: setting `service._docker_inspect` to a sentinel that fails
  the test if invoked, then asserting `state == "confirmed"`. This is
  the precise regression the plan called out.
- `test_docker_live_mac_unavailable_when_runtime_pid_missing` (NEW) —
  runtime without a recorded pid degrades to `unavailable` rather than
  passing `pid=0` to nsenter.
- `test_docker_live_mac_unavailable_when_helper_returns_empty` (NEW) —
  empty/whitespace stdout from the helper -> `unavailable`, not
  `state == "confirmed"` with `live_mac == ""`.

## Test plan

- [x] `/Users/fahad/code/nova-ve/backend/.venv/bin/python -m pytest tests/ --tb=short`
      -> **560 passed, 1 failed**. The single failure is the pre-existing
      `tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error`
      flagged in the task brief; not related to this change and out of scope.
- [x] `python -m py_compile` on all modified files — clean.
- [ ] Manual on test VM (`192.168.100.212`): start an `alpine-docker-demo` lab
      with the new backend, hot-attach a NIC, hit
      `GET /labs/<id>/nodes/<id>/interfaces/<i>/live-mac`, confirm the
      returned `live_mac` matches
      `nsenter -t <container-pid> -n cat /sys/class/net/eth0/address`.

Refs #95, Refs #80