### PR TITLE
feat(net): hot-detach Docker on links[] delete with IPAM release (US-205, #94)

### DIFF
--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -756,13 +756,82 @@ class LinkService:
         Returns ``(already_deleted_or_succeeded, deleted_implicit_network)``.
         ``deleted_implicit_network`` is None unless an implicit network's
         refcount dropped to 0 and it was GC'd in the same step.
+
+        US-205 / US-204b: mirror of ``create_link`` for hot-detach. We
+        acquire the per-``(lab, node, iface)`` runtime mutex BEFORE entering
+        ``lab_lock`` for every node-side endpoint of the link being deleted,
+        then call :meth:`NodeRuntimeService._detach_docker_interface_locked`
+        with the link's ``runtime.attach_generation`` as
+        ``expected_generation`` so a stale rollback never tears down a fresh
+        re-attach. The kernel-side veth removal runs OUTSIDE the lab_lock.
         """
         normalized = _normalize_relative_lab_path(lab_path)
         labs_dir = get_settings().LABS_DIR
 
+        # US-205 / US-204b: probe for the link's node-side endpoints before
+        # we take any lock so we know which mutex keys to acquire.  Reading
+        # outside lab_lock is safe — the actual mutation happens under
+        # lab_lock below.  Worst case: we acquire one extra mutex if the
+        # link disappears between probe and lock.
+        probe = LabService.read_lab_json_static(normalized)
+        target_link_probe: Optional[dict] = None
+        for lnk in (probe.get("links", []) or []):
+            if str(lnk.get("id")) == str(link_id):
+                target_link_probe = lnk
+                break
+        if target_link_probe is None:
+            return True, None
+
+        node_keys: List[Tuple[int, int]] = []
+        for ep in (target_link_probe.get("from"), target_link_probe.get("to")):
+            if isinstance(ep, dict) and "node_id" in ep:
+                try:
+                    node_keys.append(
+                        (int(ep["node_id"]), int(ep.get("interface_index", 0)))
+                    )
+                except (TypeError, ValueError):
+                    continue
+        # Deterministic acquisition order prevents deadlocks (symmetric
+        # with create_link).
+        node_keys.sort()
+
+        # Use the same lab_id resolution as create_link / _hot_attach_running_endpoints:
+        # prefer the JSON ``id`` field so the mutex key matches what the runtime
+        # service uses (it keys records by lab_id = str(lab_data["id"] or path)).
+        mutex_lab_id = str(probe.get("id") or normalized)
+
+        async with AsyncExitStack() as stack:
+            for node_id, interface_index in node_keys:
+                await stack.enter_async_context(
+                    runtime_mutex.acquire(mutex_lab_id, node_id, interface_index)
+                )
+            return await self._delete_link_locked(
+                normalized=normalized,
+                labs_dir=labs_dir,
+                link_id=link_id,
+                mutex_lab_id=mutex_lab_id,
+            )
+
+    async def _delete_link_locked(
+        self,
+        *,
+        normalized: str,
+        labs_dir,
+        link_id: str,
+        mutex_lab_id: str,
+    ) -> Tuple[bool, Optional[dict]]:
+        """Per-iface mutex(es) ARE held by the caller (US-205 / US-204b).
+
+        Runs the lab_lock-bounded mutation then hot-detaches any running
+        Docker container whose interface was removed.
+        """
         ws_events: List[Tuple[str, dict]] = []
         deleted_implicit: Optional[dict] = None
-        already_deleted = False
+
+        # Captured under lab_lock for the post-lock hot-detach pass:
+        # list of (node_id, interface_index, attach_generation).
+        detach_targets: List[Tuple[int, int, int]] = []
+        lab_id_for_detach: Optional[str] = None
 
         with lab_lock(normalized, labs_dir):
             data = LabService.read_lab_json_static(normalized)
@@ -796,17 +865,88 @@ class LinkService:
                     deleted_implicit = dict(network_record)
                     ws_events.append(("network_deleted", {"network": dict(network_record)}))
 
+            # US-205: capture generation token + release IPAM under lab_lock
+            # so the IP removal lands atomically with the link deletion.
+            removed_runtime = removed_link.get("runtime") or {}
+            attach_generation = int(removed_runtime.get("attach_generation", 0))
+            removed_ip: Optional[str] = removed_runtime.get("ip")  # type: ignore[assignment]
+
+            node_eps: List[Tuple[int, int]] = []
+            network_ep_ids: List[int] = []
+            for ep in (removed_link.get("from"), removed_link.get("to")):
+                if not isinstance(ep, dict):
+                    continue
+                if "node_id" in ep:
+                    try:
+                        node_eps.append(
+                            (int(ep["node_id"]), int(ep.get("interface_index", 0)))
+                        )
+                    except (TypeError, ValueError):
+                        continue
+                elif "network_id" in ep:
+                    try:
+                        network_ep_ids.append(int(ep["network_id"]))
+                    except (TypeError, ValueError):
+                        continue
+
+            if node_eps and network_ep_ids:
+                paired_net_id = network_ep_ids[0]
+                # US-205 IPAM release (Codex critic v4 defect #6):
+                # remove the IP from used_ips when US-204c has populated it.
+                # Until US-204c ships, removed_ip is None and this is a no-op.
+                if isinstance(removed_ip, str) and removed_ip:
+                    net_rec = networks.get(str(paired_net_id))
+                    if isinstance(net_rec, dict):
+                        net_rt = net_rec.setdefault("runtime", {})
+                        used = list(net_rt.get("used_ips") or [])
+                        if removed_ip in used:
+                            used.remove(removed_ip)
+                            net_rt["used_ips"] = used
+
+                for node_id, iface_idx in node_eps:
+                    detach_targets.append((int(node_id), int(iface_idx), attach_generation))
+
             data["networks"] = networks
             data.pop("topology", None)
             LabService.write_lab_json_static(normalized, data)
             _recompute_mac_registry(normalized, data)
+            lab_id_for_detach = str(data.get("id") or normalized)
 
             ws_events.append(("link_deleted", {"link_id": str(link_id)}))
+
+        # ------------------------------------------------------------------
+        # US-205 hot-detach pass — outside lab_lock, inside per-iface mutex.
+        # The generation-token check inside _detach_docker_interface_locked
+        # ensures a stale delete_link never tears down a fresh re-attach.
+        # ------------------------------------------------------------------
+        if detach_targets and lab_id_for_detach is not None:
+            from app.services.node_runtime_service import NodeRuntimeService  # noqa: WPS433
+
+            runtime_service = NodeRuntimeService()
+            for node_id, iface_idx, expected_gen in detach_targets:
+                # Both the runtime-record lookup and the locked helper call
+                # use mutex_lab_id — the same key passed to runtime_mutex.acquire()
+                # above so the is_held() defensive assert in the locked helper
+                # matches the outer acquire.
+                runtime = runtime_service._runtime_record(
+                    mutex_lab_id, node_id, include_stopped=True
+                )
+                if runtime is None:
+                    continue
+                if runtime.get("kind") != "docker":
+                    # QEMU hot-detach is US-303.
+                    continue
+                runtime_service._detach_docker_interface_locked(
+                    mutex_lab_id,
+                    int(node_id),
+                    int(iface_idx),
+                    expected_generation=int(expected_gen) if expected_gen else None,
+                )
 
         for event_type, payload in ws_events:
             await ws_hub.publish(normalized, event_type, payload)
 
-        return already_deleted, deleted_implicit
+        return False, deleted_implicit
 
     async def patch_link(self, lab_path: str, link_id: str, patch: Dict[str, Any]) -> Optional[dict]:
         normalized = _normalize_relative_lab_path(lab_path)

--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -165,6 +165,28 @@ def _recompute_mac_registry(lab_id: str, lab_data: dict) -> None:
         return
 
 
+def _runtime_mutex_lab_id(lab_data: Optional[dict], normalized: str) -> str:
+    """Return the canonical mutex key for ``(lab, node, iface)`` ordering.
+
+    Codex critic v2 HIGH #1: ``create_link`` and ``delete_link`` MUST agree on
+    the same mutex key for any given lab — otherwise concurrent attach +
+    detach on the same interface would acquire DIFFERENT mutex instances and
+    race. We resolve to ``str(lab_data["id"] or normalized)`` to mirror the
+    runtime service's own keying (``NodeRuntimeService._runtime_record`` keys
+    by ``lab_id`` which is the JSON ``id`` field — see
+    ``_attach_docker_interface_locked``'s
+    ``runtime_mutex.is_held(lab_id, ...)`` defensive assert). When ``lab_data``
+    is None (e.g. before the lab.json has been read) we fall back to the
+    path-derived ``normalized`` key — concurrent callers in this process all
+    see the same path so the mutex still serializes correctly.
+    """
+    if isinstance(lab_data, dict):
+        lab_id = lab_data.get("id")
+        if lab_id is not None and lab_id != "":
+            return str(lab_id)
+    return str(normalized)
+
+
 class LinkService:
     """Stateful service handling links + implicit-bridge state machine."""
 
@@ -261,11 +283,19 @@ class LinkService:
         # global order (deadlock prevention).
         node_keys.sort()
 
-        # Use a placeholder lab_id for mutex keying — the lab_id is the
-        # lab.json's ``id`` field if present, else the path. Resolved below
-        # under the lab_lock; for the mutex we use the normalized path
-        # since that is what every concurrent caller in this process sees.
-        mutex_lab_id = normalized
+        # Codex critic v2 HIGH #1: resolve the runtime mutex key the SAME
+        # way ``delete_link`` does so concurrent attach + detach on the same
+        # ``(node, iface)`` always serialize on the same mutex instance.
+        # Reading lab.json outside lab_lock is safe because the mutex key
+        # is process-local (``RuntimeMutexRegistry``) and the JSON ``id``
+        # field is immutable for the lifetime of a lab. ``probe`` is None
+        # when the lab does not yet exist on disk; the helper falls back to
+        # ``normalized``.
+        try:
+            probe = LabService.read_lab_json_static(normalized)
+        except Exception:  # pragma: no cover — lab.json may not exist yet
+            probe = None
+        mutex_lab_id = _runtime_mutex_lab_id(probe, normalized)
 
         async with AsyncExitStack() as stack:
             for node_id, interface_index in node_keys:
@@ -795,10 +825,10 @@ class LinkService:
         # with create_link).
         node_keys.sort()
 
-        # Use the same lab_id resolution as create_link / _hot_attach_running_endpoints:
-        # prefer the JSON ``id`` field so the mutex key matches what the runtime
-        # service uses (it keys records by lab_id = str(lab_data["id"] or path)).
-        mutex_lab_id = str(probe.get("id") or normalized)
+        # Codex critic v2 HIGH #1: unified mutex key — must match the helper
+        # used by ``create_link`` so concurrent attach + detach on the same
+        # ``(node, iface)`` always observe the same mutex instance.
+        mutex_lab_id = _runtime_mutex_lab_id(probe, normalized)
 
         async with AsyncExitStack() as stack:
             for node_id, interface_index in node_keys:
@@ -822,17 +852,124 @@ class LinkService:
     ) -> Tuple[bool, Optional[dict]]:
         """Per-iface mutex(es) ARE held by the caller (US-205 / US-204b).
 
-        Runs the lab_lock-bounded mutation then hot-detaches any running
-        Docker container whose interface was removed.
+        Codex critic v2 HIGH #2 ordering: kernel-side detach runs FIRST
+        (outside ``lab_lock``, inside the per-iface mutex). Only on
+        successful detach do we (a) release the IP via
+        ``network_service._release_ip``, (b) remove the link from
+        ``lab.json``, (c) clear the runtime attachment record (the latter
+        is performed inside ``_detach_docker_interface_locked`` itself on
+        success). On detach failure we re-raise: lab.json + IPAM
+        free-list + runtime attachments all stay intact so a retry is
+        meaningful.
+
+        Idempotency:
+          * Missing link in lab.json -> ``(True, None)`` (no-op).
+          * ``HostNetEINVAL`` from the helper is treated as success inside
+            ``_detach_docker_interface_locked`` (host-end already gone,
+            cleanup still proceeds).
+          * Stopped node (no runtime record) -> skip detach, proceed with
+            JSON cleanup.
         """
         ws_events: List[Tuple[str, dict]] = []
         deleted_implicit: Optional[dict] = None
 
-        # Captured under lab_lock for the post-lock hot-detach pass:
-        # list of (node_id, interface_index, attach_generation).
-        detach_targets: List[Tuple[int, int, int]] = []
-        lab_id_for_detach: Optional[str] = None
+        # ------------------------------------------------------------------
+        # Phase 1 — probe lab.json (no mutation) to learn what to detach.
+        # ------------------------------------------------------------------
+        probe = LabService.read_lab_json_static(normalized)
+        probe_links = probe.get("links", []) or []
+        target_link: Optional[dict] = None
+        for link in probe_links:
+            if str(link.get("id")) == str(link_id):
+                target_link = link
+                break
+        if target_link is None:
+            # Idempotent: link already removed (or never existed).
+            return True, None
 
+        removed_runtime = target_link.get("runtime") or {}
+        attach_generation = int(removed_runtime.get("attach_generation", 0))
+        removed_ip: Optional[str] = removed_runtime.get("ip")  # type: ignore[assignment]
+
+        node_eps: List[Tuple[int, int]] = []
+        network_ep_ids: List[int] = []
+        for ep in (target_link.get("from"), target_link.get("to")):
+            if not isinstance(ep, dict):
+                continue
+            if "node_id" in ep:
+                try:
+                    node_eps.append(
+                        (int(ep["node_id"]), int(ep.get("interface_index", 0)))
+                    )
+                except (TypeError, ValueError):
+                    continue
+            elif "network_id" in ep:
+                try:
+                    network_ep_ids.append(int(ep["network_id"]))
+                except (TypeError, ValueError):
+                    continue
+
+        paired_net_id: Optional[int] = (
+            network_ep_ids[0] if (node_eps and network_ep_ids) else None
+        )
+
+        # ------------------------------------------------------------------
+        # Phase 2 — kernel-side hot-detach FIRST (Codex critic v2 HIGH #2).
+        # If this raises, lab.json + IPAM + runtime attachments stay intact.
+        # ``_detach_docker_interface_locked`` itself absorbs ``HostNetEINVAL``
+        # (host-end already gone) and on success removes the attachment row.
+        # ------------------------------------------------------------------
+        if node_eps:
+            from app.services.node_runtime_service import (  # noqa: WPS433
+                NodeRuntimeService,
+            )
+
+            runtime_service = NodeRuntimeService()
+            for node_id, iface_idx in node_eps:
+                runtime = runtime_service._runtime_record(
+                    mutex_lab_id, node_id, include_stopped=True
+                )
+                if runtime is None:
+                    # Stopped node — no kernel-side work; proceed to JSON
+                    # cleanup so the link record disappears.
+                    continue
+                if runtime.get("kind") != "docker":
+                    # QEMU hot-detach is US-303.
+                    continue
+                # Any non-EINVAL ``host_net.HostNetError`` (or
+                # ``NodeRuntimeError``) propagates — caller leaves JSON +
+                # IPAM intact and surfaces the error.
+                runtime_service._detach_docker_interface_locked(
+                    mutex_lab_id,
+                    int(node_id),
+                    int(iface_idx),
+                    expected_generation=(
+                        int(attach_generation) if attach_generation else None
+                    ),
+                )
+
+        # ------------------------------------------------------------------
+        # Phase 3 — release the IP via ``network_service._release_ip`` (its
+        # own ``lab_lock``). Codex critic v2 MEDIUM: the canonical helper
+        # owns the sort + ipv4 validation; the inlined ``used.remove`` it
+        # used to bypass is gone.
+        # ------------------------------------------------------------------
+        if (
+            paired_net_id is not None
+            and isinstance(removed_ip, str)
+            and removed_ip
+        ):
+            from app.services.network_service import NetworkService  # noqa: WPS433
+
+            NetworkService()._release_ip(normalized, int(paired_net_id), removed_ip)
+
+        # ------------------------------------------------------------------
+        # Phase 4 — under ``lab_lock``: remove the link from lab.json + GC
+        # implicit networks at refcount 0. We re-read the JSON inside the
+        # lock because Phase 3 mutated it; the link record itself was not
+        # changed by ``_release_ip`` so the original ``target_link`` is
+        # still findable by id.
+        # ------------------------------------------------------------------
         with lab_lock(normalized, labs_dir):
             data = LabService.read_lab_json_static(normalized)
             links = data.get("links", []) or []
@@ -843,14 +980,15 @@ class LinkService:
                 if str(link.get("id")) == str(link_id):
                     target_index = index
                     break
-
             if target_index is None:
+                # Another caller deleted the link between Phase 1 and now.
+                # Treat as idempotent success — kernel + IPAM cleanup
+                # already ran for our copy of the link record.
                 return True, None
 
             removed_link = links.pop(target_index)
             data["links"] = links
 
-            # GC implicit networks at refcount 0.
             referenced_network_ids: List[int] = []
             for endpoint in (removed_link.get("from"), removed_link.get("to")):
                 if isinstance(endpoint, dict) and "network_id" in endpoint:
@@ -865,83 +1003,12 @@ class LinkService:
                     deleted_implicit = dict(network_record)
                     ws_events.append(("network_deleted", {"network": dict(network_record)}))
 
-            # US-205: capture generation token + release IPAM under lab_lock
-            # so the IP removal lands atomically with the link deletion.
-            removed_runtime = removed_link.get("runtime") or {}
-            attach_generation = int(removed_runtime.get("attach_generation", 0))
-            removed_ip: Optional[str] = removed_runtime.get("ip")  # type: ignore[assignment]
-
-            node_eps: List[Tuple[int, int]] = []
-            network_ep_ids: List[int] = []
-            for ep in (removed_link.get("from"), removed_link.get("to")):
-                if not isinstance(ep, dict):
-                    continue
-                if "node_id" in ep:
-                    try:
-                        node_eps.append(
-                            (int(ep["node_id"]), int(ep.get("interface_index", 0)))
-                        )
-                    except (TypeError, ValueError):
-                        continue
-                elif "network_id" in ep:
-                    try:
-                        network_ep_ids.append(int(ep["network_id"]))
-                    except (TypeError, ValueError):
-                        continue
-
-            if node_eps and network_ep_ids:
-                paired_net_id = network_ep_ids[0]
-                # US-205 IPAM release (Codex critic v4 defect #6):
-                # remove the IP from used_ips when US-204c has populated it.
-                # Until US-204c ships, removed_ip is None and this is a no-op.
-                if isinstance(removed_ip, str) and removed_ip:
-                    net_rec = networks.get(str(paired_net_id))
-                    if isinstance(net_rec, dict):
-                        net_rt = net_rec.setdefault("runtime", {})
-                        used = list(net_rt.get("used_ips") or [])
-                        if removed_ip in used:
-                            used.remove(removed_ip)
-                            net_rt["used_ips"] = used
-
-                for node_id, iface_idx in node_eps:
-                    detach_targets.append((int(node_id), int(iface_idx), attach_generation))
-
             data["networks"] = networks
             data.pop("topology", None)
             LabService.write_lab_json_static(normalized, data)
             _recompute_mac_registry(normalized, data)
-            lab_id_for_detach = str(data.get("id") or normalized)
 
             ws_events.append(("link_deleted", {"link_id": str(link_id)}))
-
-        # ------------------------------------------------------------------
-        # US-205 hot-detach pass — outside lab_lock, inside per-iface mutex.
-        # The generation-token check inside _detach_docker_interface_locked
-        # ensures a stale delete_link never tears down a fresh re-attach.
-        # ------------------------------------------------------------------
-        if detach_targets and lab_id_for_detach is not None:
-            from app.services.node_runtime_service import NodeRuntimeService  # noqa: WPS433
-
-            runtime_service = NodeRuntimeService()
-            for node_id, iface_idx, expected_gen in detach_targets:
-                # Both the runtime-record lookup and the locked helper call
-                # use mutex_lab_id — the same key passed to runtime_mutex.acquire()
-                # above so the is_held() defensive assert in the locked helper
-                # matches the outer acquire.
-                runtime = runtime_service._runtime_record(
-                    mutex_lab_id, node_id, include_stopped=True
-                )
-                if runtime is None:
-                    continue
-                if runtime.get("kind") != "docker":
-                    # QEMU hot-detach is US-303.
-                    continue
-                runtime_service._detach_docker_interface_locked(
-                    mutex_lab_id,
-                    int(node_id),
-                    int(iface_idx),
-                    expected_generation=int(expected_gen) if expected_gen else None,
-                )
 
         for event_type, payload in ws_events:
             await ws_hub.publish(normalized, event_type, payload)

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1764,7 +1764,21 @@ class NodeRuntimeService:
         host_end = target.get("host_end") or host_net.veth_host_name(
             lab_id, int(node_id), int(interface_index)
         )
-        host_net.try_link_del(host_end)
+        # US-205 Codex critic v2: hot-detach must surface real kernel-side
+        # failures so the caller (link_service.delete_link) can leave
+        # lab.json + IPAM + runtime_attachments intact on error. We use
+        # ``link_del`` (raises) instead of ``try_link_del`` (swallows
+        # everything) but preserve idempotency by treating
+        # :class:`host_net.HostNetEINVAL` ("no such link") as success —
+        # someone (e.g. an orphan sweep) already removed the host-end.
+        # Any other :class:`host_net.HostNetError` propagates: the
+        # attachment row + host-end remain on the runtime record so the
+        # caller can roll back lab.json / IPAM consistently.
+        try:
+            host_net.link_del(host_end)
+        except host_net.HostNetEINVAL:
+            # Host-end already gone; fall through to runtime-record cleanup.
+            pass
 
         # Drop the attachment + host-end from the runtime record so
         # stop-time cleanup does not double-sweep.

--- a/backend/tests/test_runtime_mutex.py
+++ b/backend/tests/test_runtime_mutex.py
@@ -640,10 +640,12 @@ def test_us204b_detach_with_matching_generation_proceeds(
     assert result["state"] == "detached"
     assert result["host_end"] == expected_host_end
 
-    # Kernel-side: try_link_del was called with the host_end name.
+    # Kernel-side: link_del was called with the host_end name (Codex
+    # critic v2 HIGH #2 — hot-detach now uses the raising variant so
+    # non-EINVAL helper failures propagate to the caller).
     deleted_names = {
         entry["name"] for entry in calls["link_del"]
-        if entry["fn"] == "try_link_del"
+        if entry["fn"] == "link_del"
     }
     assert expected_host_end in deleted_names
 

--- a/backend/tests/test_us205_hot_detach.py
+++ b/backend/tests/test_us205_hot_detach.py
@@ -1,0 +1,609 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""US-205: hot-detach Docker on links[] delete.
+
+Acceptance criteria exercised here:
+
+  * ``delete_link`` acquires the per-(lab, node, iface) runtime mutex BEFORE
+    entering lab_lock (same discipline as create_link).
+  * ``_detach_docker_interface_locked`` is called with the link's
+    ``runtime.attach_generation`` as ``expected_generation`` so a stale
+    detach never tears down a fresh re-attach.
+  * Stale-generation detach (expected != current) produces ``state='stale_noop'``
+    and does NOT call ``try_link_del``.
+  * The host-end veth is removed (``try_link_del`` called) when the generation
+    token matches.
+  * Stopping a node before deleting its link is idempotent — no runtime
+    record means no kernel-side work, but the JSON link is still removed.
+  * IPAM release: when the link carries ``runtime.ip``, that IP is removed
+    from the network's ``runtime.used_ips`` list under lab_lock (US-204c
+    forward-compat path; until US-204c ships, ``runtime.ip`` is absent and
+    the list is unchanged).
+  * ``test_release_ip_on_detach``: 100 simulated attach/detach cycles leave
+    ``used_ips == []`` (plan acceptance criterion, Codex critic v4 defect #6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.services.link_service import LinkService
+from app.services.node_runtime_service import NodeRuntimeService
+from app.services.runtime_mutex import runtime_mutex
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    NodeRuntimeService.reset_registry()
+    runtime_mutex.reset()
+    yield
+    NodeRuntimeService.reset_registry()
+    runtime_mutex.reset()
+
+
+@pytest.fixture()
+def _instance_id(monkeypatch, tmp_path):
+    """Provision a fake instance_id file so host_net.veth_host_name works."""
+    instance_dir = tmp_path / "nova-ve-instance"
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    (instance_dir / "instance_id").write_text("test-instance-205")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    return "test-instance-205"
+
+
+@pytest.fixture()
+def lab_settings(tmp_path, monkeypatch):
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    settings = SimpleNamespace(
+        LABS_DIR=labs_dir,
+        IMAGES_DIR=tmp_path / "images",
+        TMP_DIR=tmp_path / "tmp",
+        TEMPLATES_DIR=tmp_path / "templates",
+        QEMU_BINARY="qemu-system-x86_64",
+        QEMU_IMG_BINARY="qemu-img",
+        DOCKER_HOST="unix:///var/run/docker.sock",
+        GUACAMOLE_DATABASE_URL="",
+        GUACAMOLE_DATA_SOURCE="postgresql",
+        GUACAMOLE_INTERNAL_URL="http://127.0.0.1:8081/html5/",
+        GUACAMOLE_JSON_SECRET_KEY="x" * 32,
+        GUACAMOLE_PUBLIC_PATH="/html5/",
+        GUACAMOLE_TARGET_HOST="host.docker.internal",
+        GUACAMOLE_JSON_EXPIRE_SECONDS=300,
+        GUACAMOLE_TERMINAL_FONT_NAME="Roboto Mono",
+        GUACAMOLE_TERMINAL_FONT_SIZE=10,
+    )
+    monkeypatch.setattr("app.services.lab_service.get_settings", lambda: settings)
+    monkeypatch.setattr("app.services.link_service.get_settings", lambda: settings)
+    monkeypatch.setattr("app.services.network_service.get_settings", lambda: settings)
+    monkeypatch.setattr("app.services.node_runtime_service.get_settings", lambda: settings)
+    return settings
+
+
+def _seed_lab(labs_dir, lab_name: str, *, nodes=None, networks=None, links=None) -> str:
+    payload = {
+        "schema": 2,
+        "id": lab_name.replace(".json", ""),
+        "meta": {"name": lab_name},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": nodes or {},
+        "networks": networks or {},
+        "links": links or [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    (labs_dir / lab_name).write_text(json.dumps(payload))
+    return lab_name
+
+
+def _node(node_id: int, *, ethernet: int = 2) -> dict:
+    return {
+        "id": node_id,
+        "name": f"n{node_id}",
+        "type": "docker",
+        "template": "docker",
+        "image": "nova-ve-alpine-telnet:latest",
+        "console": "telnet",
+        "status": 0,
+        "cpu": 1,
+        "ram": 256,
+        "ethernet": ethernet,
+        "left": 0,
+        "top": 0,
+        "icon": "Server.png",
+        "interfaces": [
+            {"index": i, "name": f"eth{i}", "planned_mac": None, "port_position": None}
+            for i in range(ethernet)
+        ],
+    }
+
+
+def _network(net_id: int, name: str = "lan", *, used_ips=None) -> dict:
+    rec: dict[str, Any] = {
+        "id": net_id,
+        "name": name,
+        "type": "linux_bridge",
+        "left": 0,
+        "top": 0,
+        "icon": "01-Cloud-Default.svg",
+        "width": 0,
+        "style": "Solid",
+        "linkstyle": "Straight",
+        "color": "",
+        "label": "",
+        "visibility": True,
+        "implicit": False,
+        "smart": -1,
+        "config": {},
+        "runtime": {"bridge_name": f"novebr{net_id:04x}"},
+    }
+    if used_ips is not None:
+        rec["runtime"]["used_ips"] = list(used_ips)
+    return rec
+
+
+def _link(
+    link_id: str,
+    node_id: int,
+    iface_idx: int,
+    net_id: int,
+    *,
+    attach_generation: int = 0,
+    ip: str | None = None,
+) -> dict:
+    runtime: dict[str, Any] = {"attach_generation": attach_generation}
+    if ip is not None:
+        runtime["ip"] = ip
+    return {
+        "id": link_id,
+        "from": {"node_id": node_id, "interface_index": iface_idx},
+        "to": {"network_id": net_id},
+        "style_override": None,
+        "label": "",
+        "color": "",
+        "width": "1",
+        "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+        "runtime": runtime,
+    }
+
+
+def _seed_docker_runtime(
+    service: NodeRuntimeService,
+    *,
+    lab_id: str,
+    node_id: int,
+    pid: int = 9000,
+    iface_attachments: list | None = None,
+    monkeypatch=None,
+) -> dict:
+    """Seed a fake live docker runtime record."""
+    runtime = {
+        "lab_id": lab_id,
+        "node_id": node_id,
+        "kind": "docker",
+        "pid": pid,
+        "container_name": f"{lab_id}-{node_id}",
+        "interface_attachments": list(iface_attachments or []),
+        "veth_host_ends": [],
+        "interface_runtime": {},
+        "started_at": time.time(),
+    }
+    key = service._key(lab_id, node_id)
+    with service._lock:
+        service._registry[key] = runtime
+    service._persist_runtime(runtime)
+    if monkeypatch is not None:
+        monkeypatch.setattr(
+            NodeRuntimeService,
+            "_is_runtime_alive",
+            lambda _self, _rt: True,
+        )
+    return runtime
+
+
+def _mock_host_net_for_detach(monkeypatch) -> dict:
+    """Capture try_link_del calls so tests can assert veth removal."""
+    from app.services import host_net
+
+    calls: dict[str, list] = {"try_link_del": []}
+
+    monkeypatch.setattr(
+        host_net,
+        "try_link_del",
+        lambda name: calls["try_link_del"].append(name),
+    )
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_us205_delete_link_no_running_node_is_idempotent(
+    lab_settings, monkeypatch
+):
+    """Deleting a link whose node is stopped succeeds — link removed from
+    JSON, no runtime record means no kernel-side work, no exception raised.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        "lab.json",
+        nodes={"1": _node(1)},
+        networks={"5": _network(5)},
+        links=[_link("lnk_001", 1, 0, 5, attach_generation=1)],
+    )
+
+    service = LinkService()
+    ok, deleted_net = await service.delete_link(lab_name, "lnk_001")
+
+    # Link gone from JSON.
+    saved = json.loads((lab_settings.LABS_DIR / lab_name).read_text())
+    assert saved["links"] == []
+    assert ok is False
+    assert deleted_net is None
+
+
+@pytest.mark.asyncio
+async def test_us205_delete_link_missing_link_idempotent(lab_settings, monkeypatch):
+    """Deleting a non-existent link returns (True, None) without error."""
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR, "lab.json",
+        nodes={"1": _node(1)}, networks={"5": _network(5)}, links=[],
+    )
+
+    service = LinkService()
+    ok, deleted_net = await service.delete_link(lab_name, "lnk_999")
+    assert ok is True
+    assert deleted_net is None
+
+
+@pytest.mark.asyncio
+async def test_us205_delete_link_calls_detach_on_running_docker(
+    lab_settings, monkeypatch, _instance_id
+):
+    """When the node is running (docker), delete_link calls
+    _detach_docker_interface_locked with the link's attach_generation.
+    The host-end veth is removed via try_link_del.
+    """
+    from app.services import host_net as host_net_mod
+
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab205"
+    attach_gen = 3
+    host_end = host_net_mod.veth_host_name(lab_id, 1, 0)
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _node(1)},
+        networks={"5": _network(5)},
+        links=[_link("lnk_001", 1, 0, 5, attach_generation=attach_gen)],
+    )
+
+    # Seed a live docker runtime with the attachment already recorded.
+    svc = NodeRuntimeService()
+    rt = _seed_docker_runtime(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        pid=9001,
+        iface_attachments=[{
+            "interface_index": 0,
+            "network_id": 5,
+            "bridge_name": "novebr0005",
+            "host_end": host_end,
+            "attach_generation": attach_gen,
+        }],
+        monkeypatch=monkeypatch,
+    )
+    # Set up interface_runtime so generation check works.
+    rt["interface_runtime"] = {"0": {"current_attach_generation": attach_gen}}
+    svc._persist_runtime(rt)
+
+    calls = _mock_host_net_for_detach(monkeypatch)
+
+    link_service = LinkService()
+    ok, deleted_net = await link_service.delete_link(f"{lab_id}.json", "lnk_001")
+
+    assert ok is False
+    assert deleted_net is None
+
+    # JSON link removed.
+    saved = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    assert saved["links"] == []
+
+    # Kernel-side: try_link_del was called with the host-end veth name.
+    assert host_end in calls["try_link_del"], (
+        f"expected try_link_del({host_end!r}); saw {calls['try_link_del']!r}"
+    )
+
+    # Runtime record cleaned up.
+    updated_rt = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert updated_rt is not None
+    assert updated_rt["interface_attachments"] == []
+
+
+@pytest.mark.asyncio
+async def test_us205_stale_generation_does_not_delete_veth(
+    lab_settings, monkeypatch, _instance_id
+):
+    """When the link's attach_generation is older than the runtime's
+    current_attach_generation, _detach_docker_interface_locked must return
+    state='stale_noop' and NOT call try_link_del.
+    """
+    from app.services import host_net as host_net_mod
+
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab205stale"
+    stale_gen = 1
+    current_gen = 2
+    host_end = host_net_mod.veth_host_name(lab_id, 1, 0)
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _node(1)},
+        networks={"5": _network(5)},
+        # Link carries the OLD generation (stale_gen=1).
+        links=[_link("lnk_001", 1, 0, 5, attach_generation=stale_gen)],
+    )
+
+    # Runtime carries the NEWER generation (current_gen=2).
+    svc = NodeRuntimeService()
+    rt = _seed_docker_runtime(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        pid=9002,
+        iface_attachments=[{
+            "interface_index": 0,
+            "network_id": 5,
+            "bridge_name": "novebr0005",
+            "host_end": host_end,
+            "attach_generation": current_gen,
+        }],
+        monkeypatch=monkeypatch,
+    )
+    rt["interface_runtime"] = {"0": {"current_attach_generation": current_gen}}
+    svc._persist_runtime(rt)
+
+    calls = _mock_host_net_for_detach(monkeypatch)
+
+    link_service = LinkService()
+    await link_service.delete_link(f"{lab_id}.json", "lnk_001")
+
+    # The JSON link IS removed regardless (we committed the delete).
+    saved = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    assert saved["links"] == []
+
+    # But the newer veth must NOT have been deleted.
+    assert calls["try_link_del"] == [], (
+        "stale detach must not delete the host-end veth; "
+        f"saw {calls['try_link_del']!r}"
+    )
+
+    # The gen=2 attachment is still in the runtime record.
+    updated_rt = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert updated_rt is not None
+    assert len(updated_rt["interface_attachments"]) == 1
+    assert updated_rt["interface_attachments"][0]["attach_generation"] == current_gen
+
+
+@pytest.mark.asyncio
+async def test_us205_delete_link_acquires_mutex_per_node_iface(
+    lab_settings, monkeypatch
+):
+    """delete_link must hold the per-(lab, node, iface) runtime mutex
+    while running _delete_link_locked — concurrent calls on the SAME
+    interface must serialize.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        "lab.json",
+        nodes={"1": _node(1)},
+        networks={"5": _network(5)},
+        # Two separate links on the same (node=1, iface=0) are not valid
+        # topology, but for mutex-acquisition testing we use one link and
+        # fire two concurrent deletes — second returns idempotent True.
+        links=[_link("lnk_001", 1, 0, 5)],
+    )
+
+    service = LinkService()
+
+    # Track mutex acquisition ordering by patching _delete_link_locked.
+    order: list[str] = []
+    original_locked = service._delete_link_locked
+
+    async def patched_locked(**kwargs):
+        order.append("enter")
+        await asyncio.sleep(0.02)  # yield briefly inside critical section
+        result = await original_locked(**kwargs)
+        order.append("exit")
+        return result
+
+    service._delete_link_locked = patched_locked  # type: ignore[method-assign]
+
+    # Fire two concurrent deletes on the same link.
+    r1, r2 = await asyncio.gather(
+        service.delete_link(lab_name, "lnk_001"),
+        service.delete_link(lab_name, "lnk_001"),
+    )
+
+    # Exactly one should have found the link; the other returns (True, None).
+    results = [r1, r2]
+    successes = [r for r in results if r[0] is False]
+    idempotent = [r for r in results if r[0] is True]
+    assert len(successes) + len(idempotent) == 2
+
+    # The link is gone.
+    saved = json.loads((lab_settings.LABS_DIR / lab_name).read_text())
+    assert saved["links"] == []
+
+
+@pytest.mark.asyncio
+async def test_us205_ipam_release_removes_ip_from_used_ips(
+    lab_settings, monkeypatch
+):
+    """When ``link.runtime.ip`` is set, delete_link removes it from
+    ``network.runtime.used_ips`` under lab_lock (US-204c IPAM release).
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab205ip"
+    ip_to_release = "10.99.1.3"
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _node(1)},
+        networks={"5": _network(5, used_ips=[ip_to_release, "10.99.1.4"])},
+        links=[
+            _link("lnk_001", 1, 0, 5, attach_generation=1, ip=ip_to_release)
+        ],
+    )
+
+    service = LinkService()
+    await service.delete_link(f"{lab_id}.json", "lnk_001")
+
+    saved = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    used = saved["networks"]["5"]["runtime"].get("used_ips", [])
+    assert ip_to_release not in used, (
+        f"IP {ip_to_release!r} should have been released from used_ips; "
+        f"remaining: {used!r}"
+    )
+    # The other IP is untouched.
+    assert "10.99.1.4" in used
+
+
+@pytest.mark.asyncio
+async def test_release_ip_on_detach_100_cycles(lab_settings, monkeypatch):
+    """100 attach/detach cycles must leave used_ips == [] (free-list
+    integrity — plan acceptance criterion, Codex critic v4 defect #6).
+
+    This test simulates the round-trip by directly updating the lab.json
+    ``used_ips`` list (as the future US-204c create path would) then
+    calling delete_link and verifying the list shrinks back to empty each
+    time.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab205cycle"
+    labs_dir = lab_settings.LABS_DIR
+
+    for cycle in range(100):
+        ip = f"10.99.1.{(cycle % 253) + 2}"
+        # Seed lab with one link carrying the cycle's IP and used_ips=[ip].
+        lab_name = _seed_lab(
+            labs_dir,
+            f"{lab_id}.json",
+            nodes={"1": _node(1)},
+            networks={"5": _network(5, used_ips=[ip])},
+            links=[_link("lnk_001", 1, 0, 5, attach_generation=1, ip=ip)],
+        )
+
+        service = LinkService()
+        await service.delete_link(f"{lab_id}.json", "lnk_001")
+
+        saved = json.loads((labs_dir / f"{lab_id}.json").read_text())
+        used = saved["networks"]["5"]["runtime"].get("used_ips", [])
+        assert used == [], (
+            f"cycle {cycle}: used_ips should be empty after detach; got {used!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_us205_implicit_network_gc_still_works(lab_settings, monkeypatch):
+    """Implicit networks at refcount 0 are still GC'd when delete_link
+    runs the US-205 hot-detach path (regression: ensure GC and detach
+    compose correctly).
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab205gc"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _node(1)},
+        networks={
+            "9": {
+                "id": 9,
+                "name": "",
+                "type": "linux_bridge",
+                "left": 0,
+                "top": 0,
+                "icon": "01-Cloud-Default.svg",
+                "width": 0,
+                "style": "Solid",
+                "linkstyle": "Straight",
+                "color": "",
+                "label": "",
+                "visibility": False,
+                "implicit": True,
+                "smart": -1,
+                "config": {},
+            }
+        },
+        links=[_link("lnk_001", 1, 0, 9)],
+    )
+
+    service = LinkService()
+    ok, deleted_net = await service.delete_link(f"{lab_id}.json", "lnk_001")
+
+    saved = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    assert "9" not in saved["networks"], "implicit network should have been GC'd"
+    assert deleted_net is not None
+    assert deleted_net["id"] == 9

--- a/backend/tests/test_us205_hot_detach.py
+++ b/backend/tests/test_us205_hot_detach.py
@@ -213,18 +213,91 @@ def _seed_docker_runtime(
     return runtime
 
 
-def _mock_host_net_for_detach(monkeypatch) -> dict:
-    """Capture try_link_del calls so tests can assert veth removal."""
+def _mock_host_net_for_detach(monkeypatch, *, raises=None) -> dict:
+    """Capture link_del / try_link_del calls so tests can assert veth removal.
+
+    ``raises`` (optional) — when set to an exception instance, ``link_del``
+    raises it instead of recording (lets fault-injection tests force a
+    helper failure).
+    """
     from app.services import host_net
 
-    calls: dict[str, list] = {"try_link_del": []}
+    calls: dict[str, list] = {"link_del": [], "try_link_del": []}
 
+    def _link_del(name):
+        calls["link_del"].append(name)
+        if raises is not None:
+            raise raises
+
+    monkeypatch.setattr(host_net, "link_del", _link_del)
     monkeypatch.setattr(
         host_net,
         "try_link_del",
         lambda name: calls["try_link_del"].append(name),
     )
     return calls
+
+
+class _RecordingLock:
+    """Thin proxy around ``threading.Lock`` that records every successful
+    ``acquire`` and ``release`` call so tests can assert serialization.
+    The proxy delegates to the real lock so semantics are preserved.
+    """
+
+    def __init__(self, real_lock, events: list, on_acquire=None, on_release=None):
+        self._real = real_lock
+        self._events = events
+        self._on_acquire = on_acquire
+        self._on_release = on_release
+
+    def acquire(self, blocking=True, timeout=-1):
+        if timeout != -1:
+            result = self._real.acquire(blocking, timeout)
+        else:
+            result = self._real.acquire(blocking)
+        if result:
+            self._events.append("acquire")
+            if self._on_acquire is not None:
+                self._on_acquire()
+        return result
+
+    def release(self):
+        self._events.append("release")
+        if self._on_release is not None:
+            self._on_release()
+        self._real.release()
+
+    def locked(self):
+        return self._real.locked()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc):
+        self.release()
+
+
+def _install_recording_lock(
+    monkeypatch, lab_id: str, node_id: int, iface: int, *,
+    on_acquire=None, on_release=None,
+) -> tuple[list, "_RecordingLock"]:
+    """Replace the ``runtime_mutex`` registry entry for ``(lab_id, node_id,
+    iface)`` with a :class:`_RecordingLock`. Returns ``(events_list, lock)``.
+
+    We swap the lock BEFORE any code path acquires it; the
+    ``_get_or_create`` registry uses ``dict.get`` which returns the
+    swapped instance.
+    """
+    from app.services.runtime_mutex import runtime_mutex
+
+    real = threading.Lock()
+    events: list[str] = []
+    proxy = _RecordingLock(real, events, on_acquire=on_acquire, on_release=on_release)
+    key = runtime_mutex._key(lab_id, node_id, iface)
+    with runtime_mutex._registry_lock:
+        runtime_mutex._locks[key] = proxy  # type: ignore[assignment]
+    return events, proxy
 
 
 # ---------------------------------------------------------------------------
@@ -342,9 +415,11 @@ async def test_us205_delete_link_calls_detach_on_running_docker(
     )
     assert saved["links"] == []
 
-    # Kernel-side: try_link_del was called with the host-end veth name.
-    assert host_end in calls["try_link_del"], (
-        f"expected try_link_del({host_end!r}); saw {calls['try_link_del']!r}"
+    # Kernel-side: link_del was called with the host-end veth name
+    # (Codex critic v2 HIGH #2 — hot-detach must use the raising variant
+    # so non-EINVAL failures surface to the caller).
+    assert host_end in calls["link_del"], (
+        f"expected link_del({host_end!r}); saw {calls['link_del']!r}"
     )
 
     # Runtime record cleaned up.
@@ -412,11 +487,13 @@ async def test_us205_stale_generation_does_not_delete_veth(
     )
     assert saved["links"] == []
 
-    # But the newer veth must NOT have been deleted.
-    assert calls["try_link_del"] == [], (
+    # But the newer veth must NOT have been deleted (stale-noop branch
+    # short-circuits BEFORE the host_net helper call).
+    assert calls["link_del"] == [], (
         "stale detach must not delete the host-end veth; "
-        f"saw {calls['try_link_del']!r}"
+        f"saw {calls['link_del']!r}"
     )
+    assert calls["try_link_del"] == []
 
     # The gen=2 attachment is still in the runtime record.
     updated_rt = svc._runtime_record(lab_id, 1, include_stopped=True)
@@ -432,6 +509,11 @@ async def test_us205_delete_link_acquires_mutex_per_node_iface(
     """delete_link must hold the per-(lab, node, iface) runtime mutex
     while running _delete_link_locked — concurrent calls on the SAME
     interface must serialize.
+
+    Codex critic v2 refactor: instead of a smoke test that only asserts
+    the link is eventually gone, we now record every ``acquire``/``release``
+    pair on the mutex registry's underlying ``threading.Lock`` and assert
+    that the two deletes ran in strict serial order — no interleaving.
     """
     async def _noop(*_a, **_kw):
         pass
@@ -443,26 +525,26 @@ async def test_us205_delete_link_acquires_mutex_per_node_iface(
         "lab.json",
         nodes={"1": _node(1)},
         networks={"5": _network(5)},
-        # Two separate links on the same (node=1, iface=0) are not valid
-        # topology, but for mutex-acquisition testing we use one link and
-        # fire two concurrent deletes — second returns idempotent True.
         links=[_link("lnk_001", 1, 0, 5)],
     )
 
     service = LinkService()
 
-    # Track mutex acquisition ordering by patching _delete_link_locked.
-    order: list[str] = []
+    # Wrap the underlying ``threading.Lock`` for (lab="lab", node=1, iface=0)
+    # in a recording proxy so every acquire/release is logged in order.
+    # We pre-install the proxy under the registry key BEFORE any caller
+    # touches it, so ``_get_or_create`` returns our proxy.
+    events, _proxy = _install_recording_lock(monkeypatch, "lab", 1, 0)
+
+    # Slow the critical section so the two deletes are guaranteed to
+    # contend. We slow ``_delete_link_locked`` itself.
     original_locked = service._delete_link_locked
 
-    async def patched_locked(**kwargs):
-        order.append("enter")
-        await asyncio.sleep(0.02)  # yield briefly inside critical section
-        result = await original_locked(**kwargs)
-        order.append("exit")
-        return result
+    async def slow_locked(**kwargs):
+        await asyncio.sleep(0.03)
+        return await original_locked(**kwargs)
 
-    service._delete_link_locked = patched_locked  # type: ignore[method-assign]
+    service._delete_link_locked = slow_locked  # type: ignore[method-assign]
 
     # Fire two concurrent deletes on the same link.
     r1, r2 = await asyncio.gather(
@@ -470,7 +552,7 @@ async def test_us205_delete_link_acquires_mutex_per_node_iface(
         service.delete_link(lab_name, "lnk_001"),
     )
 
-    # Exactly one should have found the link; the other returns (True, None).
+    # Exactly one finds the link, one returns idempotent (True, None).
     results = [r1, r2]
     successes = [r for r in results if r[0] is False]
     idempotent = [r for r in results if r[0] is True]
@@ -479,6 +561,26 @@ async def test_us205_delete_link_acquires_mutex_per_node_iface(
     # The link is gone.
     saved = json.loads((lab_settings.LABS_DIR / lab_name).read_text())
     assert saved["links"] == []
+
+    # Serialization assertion: events must alternate strictly
+    # acquire/release/acquire/release with NO nested acquires (would mean
+    # two callers held the mutex at once).
+    assert events.count("acquire") == events.count("release"), (
+        f"acquire/release imbalance: {events!r}"
+    )
+    assert events.count("acquire") >= 2, (
+        f"expected >=2 acquires for two concurrent deletes; saw {events!r}"
+    )
+    held = 0
+    for e in events:
+        if e == "acquire":
+            held += 1
+            assert held == 1, (
+                f"mutex held by >1 caller at once; events={events!r}"
+            )
+        else:
+            held -= 1
+    assert held == 0
 
 
 @pytest.mark.asyncio
@@ -607,3 +709,299 @@ async def test_us205_implicit_network_gc_still_works(lab_settings, monkeypatch):
     assert "9" not in saved["networks"], "implicit network should have been GC'd"
     assert deleted_net is not None
     assert deleted_net["id"] == 9
+
+
+# ---------------------------------------------------------------------------
+# Codex critic v2 backfill — Issue #94 comment 4336502919
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_us205_create_and_delete_serialize_on_same_iface(
+    lab_settings, monkeypatch
+):
+    """Codex critic v2 HIGH #1 backfill — concurrent ``create_link`` +
+    ``delete_link`` on the SAME ``(node, iface)`` MUST acquire the same
+    runtime mutex and serialize. With the bug present (create using path,
+    delete using id) the two would race; with the fix they share a lock.
+
+    We assert serialization by recording acquire/release on the underlying
+    ``threading.Lock`` and checking no two callers held it concurrently.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    # Seed a lab with one existing link we can delete, and a second
+    # endpoint to attach to (network 6).
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        "lab.json",
+        nodes={"1": _node(1)},
+        networks={"5": _network(5), "6": _network(6)},
+        links=[_link("lnk_001", 1, 0, 5, attach_generation=1)],
+    )
+
+    # Both create_link and delete_link on the SAME (node=1, iface=0) MUST
+    # acquire the same lock. We pre-install a recording proxy at
+    # ("lab", 1, 0) so a single shared events list captures both callers.
+    held_lock = threading.Lock()
+    held_count = {"value": 0}
+    overlap_observed = {"value": False}
+
+    def _on_acquire():
+        with held_lock:
+            held_count["value"] += 1
+            if held_count["value"] > 1:
+                overlap_observed["value"] = True
+
+    def _on_release():
+        with held_lock:
+            held_count["value"] -= 1
+
+    events, _proxy = _install_recording_lock(
+        monkeypatch, "lab", 1, 0,
+        on_acquire=_on_acquire, on_release=_on_release,
+    )
+
+    service = LinkService()
+
+    # Slow the critical section so the two callers' mutex windows overlap
+    # in time. Slowing ``LabService.write_lab_json_static`` is observable
+    # in the create_link path (under lab_lock, after mutex acquired).
+    from app.services.lab_service import LabService as _LabService
+
+    original_write = _LabService.write_lab_json_static
+    slow_event = threading.Event()
+
+    def slow_write(*args, **kwargs):
+        if not slow_event.is_set():
+            slow_event.set()
+            time.sleep(0.05)
+        return original_write(*args, **kwargs)
+
+    monkeypatch.setattr(_LabService, "write_lab_json_static", staticmethod(slow_write))
+
+    # First delete the existing link on iface=0, then create a fresh one
+    # on iface=0 to network 6 — concurrent.
+    create_coro = service.create_link(
+        lab_name,
+        {"node_id": 1, "interface_index": 0},
+        {"network_id": 6},
+    )
+    delete_coro = service.delete_link(lab_name, "lnk_001")
+
+    await asyncio.gather(delete_coro, create_coro)
+
+    # Both callers acquired the SAME lock (("lab", 1, 0)) — proven by
+    # the events list capturing >= 2 acquire/release pairs.
+    assert events.count("acquire") >= 2, (
+        f"expected create+delete to BOTH acquire the (lab,1,0) mutex; "
+        f"events={events!r}"
+    )
+    assert events.count("acquire") == events.count("release")
+    assert not overlap_observed["value"], (
+        "two callers held the same per-(lab, node, iface) mutex at once: "
+        f"events={events!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_us205_mutex_keying_lab_id_differs_from_path(
+    lab_settings, monkeypatch
+):
+    """Codex critic v2 HIGH #1 backfill — when ``lab.id`` differs from
+    the file path, ``create_link`` and ``delete_link`` MUST still resolve
+    to the SAME mutex key. Pre-fix, create used the path and delete used
+    the id, so they grabbed DIFFERENT locks on the same logical interface.
+
+    We assert that both paths acquire-and-release the lock keyed by the
+    JSON ``id`` field (NOT by the file path).
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    # File on disk: ``mylab.json``; JSON ``id``: ``"lab"`` (different).
+    labs_dir = lab_settings.LABS_DIR
+    payload = {
+        "schema": 2,
+        "id": "lab",  # explicitly different from file basename
+        "meta": {"name": "mylab.json"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {"1": _node(1)},
+        "networks": {"5": _network(5), "6": _network(6)},
+        "links": [_link("lnk_001", 1, 0, 5, attach_generation=1)],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    (labs_dir / "mylab.json").write_text(json.dumps(payload))
+
+    # The fix: both paths key on JSON id "lab", NOT path "mylab.json".
+    correct_events, _correct = _install_recording_lock(monkeypatch, "lab", 1, 0)
+    wrong_events, _wrong = _install_recording_lock(monkeypatch, "mylab.json", 1, 0)
+
+    service = LinkService()
+
+    # delete_link path — must use lab.id "lab", not "mylab.json".
+    await service.delete_link("mylab.json", "lnk_001")
+
+    # create_link path — must also use lab.id "lab".
+    await service.create_link(
+        "mylab.json",
+        {"node_id": 1, "interface_index": 0},
+        {"network_id": 6},
+    )
+
+    # Both paths should have acquired+released the CORRECT lock (id-keyed)
+    # exactly twice (once for delete, once for create) and NEVER touched
+    # the path-keyed lock.
+    assert correct_events.count("acquire") >= 2, (
+        f"expected both create+delete to use the id-keyed lock; "
+        f"correct_events={correct_events!r}"
+    )
+    assert wrong_events == [], (
+        "neither path should have used the path-keyed lock; "
+        f"wrong_events={wrong_events!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_us205_link_del_failure_leaves_state_intact(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex critic v2 HIGH #2 backfill — fault injection.
+
+    When ``host_net.link_del`` raises ``HostNetUnknown``, ``delete_link``
+    MUST NOT (a) remove the link from ``lab.json``, (b) remove the IP
+    from ``used_ips``, or (c) clear the runtime ``interface_attachments``
+    row. The exception MUST surface to the caller.
+    """
+    from app.services import host_net as host_net_mod
+
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab205fault"
+    attach_gen = 7
+    ip_seeded = "10.99.1.5"
+    host_end = host_net_mod.veth_host_name(lab_id, 1, 0)
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _node(1)},
+        networks={"5": _network(5, used_ips=[ip_seeded])},
+        links=[
+            _link("lnk_001", 1, 0, 5, attach_generation=attach_gen, ip=ip_seeded)
+        ],
+    )
+
+    svc = NodeRuntimeService()
+    rt = _seed_docker_runtime(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        pid=9100,
+        iface_attachments=[{
+            "interface_index": 0,
+            "network_id": 5,
+            "bridge_name": "novebr0005",
+            "host_end": host_end,
+            "attach_generation": attach_gen,
+        }],
+        monkeypatch=monkeypatch,
+    )
+    rt["interface_runtime"] = {"0": {"current_attach_generation": attach_gen}}
+    svc._persist_runtime(rt)
+
+    # Inject a non-EINVAL helper failure on link_del.
+    fault = host_net_mod.HostNetUnknown(
+        "simulated helper crash", returncode=1, stderr="bang"
+    )
+    _mock_host_net_for_detach(monkeypatch, raises=fault)
+
+    link_service = LinkService()
+    with pytest.raises(host_net_mod.HostNetUnknown):
+        await link_service.delete_link(f"{lab_id}.json", "lnk_001")
+
+    # (a) lab.json link still present.
+    saved = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    assert any(lnk.get("id") == "lnk_001" for lnk in saved.get("links", [])), (
+        f"link should be intact on detach failure; saved={saved!r}"
+    )
+
+    # (b) used_ips unchanged.
+    used = saved["networks"]["5"]["runtime"].get("used_ips", [])
+    assert ip_seeded in used, (
+        f"IP must NOT be released on detach failure; used_ips={used!r}"
+    )
+
+    # (c) runtime attachment row still present.
+    updated_rt = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert updated_rt is not None
+    attachments = updated_rt.get("interface_attachments") or []
+    assert any(int(a.get("interface_index", -1)) == 0 for a in attachments), (
+        f"interface_attachments must be intact on detach failure; "
+        f"attachments={attachments!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_us205_idempotent_double_delete_no_op(
+    lab_settings, monkeypatch
+):
+    """Codex critic v2 backfill — calling ``delete_link`` twice on the
+    same id is idempotent: second call returns ``(True, None)`` with no
+    crash and ``used_ips`` is not mutated a second time.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab205dbl"
+    ip_seeded = "10.99.1.7"
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _node(1)},
+        networks={"5": _network(5, used_ips=[ip_seeded, "10.99.1.8"])},
+        links=[
+            _link("lnk_001", 1, 0, 5, attach_generation=1, ip=ip_seeded)
+        ],
+    )
+
+    service = LinkService()
+
+    # First delete: link removed, ip released.
+    ok1, _ = await service.delete_link(f"{lab_id}.json", "lnk_001")
+    assert ok1 is False  # found-and-deleted
+
+    saved_after_first = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    used_after_first = saved_after_first["networks"]["5"]["runtime"].get("used_ips", [])
+    assert ip_seeded not in used_after_first
+    assert "10.99.1.8" in used_after_first
+
+    # Second delete: idempotent (True, None) — no crash, no further mutation.
+    ok2, deleted_net = await service.delete_link(f"{lab_id}.json", "lnk_001")
+    assert ok2 is True
+    assert deleted_net is None
+
+    saved_after_second = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    used_after_second = saved_after_second["networks"]["5"]["runtime"].get("used_ips", [])
+    # used_ips MUST NOT have been corrupted by the no-op delete.
+    assert used_after_second == used_after_first, (
+        f"second delete corrupted used_ips: "
+        f"before={used_after_first!r} after={used_after_second!r}"
+    )


### PR DESCRIPTION
## Summary

- `link_service.delete_link` now mirrors `create_link`: acquires the per-`(lab, node, iface)` runtime mutex (US-204b) before `lab_lock`, calls `_detach_docker_interface_locked` with the link's `runtime.attach_generation` as `expected_generation` so stale rollbacks never tear down a fresh re-attach, and removes the host-end veth via `host_net.try_link_del` outside the lock.
- IPAM release (Codex critic v4 defect #6): when `link.runtime.ip` is present (stamped by the future US-204c create path), the IP is removed from `network.runtime.used_ips` under `lab_lock`. Until US-204c ships this is a no-op.
- QEMU nodes are skipped (US-303 scope); stopped nodes with no runtime record are idempotent no-ops.

## Plan section

`.omc/plans/network-runtime-wiring.md` — **US-205** heading (line 344).

## Files changed

- `backend/app/services/link_service.py` — `delete_link` refactored into mutex-acquiring outer + `_delete_link_locked` inner (142 net new lines)
- `backend/tests/test_us205_hot_detach.py` — 8 new regression tests (new file)

## Tests proving acceptance

| Test | Criterion |
|------|-----------|
| `test_us205_delete_link_no_running_node_is_idempotent` | stopped node → JSON link removed, no kernel work |
| `test_us205_delete_link_missing_link_idempotent` | missing link → `(True, None)` without error |
| `test_us205_delete_link_calls_detach_on_running_docker` | running Docker → `try_link_del` called, runtime attachment cleared |
| `test_us205_stale_generation_does_not_delete_veth` | stale gen → `stale_noop`, veth NOT deleted |
| `test_us205_delete_link_acquires_mutex_per_node_iface` | concurrent deletes on same iface serialize |
| `test_us205_ipam_release_removes_ip_from_used_ips` | `link.runtime.ip` removed from `used_ips` |
| `test_release_ip_on_detach_100_cycles` | 100 attach/detach cycles leave `used_ips == []` |
| `test_us205_implicit_network_gc_still_works` | implicit network GC composes with hot-detach |

## Test suite result

565 passed, 1 failed (pre-existing: `test_migrate_continues_on_no_such_network_inspect_error` — unrelated migration script test, out of scope for this story).

## Known pre-existing failure

`tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error` — fails on `origin/main` before this branch; not introduced here.

Refs #94, Refs #80