### PR TITLE
feat(qemu): QMP-driven hot-add NIC with attach lock + slot reservation (US-303, #101)

### DIFF
--- a/backend/app/routers/links.py
+++ b/backend/app/routers/links.py
@@ -13,7 +13,11 @@ from fastapi.responses import JSONResponse
 from app.dependencies import get_current_user
 from app.schemas.user import UserRead
 from app.services.lab_service import LEGACY_SCHEMA_ERROR
-from app.services.link_service import DuplicateLinkError, link_service
+from app.services.link_service import (
+    DuplicateLinkError,
+    LinkContentionError,
+    link_service,
+)
 
 
 router = APIRouter(prefix="/api/labs", tags=["links"])
@@ -108,6 +112,17 @@ async def create_link(
                 "existing_link": exc.existing_link,
             },
         )
+    except LinkContentionError as exc:
+        # US-303 codex iter1 MEDIUM: bounded mutex wait expired (default
+        # 2.0s); surface as 409 so the client can retry deliberately.
+        return JSONResponse(
+            status_code=409,
+            content={
+                "code": 409,
+                "status": "fail",
+                "message": str(exc),
+            },
+        )
     except KeyError as exc:
         return JSONResponse(
             status_code=404,
@@ -153,7 +168,18 @@ async def delete_link(
     pre_links = data.get("links", []) or []
     existed = any(str(l.get("id")) == str(link_id) for l in pre_links)
 
-    await link_service.delete_link(lab_path, link_id)
+    try:
+        await link_service.delete_link(lab_path, link_id)
+    except LinkContentionError as exc:
+        # US-303 codex iter1 MEDIUM: bounded mutex wait expired.
+        return JSONResponse(
+            status_code=409,
+            content={
+                "code": 409,
+                "status": "fail",
+                "message": str(exc),
+            },
+        )
 
     if not existed:
         return {

--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -571,12 +571,12 @@ class LinkService:
         lab_id = str(lab_data.get("id") or lab_path)
         nodes = lab_data.get("nodes") or {}
 
-        # Pre-pass: identify candidate (node_id, interface_index, network_id)
+        # Pre-pass: identify candidate (node_id, interface_index, network_id, kind)
         # tuples whose node is currently running. We defer bridge_name
         # resolution (which requires a per-host instance_id) until we know
         # there is at least one candidate — labs that never start nodes
         # never trigger the instance_id read.
-        pending: List[Tuple[int, int, int]] = []
+        pending: List[Tuple[int, int, int, str]] = []
         for link in concrete_links:
             node_endpoint = None
             network_endpoint = None
@@ -603,11 +603,13 @@ class LinkService:
             runtime = runtime_service._runtime_record(lab_id, node_id)
             if runtime is None:
                 continue
-            if runtime.get("kind") != "docker":
-                # QEMU hot-attach is US-303, not US-204.
+            kind = str(runtime.get("kind") or "")
+            if kind not in ("docker", "qemu"):
+                # Other runtime kinds (iol, dynamips, vpcs) have no hot-add
+                # path yet — initial-attach at start time covers them.
                 continue
 
-            pending.append((node_id, interface_index, network_id))
+            pending.append((node_id, interface_index, network_id, kind))
 
         if not pending:
             return False
@@ -623,15 +625,17 @@ class LinkService:
             resolved_implicit_bridge = (int(implicit_net_id), implicit_name)
 
         # Now resolve a bridge name for every pending target.
-        attach_targets: List[Tuple[int, int, int, str]] = []
-        for node_id, interface_index, network_id in pending:
+        attach_targets: List[Tuple[int, int, int, str, str]] = []
+        for node_id, interface_index, network_id, kind in pending:
             bridge = self._resolve_bridge_name(
                 lab_id=lab_id,
                 network_id=network_id,
                 networks=lab_data.get("networks") or {},
                 implicit_bridge=resolved_implicit_bridge,
             )
-            attach_targets.append((node_id, interface_index, network_id, bridge))
+            attach_targets.append(
+                (node_id, interface_index, network_id, bridge, kind)
+            )
 
         # Provision the implicit network's bridge exactly once before any
         # attach call (Codex critic v4 new defect #3). Idempotent: pre-existing
@@ -646,20 +650,32 @@ class LinkService:
 
         # Attach each target. On the FIRST failure, sweep the bridges + every
         # already-attached interface so we leave no host-side leftover.
-        attached: List[Tuple[int, int]] = []
+        # ``attached`` carries the kind so rollback can pick the matching
+        # cleanup path (veth host-end for docker, TAP for qemu).
+        attached: List[Tuple[int, int, str]] = []
         try:
-            for node_id, interface_index, network_id, bridge in attach_targets:
+            for node_id, interface_index, network_id, bridge, kind in attach_targets:
                 # US-204b: the per-(lab, node, iface) mutex is held by the
                 # caller (``create_link``). Call the PRIVATE locked helper
                 # directly to avoid double-acquiring the same mutex.
-                attachment = runtime_service._attach_docker_interface_locked(
-                    lab_id,
-                    node_id,
-                    network_id,
-                    interface_index,
-                    bridge_name=bridge,
-                )
-                attached.append((node_id, interface_index))
+                if kind == "docker":
+                    attachment = runtime_service._attach_docker_interface_locked(
+                        lab_id,
+                        node_id,
+                        network_id,
+                        interface_index,
+                        bridge_name=bridge,
+                    )
+                else:
+                    # US-303: QEMU hot-add via QMP.
+                    attachment = runtime_service._attach_qemu_interface_locked(
+                        lab_id,
+                        node_id,
+                        network_id,
+                        interface_index,
+                        bridge_name=bridge,
+                    )
+                attached.append((node_id, interface_index, kind))
 
                 # US-204b: stamp the link's ``runtime.attach_generation``
                 # under lab_lock — atomic with the lab.json write so the
@@ -675,23 +691,64 @@ class LinkService:
                     attach_generation=attach_generation,
                 )
         except (NodeRuntimeError, host_net.HostNetError):
-            for node_id, interface_index in attached:
-                host_end = host_net.veth_host_name(lab_id, node_id, interface_index)
-                host_net.try_link_del(host_end)
-                # Best-effort: drop the rolled-back attachment from the
-                # runtime record so subsequent reads stay consistent.
-                runtime = runtime_service._runtime_record(lab_id, node_id)
-                if runtime is not None:
+            for node_id, interface_index, kind in attached:
+                if kind == "docker":
+                    host_end = host_net.veth_host_name(lab_id, node_id, interface_index)
+                    host_net.try_link_del(host_end)
+                    # Best-effort: drop the rolled-back attachment from the
+                    # runtime record so subsequent reads stay consistent.
+                    runtime = runtime_service._runtime_record(lab_id, node_id)
+                    if runtime is not None:
+                        attachments = [
+                            a for a in (runtime.get("interface_attachments") or [])
+                            if int(a.get("interface_index", -1)) != interface_index
+                        ]
+                        runtime["interface_attachments"] = attachments
+                        host_ends = [
+                            h for h in (runtime.get("veth_host_ends") or [])
+                            if h != host_end
+                        ]
+                        runtime["veth_host_ends"] = host_ends
+                        runtime_service._persist_runtime(runtime)
+                elif kind == "qemu":
+                    # US-303 inverse: attach_qemu_interface ran the full
+                    # 6-step rollback for the FAILING target itself; for
+                    # earlier successful targets we tear down the QMP
+                    # device + netdev + TAP here. Best-effort throughout.
+                    runtime = runtime_service._runtime_record(lab_id, node_id)
+                    if runtime is None:
+                        continue
+                    socket_path = runtime.get("qmp_socket") or ""
+                    netdev_id = f"net{interface_index}"
+                    device_id = f"dev{interface_index}"
+                    tap = host_net.tap_name(lab_id, node_id, interface_index)
+                    if socket_path:
+                        try:
+                            runtime_service._qmp_command(
+                                socket_path, "device_del", {"id": device_id}
+                            )
+                        except Exception:  # noqa: BLE001
+                            pass
+                        try:
+                            runtime_service._qmp_command(
+                                socket_path, "netdev_del", {"id": netdev_id}
+                            )
+                        except Exception:  # noqa: BLE001
+                            pass
+                    try:
+                        host_net.link_set_nomaster(tap)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    host_net.try_link_del(tap)
                     attachments = [
                         a for a in (runtime.get("interface_attachments") or [])
                         if int(a.get("interface_index", -1)) != interface_index
                     ]
                     runtime["interface_attachments"] = attachments
-                    host_ends = [
-                        h for h in (runtime.get("veth_host_ends") or [])
-                        if h != host_end
+                    tap_names = [
+                        t for t in (runtime.get("tap_names") or []) if t != tap
                     ]
-                    runtime["veth_host_ends"] = host_ends
+                    runtime["tap_names"] = tap_names
                     runtime_service._persist_runtime(runtime)
             if provisioned_implicit_bridge is not None:
                 try:

--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -23,7 +23,7 @@ from app.services import host_net
 from app.services.lab_lock import lab_lock
 from app.services.lab_service import LabService, _normalize_relative_lab_path
 from app.services.link_utils import _endpoint_key, _link_pair_key  # noqa: F401 — re-exported
-from app.services.runtime_mutex import runtime_mutex
+from app.services.runtime_mutex import RuntimeMutexContention, runtime_mutex
 from app.services.ws_hub import ws_hub
 
 
@@ -39,6 +39,17 @@ class DuplicateLinkError(Exception):
     def __init__(self, existing_link: dict) -> None:
         super().__init__("link already exists")
         self.existing_link = existing_link
+
+
+class LinkContentionError(Exception):
+    """US-303 codex iter1 MEDIUM: raised when the per-(lab, node, iface)
+    runtime mutex cannot be acquired within the bounded contention
+    window (default 2.0s). The router translates this to HTTP 409.
+    """
+
+    def __init__(self, contention: RuntimeMutexContention) -> None:
+        self.contention = contention
+        super().__init__(str(contention))
 
 
 def _refcount(lab_data: dict, network_id: int) -> int:
@@ -297,21 +308,25 @@ class LinkService:
             probe = None
         mutex_lab_id = _runtime_mutex_lab_id(probe, normalized)
 
-        async with AsyncExitStack() as stack:
-            for node_id, interface_index in node_keys:
-                await stack.enter_async_context(
-                    runtime_mutex.acquire(mutex_lab_id, node_id, interface_index)
+        try:
+            async with AsyncExitStack() as stack:
+                for node_id, interface_index in node_keys:
+                    await stack.enter_async_context(
+                        runtime_mutex.acquire(mutex_lab_id, node_id, interface_index)
+                    )
+                return await self._create_link_locked(
+                    normalized=normalized,
+                    labs_dir=labs_dir,
+                    endpoint_a=endpoint_a,
+                    endpoint_b=endpoint_b,
+                    style_override=style_override,
+                    idempotency_key=idempotency_key,
+                    ws_events=ws_events,
+                    mutex_lab_id=mutex_lab_id,
                 )
-            return await self._create_link_locked(
-                normalized=normalized,
-                labs_dir=labs_dir,
-                endpoint_a=endpoint_a,
-                endpoint_b=endpoint_b,
-                style_override=style_override,
-                idempotency_key=idempotency_key,
-                ws_events=ws_events,
-                mutex_lab_id=mutex_lab_id,
-            )
+        except RuntimeMutexContention as exc:
+            # US-303 codex iter1 MEDIUM: bounded-wait timeout → 409.
+            raise LinkContentionError(exc) from exc
 
     async def _create_link_locked(
         self,
@@ -561,6 +576,7 @@ class LinkService:
         # link_service back).
         from app.services.node_runtime_service import (  # noqa: WPS433 — local import
             NodeRuntimeError,
+            NodeRuntimeQMPTimeout,
             NodeRuntimeService,
         )
 
@@ -690,7 +706,12 @@ class LinkService:
                     network_id=network_id,
                     attach_generation=attach_generation,
                 )
-        except (NodeRuntimeError, host_net.HostNetError):
+        except (NodeRuntimeError, NodeRuntimeQMPTimeout, host_net.HostNetError):
+            # US-303 codex iter1 HIGH-1: NodeRuntimeQMPTimeout is a
+            # subclass of NodeRuntimeError so the listing is technically
+            # redundant, but we list it explicitly so multi-endpoint
+            # rollback intent is grep-able. A raw transport timeout on
+            # endpoint B MUST roll back endpoint A's successful attach.
             for node_id, interface_index, kind in attached:
                 if kind == "docker":
                     host_end = host_net.veth_host_name(lab_id, node_id, interface_index)
@@ -887,17 +908,21 @@ class LinkService:
         # ``(node, iface)`` always observe the same mutex instance.
         mutex_lab_id = _runtime_mutex_lab_id(probe, normalized)
 
-        async with AsyncExitStack() as stack:
-            for node_id, interface_index in node_keys:
-                await stack.enter_async_context(
-                    runtime_mutex.acquire(mutex_lab_id, node_id, interface_index)
+        try:
+            async with AsyncExitStack() as stack:
+                for node_id, interface_index in node_keys:
+                    await stack.enter_async_context(
+                        runtime_mutex.acquire(mutex_lab_id, node_id, interface_index)
+                    )
+                return await self._delete_link_locked(
+                    normalized=normalized,
+                    labs_dir=labs_dir,
+                    link_id=link_id,
+                    mutex_lab_id=mutex_lab_id,
                 )
-            return await self._delete_link_locked(
-                normalized=normalized,
-                labs_dir=labs_dir,
-                link_id=link_id,
-                mutex_lab_id=mutex_lab_id,
-            )
+        except RuntimeMutexContention as exc:
+            # US-303 codex iter1 MEDIUM: bounded-wait timeout → 409.
+            raise LinkContentionError(exc) from exc
 
     async def _delete_link_locked(
         self,

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -36,7 +36,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, Optional
 
 import psutil
 
@@ -62,6 +62,23 @@ def _extra_str(extras: dict[str, Any], key: str, default: str = "") -> str:
 
 
 class NodeRuntimeError(Exception):
+    pass
+
+
+class NodeRuntimeQMPTimeout(NodeRuntimeError):
+    """US-303 codex iter1 HIGH-1: raised when a QMP transport-level
+    error or socket timeout is observed while sending a command.
+
+    Subclass of :class:`NodeRuntimeError` so existing
+    ``except NodeRuntimeError`` clauses still catch it. The distinct
+    subclass lets the rollback dispatcher in
+    ``_attach_qemu_interface_locked`` recognise the "may have succeeded
+    in QEMU" case and run the FULL rollback chain (both ``device_del``
+    AND ``netdev_del``) regardless of which step the timeout fired on,
+    because after a transport-level failure we cannot tell whether QEMU
+    applied the command.
+    """
+
     pass
 
 
@@ -2027,111 +2044,179 @@ class NodeRuntimeService:
         max_nics = int(runtime.get("max_nics", 8) or 8)
 
         # ----- Step 2: query-pci → find free pcie-root-port slot --------
-        try:
-            slot = self._find_free_pcie_slot(socket_path, max_nics)
-        except NodeRuntimeError:
-            raise
-        except Exception as exc:  # noqa: BLE001 — typed below
-            raise NodeRuntimeError(
-                f"QMP query-pci failed during hot-add: {exc}"
-            ) from exc
+        # US-303 codex iter1 HIGH-2: PCIe slots are NODE-wide, not
+        # iface-local. Two concurrent attaches to different ifaces on the
+        # same VM can both call query-pci, both see the same free rpN,
+        # and both attempt device_add → race. Wrap the slot-pick →
+        # device_add window in a per-(lab, node) "node-scoped" lock so
+        # only one attach picks a slot at a time. The per-(lab, node,
+        # iface) mutex (US-204b contract) is still held by the caller
+        # for delete-vs-attach serialization on the same iface.
+        from app.services.runtime_mutex import runtime_mutex as _mutex
 
-        if slot is None:
-            raise NodeRuntimeError(
-                f"All {max_nics} hot-plug slots in use on this VM. To grow the "
-                "pool, edit the template's `capabilities.max_nics` in "
-                "backend/templates/qemu/{type}/{template}.yml and restart "
-                "this node."
-            )
-
-        tap = host_net.tap_name(lab_id, int(node_id), int(interface_index))
-        netdev_id = f"net{int(interface_index)}"
-        device_id = f"dev{int(interface_index)}"
-
-        tap_provisioned = False
-        bridge_attached = False
-        netdev_added = False
-        try:
-            # ----- Step 3: tap_add ------------------------------------
-            host_net.tap_add(tap)
-            tap_provisioned = True
-
-            # ----- Step 4: link_master (TAP -> bridge) ----------------
-            host_net.link_master(tap, bridge)
-            bridge_attached = True
-            # Bring the host side of the TAP up so traffic can flow.
+        with _mutex.acquire_node_sync(lab_id, int(node_id)):
             try:
-                host_net.link_up(tap)
-            except host_net.HostNetError:
-                # link_up failure does not leak kernel objects (TAP+master
-                # are already in place); roll back identically to step 4.
+                slot = self._find_free_pcie_slot(
+                    socket_path,
+                    max_nics,
+                    reserved_slots=runtime.get("allocated_slots") or [],
+                )
+            except NodeRuntimeError:
                 raise
-
-            # ----- Step 5: QMP netdev_add -----------------------------
-            netdev_response = self._qmp_command(
-                socket_path,
-                "netdev_add",
-                {
-                    "type": "tap",
-                    "id": netdev_id,
-                    "ifname": tap,
-                    "script": "no",
-                    "downscript": "no",
-                },
-            )
-            if isinstance(netdev_response, dict) and "error" in netdev_response:
+            except Exception as exc:  # noqa: BLE001 — typed below
                 raise NodeRuntimeError(
-                    f"QMP netdev_add failed: {netdev_response['error']}"
-                )
-            netdev_added = True
+                    f"QMP query-pci failed during hot-add: {exc}"
+                ) from exc
 
-            # ----- Step 6: QMP device_add -----------------------------
-            device_args: dict[str, Any] = {
-                "driver": nic_model,
-                "id": device_id,
-                "netdev": netdev_id,
-                "bus": f"rp{slot}",
-            }
-            if planned_mac:
-                device_args["mac"] = planned_mac
-            device_response = self._qmp_command(
-                socket_path, "device_add", device_args
-            )
-            if isinstance(device_response, dict) and "error" in device_response:
+            if slot is None:
                 raise NodeRuntimeError(
-                    f"QMP device_add failed: {device_response['error']}"
+                    f"All {max_nics} hot-plug slots in use on this VM. To grow the "
+                    "pool, edit the template's `capabilities.max_nics` in "
+                    "backend/templates/qemu/{type}/{template}.yml and restart "
+                    "this node."
                 )
-        except Exception:
-            # 6-step rollback per plan §US-303. Each cleanup is wrapped in
-            # try/except so a rollback failure logs but does not mask the
-            # original error.
-            if netdev_added:
+
+            # Reserve the slot in-runtime BEFORE issuing device_add so a
+            # concurrent attach that grabs the node-lock immediately
+            # after we release it sees the slot as taken even though
+            # query-pci has not yet observed it. We move pending →
+            # final on success or strip on rollback.
+            with self._lock:
+                allocated_slots = list(runtime.get("allocated_slots") or [])
+                if int(slot) not in allocated_slots:
+                    allocated_slots.append(int(slot))
+                runtime["allocated_slots"] = allocated_slots
+
+            tap = host_net.tap_name(lab_id, int(node_id), int(interface_index))
+            netdev_id = f"net{int(interface_index)}"
+            device_id = f"dev{int(interface_index)}"
+
+            tap_provisioned = False
+            bridge_attached = False
+            netdev_added = False
+            device_added = False
+            slot_reserved_in_runtime = True
+            timeout_seen = False
+            try:
+                # ----- Step 3: tap_add ------------------------------------
+                host_net.tap_add(tap)
+                tap_provisioned = True
+
+                # ----- Step 4: link_master (TAP -> bridge) ----------------
+                host_net.link_master(tap, bridge)
+                bridge_attached = True
+                # Bring the host side of the TAP up so traffic can flow.
+                host_net.link_up(tap)
+
+                # ----- Step 5: QMP netdev_add -----------------------------
                 try:
-                    self._qmp_command(
-                        socket_path, "netdev_del", {"id": netdev_id}
+                    netdev_response = self._qmp_command(
+                        socket_path,
+                        "netdev_add",
+                        {
+                            "type": "tap",
+                            "id": netdev_id,
+                            "ifname": tap,
+                            "script": "no",
+                            "downscript": "no",
+                        },
                     )
-                except Exception:  # noqa: BLE001
-                    _logger.exception(
-                        "rollback: QMP netdev_del(%s) failed", netdev_id
+                except NodeRuntimeQMPTimeout:
+                    # Transport timeout: QEMU may already have created
+                    # the netdev — assume YES so rollback issues
+                    # netdev_del idempotently.
+                    netdev_added = True
+                    timeout_seen = True
+                    raise
+                if isinstance(netdev_response, dict) and "error" in netdev_response:
+                    raise NodeRuntimeError(
+                        f"QMP netdev_add failed: {netdev_response['error']}"
                     )
-            if bridge_attached:
+                netdev_added = True
+
+                # ----- Step 6: QMP device_add -----------------------------
+                device_args: dict[str, Any] = {
+                    "driver": nic_model,
+                    "id": device_id,
+                    "netdev": netdev_id,
+                    "bus": f"rp{slot}",
+                }
+                if planned_mac:
+                    device_args["mac"] = planned_mac
                 try:
-                    host_net.link_set_nomaster(tap)
-                except Exception:  # noqa: BLE001
-                    _logger.exception(
-                        "rollback: link_set_nomaster(%s) failed", tap
+                    device_response = self._qmp_command(
+                        socket_path, "device_add", device_args
                     )
-            if tap_provisioned:
-                try:
-                    host_net.tap_del(tap)
-                except Exception:  # noqa: BLE001
+                except NodeRuntimeQMPTimeout:
+                    # Transport timeout: QEMU may already have created
+                    # the device — assume YES so rollback issues
+                    # device_del idempotently.
+                    device_added = True
+                    timeout_seen = True
+                    raise
+                if isinstance(device_response, dict) and "error" in device_response:
+                    raise NodeRuntimeError(
+                        f"QMP device_add failed: {device_response['error']}"
+                    )
+                device_added = True
+            except Exception:
+                # 6-step rollback per plan §US-303. Each cleanup is wrapped in
+                # try/except so a rollback failure logs but does not mask the
+                # original error.
+                #
+                # US-303 codex iter1 HIGH-1: on a transport-level
+                # timeout, we cannot tell whether QEMU applied the
+                # command. We must run BOTH device_del and netdev_del
+                # idempotently — if QEMU never applied the command, the
+                # *_del will return "no such device" / "no such netdev"
+                # and we swallow it (the inner try/except).
+                if device_added:
                     try:
-                        host_net.try_link_del(tap)
+                        self._qmp_command(
+                            socket_path, "device_del", {"id": device_id}
+                        )
                     except Exception:  # noqa: BLE001
                         _logger.exception(
-                            "rollback: tap_del(%s) failed", tap
+                            "rollback: QMP device_del(%s) failed", device_id
                         )
-            raise
+                if netdev_added:
+                    try:
+                        self._qmp_command(
+                            socket_path, "netdev_del", {"id": netdev_id}
+                        )
+                    except Exception:  # noqa: BLE001
+                        _logger.exception(
+                            "rollback: QMP netdev_del(%s) failed", netdev_id
+                        )
+                if bridge_attached:
+                    try:
+                        host_net.link_set_nomaster(tap)
+                    except Exception:  # noqa: BLE001
+                        _logger.exception(
+                            "rollback: link_set_nomaster(%s) failed", tap
+                        )
+                if tap_provisioned:
+                    try:
+                        host_net.tap_del(tap)
+                    except Exception:  # noqa: BLE001
+                        try:
+                            host_net.try_link_del(tap)
+                        except Exception:  # noqa: BLE001
+                            _logger.exception(
+                                "rollback: tap_del(%s) failed", tap
+                            )
+                # Release the pending slot reservation so a retry can
+                # pick it up.
+                if slot_reserved_in_runtime:
+                    with self._lock:
+                        allocated = list(runtime.get("allocated_slots") or [])
+                        runtime["allocated_slots"] = [
+                            s for s in allocated if int(s) != int(slot)
+                        ]
+                # Suppress the unused-flag lint warning while keeping
+                # the timeout context for future debugging.
+                _ = timeout_seen
+                raise
 
         # ----- US-204b: bump current_attach_generation ----------------
         new_generation = self._bump_interface_attach_generation(
@@ -2146,11 +2231,14 @@ class NodeRuntimeService:
             "slot": int(slot),
             "nic_model": nic_model,
             "attach_generation": new_generation,
+            "planned_mac": planned_mac or "",
         }
 
         # Persist the new attachment + tap onto the runtime record so
         # stop-time cleanup sweeps the TAP (matches initial-attach
-        # contract at ``_stop_qemu_runtime``).
+        # contract at ``_stop_qemu_runtime``). The slot was already
+        # reserved during the slot-pick window above; we just add the
+        # attachment record + TAP name here.
         with self._lock:
             attachments_list = list(runtime.get("interface_attachments") or [])
             attachments_list.append(new_attachment)
@@ -2159,11 +2247,29 @@ class NodeRuntimeService:
             if tap not in tap_names:
                 tap_names.append(tap)
             runtime["tap_names"] = tap_names
-            allocated_slots = list(runtime.get("allocated_slots") or [])
-            if int(slot) not in allocated_slots:
-                allocated_slots.append(int(slot))
-            runtime["allocated_slots"] = allocated_slots
         self._persist_runtime(runtime)
+
+        # US-303 codex iter1: persist the computed planned_mac onto
+        # ``interface.planned_mac`` in lab.json so the live-MAC mismatch
+        # detection path (``_read_qemu_live_mac``) can compare against
+        # the value we actually passed to device_add. Without this, the
+        # ``firstmac`` default case would leave ``interface.planned_mac``
+        # empty and the mismatch detector would have nothing to compare
+        # against.
+        if planned_mac:
+            try:
+                self._persist_planned_mac_to_lab_json(
+                    lab_id, int(node_id), int(interface_index), planned_mac
+                )
+            except Exception:  # noqa: BLE001 — best-effort, observability only
+                _logger.exception(
+                    "failed to persist planned_mac=%s for "
+                    "lab=%s node=%s iface=%s",
+                    planned_mac,
+                    lab_id,
+                    node_id,
+                    interface_index,
+                )
 
         return new_attachment
 
@@ -2173,6 +2279,14 @@ class NodeRuntimeService:
         """Send a QMP command with optional arguments and return the parsed
         response dict. Wraps :func:`_default_qmp_client` so tests can
         monkey-patch the underlying transport via ``self._qmp_client``.
+
+        US-303 codex iter1 HIGH-1: socket-level errors / timeouts
+        (``OSError``, :class:`socket.timeout`) are wrapped in
+        :class:`NodeRuntimeQMPTimeout` so the hot-add rollback dispatcher
+        can recognise the ambiguous "may have applied in QEMU" case and
+        run the FULL idempotent rollback chain. In-band command errors
+        (``response["error"]``) are still returned verbatim — they are
+        unambiguous failures.
         """
         # The default_qmp_client signature ``(socket_path, command)`` does
         # not accept arguments; for commands needing arguments we go
@@ -2182,15 +2296,28 @@ class NodeRuntimeService:
         # ``(socket_path, command, arguments)`` to capture both pieces.
         client = self._qmp_client
         try:
-            # Test-injected client may accept a 3rd positional arg.
-            return client(socket_path, command, arguments) if arguments else client(socket_path, command)  # type: ignore[call-arg]
-        except TypeError:
-            # Fall back to default 2-arg signature: encode arguments inline
-            # via the bare socket protocol.
-            return _qmp_send_with_args(socket_path, command, arguments)
+            try:
+                # Test-injected client may accept a 3rd positional arg.
+                return client(socket_path, command, arguments) if arguments else client(socket_path, command)  # type: ignore[call-arg]
+            except TypeError:
+                # Fall back to default 2-arg signature: encode arguments inline
+                # via the bare socket protocol.
+                return _qmp_send_with_args(socket_path, command, arguments)
+        except (OSError, socket.timeout) as exc:
+            # Transport-level failure: socket closed mid-flight, host
+            # network blip, command exceeded ``sock.settimeout``. We do
+            # NOT know whether QEMU applied the command, so the caller
+            # MUST run the full rollback chain.
+            raise NodeRuntimeQMPTimeout(
+                f"QMP {command} transport error on {socket_path}: {exc}"
+            ) from exc
 
     def _find_free_pcie_slot(
-        self, socket_path: str, max_nics: int
+        self,
+        socket_path: str,
+        max_nics: int,
+        *,
+        reserved_slots: list[int] | None = None,
     ) -> int | None:
         """Scan ``query-pci`` for the highest free pcie-root-port (US-301
         policy: hot-add scans descending so additions never collide with
@@ -2198,6 +2325,14 @@ class NodeRuntimeService:
 
         Returns the slot index (0-based, matching ``rp{i}`` ids) or
         ``None`` if every pre-allocated slot is occupied.
+
+        ``reserved_slots`` (US-303 codex iter1 HIGH-2) lists slots
+        already reserved in-runtime by an earlier (still-pending) hot-add
+        on this same VM. We treat them as occupied even if ``query-pci``
+        has not yet observed the device — covers the window between
+        slot-pick and ``device_add`` where two concurrent attaches on
+        the same VM (different ifaces) would otherwise pick the same
+        slot.
 
         QMP ``query-pci`` returns a list of bus dicts; each bus has
         ``devices`` with the actual NIC devices, plus ``pci_bridge`` for
@@ -2234,6 +2369,15 @@ class NodeRuntimeService:
                                 occupied.add(int(qdev_id[2:]))
                             except ValueError:
                                 continue
+
+        # Treat in-runtime reservations as occupied so a concurrent
+        # attach that has already picked a slot but not yet flushed
+        # device_add to QEMU does not collide.
+        for reserved in reserved_slots or []:
+            try:
+                occupied.add(int(reserved))
+            except (TypeError, ValueError):
+                continue
 
         # Descending scan: pick the highest free slot.
         for slot_index in range(int(max_nics) - 1, -1, -1):
@@ -2331,6 +2475,67 @@ class NodeRuntimeService:
             first_mac = node.get("firstmac") or extras.get("firstmac")
             return self._mac_for_index(first_mac, interface_index)
         return ""
+
+    def _persist_planned_mac_to_lab_json(
+        self,
+        lab_id: str,
+        node_id: int,
+        interface_index: int,
+        planned_mac: str,
+    ) -> None:
+        """US-303 codex iter1: persist the computed ``planned_mac`` onto
+        ``node.interfaces[i].planned_mac`` in lab.json so live-MAC
+        mismatch detection (``_read_qemu_live_mac``) can compare against
+        the value we actually passed to ``device_add``.
+
+        Without this, the ``firstmac`` default case leaves
+        ``interface.planned_mac = None`` and the mismatch detector
+        returns ``state="confirmed"`` against an empty string regardless
+        of what the guest reports.
+
+        Idempotent: a non-empty existing value is left untouched (the
+        operator may have set an explicit MAC; we never overwrite it).
+        """
+        from app.services.lab_lock import lab_lock  # local import: cycle-free
+        from app.services.lab_service import LabService  # noqa: WPS433
+
+        try:
+            settings = get_settings()
+        except Exception:  # noqa: BLE001
+            return
+        labs_dir = Path(settings.LABS_DIR)
+        if not labs_dir.exists():
+            return
+
+        # Find the lab.json file whose ``id`` matches lab_id.
+        target: Optional[Path] = None
+        for path in labs_dir.glob("*.json"):
+            try:
+                data = LabService.read_lab_json_static(path.name)
+            except Exception:  # noqa: BLE001
+                continue
+            if str(data.get("id") or "") == lab_id:
+                target = path
+                break
+        if target is None:
+            return
+
+        with lab_lock(target.name, labs_dir):
+            data = LabService.read_lab_json_static(target.name)
+            node = data.get("nodes", {}).get(str(int(node_id)))
+            if not isinstance(node, dict):
+                return
+            iface = self._lookup_interface(node, int(interface_index))
+            if not isinstance(iface, dict):
+                return
+            existing = iface.get("planned_mac")
+            if existing:  # non-empty: respect operator-supplied MAC.
+                return
+            iface["planned_mac"] = str(planned_mac)
+            # Strip the read-time topology shim so the writer does not
+            # regenerate links[] from a stale snapshot.
+            data.pop("topology", None)
+            LabService.write_lab_json_static(target.name, data)
 
     def _docker_force_remove(self, docker_binary: str, container_name: str) -> None:
         """Force-remove a container, swallowing any error (best-effort cleanup)."""

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -71,6 +71,20 @@ def _default_qmp_client(socket_path: str, command: str) -> dict:
     Performs a minimal QMP handshake (read greeting, send qmp_capabilities, send command).
     Raises FileNotFoundError or OSError when the socket is missing/unreachable.
     """
+    return _qmp_send_with_args(socket_path, command, None)
+
+
+def _qmp_send_with_args(
+    socket_path: str, command: str, arguments: dict[str, Any] | None
+) -> dict:
+    """Connect to a QEMU QMP socket, send `command` with optional `arguments`,
+    return the parsed response.
+
+    Used by US-303 hot-add (which needs ``netdev_add`` / ``device_add``
+    arguments) and as the implementation backing the bare-2-arg
+    :func:`_default_qmp_client` for the simple ``query-rx-filter`` /
+    ``query-pci`` path.
+    """
     if not Path(socket_path).exists():
         raise FileNotFoundError(f"qmp socket not found: {socket_path}")
 
@@ -94,7 +108,10 @@ def _default_qmp_client(socket_path: str, command: str) -> dict:
         _read_line()
         sock.sendall(json.dumps({"execute": "qmp_capabilities"}).encode("utf-8") + b"\n")
         _read_line()
-        sock.sendall(json.dumps({"execute": command}).encode("utf-8") + b"\n")
+        payload: dict[str, Any] = {"execute": command}
+        if arguments:
+            payload["arguments"] = arguments
+        sock.sendall(json.dumps(payload).encode("utf-8") + b"\n")
         response = _read_line()
         return response if isinstance(response, dict) else {}
     finally:
@@ -1840,6 +1857,480 @@ class NodeRuntimeService:
         iface_runtime = runtime.get("interface_runtime") or {}
         record = iface_runtime.get(str(int(interface_index))) or {}
         return int(record.get("current_attach_generation", 0))
+
+    # ------------------------------------------------------------------
+    # US-303 — QMP-driven hot-add NIC for running QEMU nodes
+    # ------------------------------------------------------------------
+
+    def attach_qemu_interface(
+        self,
+        lab_id: str,
+        node_id: int,
+        network_id: int,
+        interface_index: int,
+        *,
+        bridge_name: str | None = None,
+        nic_model: str | None = None,
+        planned_mac: str | None = None,
+    ) -> dict[str, Any]:
+        """US-303 PUBLIC hot-add NIC for a running QEMU node.
+
+        Acquires the per-``(lab_id, node_id, interface_index)`` mutex
+        internally (mirrors :meth:`attach_docker_interface`) and delegates
+        to :meth:`_attach_qemu_interface_locked`. Used by callers that do
+        NOT already hold the mutex on entry (e.g. start-path callers,
+        direct API entry points). ``link_service.create_link`` instead
+        acquires the mutex itself and calls the locked helper directly to
+        avoid double-acquisition.
+
+        Returns the attachment record (which includes ``attach_generation``
+        per US-204b) describing the newly-created TAP + QMP-side objects.
+        """
+        from app.services.runtime_mutex import runtime_mutex
+
+        with runtime_mutex.acquire_sync(lab_id, node_id, interface_index):
+            return self._attach_qemu_interface_locked(
+                lab_id,
+                node_id,
+                network_id,
+                interface_index,
+                bridge_name=bridge_name,
+                nic_model=nic_model,
+                planned_mac=planned_mac,
+            )
+
+    def _attach_qemu_interface_locked(
+        self,
+        lab_id: str,
+        node_id: int,
+        network_id: int,
+        interface_index: int,
+        *,
+        bridge_name: str | None = None,
+        nic_model: str | None = None,
+        planned_mac: str | None = None,
+    ) -> dict[str, Any]:
+        """US-303 PRIVATE hot-add NIC. Mutex MUST be held.
+
+        Sequence (rollback per the plan §US-303):
+
+          1. Acquire lock — done by caller; assert mutex is held here.
+          2. ``query-pci`` → find the highest free ``pcie-root-port`` slot
+             (descending scan per US-301 policy: hot-add never collides
+             with the boot-time positional layout).
+          3. ``host_net.tap_add(tap_name)``.
+          4. ``host_net.link_master(tap_name, bridge_name)``.
+          5. QMP ``netdev_add type=tap id=net{interface_index}
+             ifname={tap_name} script=no downscript=no``.
+          6. QMP ``device_add driver={qemu_nic_model} id=dev{interface_index}
+             netdev=net{interface_index} bus=rp{slot} mac={planned_mac}``.
+
+        Rollback (Codex critic enumerated, no hand-waving):
+
+          * Step 2 (query-pci) fails → release lock, raise NodeRuntimeError.
+          * Step 3 (``host_net.tap_add``) fails → raise NodeRuntimeError.
+          * Step 4 (``host_net.link_master``) fails → ``host_net.tap_del``.
+          * Step 5 (QMP ``netdev_add``) fails → ``host_net.link_set_nomaster``,
+            ``host_net.tap_del``.
+          * Step 6 (QMP ``device_add``) fails → QMP ``netdev_del``,
+            ``host_net.link_set_nomaster``, ``host_net.tap_del``.
+
+        All rollback steps are wrapped in ``try/except`` so a rollback
+        failure logs but does NOT mask the original error.
+
+        QMP ``id=`` MUST use ``interface_index``, NOT slot number — this
+        preserves the ``_read_qemu_live_mac`` invariant (see line ~367
+        of this module: ``query-rx-filter`` lookups use
+        ``f"net{interface_index}"``). Slot is just topology placement.
+
+        ``nic_model`` MUST come from the same ``extras.qemu_nic`` /
+        ``node.template.qemu_nic`` used at boot — Codex critic finding #4.
+        Hardcoding ``virtio-net-pci`` would mix boot/hotplug device types
+        in the same VM.
+
+        Returns the attachment record (with ``attach_generation``) for the
+        link router / link_service to stamp on ``Link.runtime``.
+        """
+        from app.services.runtime_mutex import runtime_mutex
+
+        # Defensive contract: catches accidental bypass of the public API.
+        assert runtime_mutex.is_held(lab_id, node_id, interface_index), (
+            f"_attach_qemu_interface_locked called without the per-"
+            f"(lab, node, iface) mutex held for "
+            f"({lab_id!r}, {node_id}, {interface_index}); use the public "
+            f"attach_qemu_interface(...) entrypoint or acquire "
+            f"runtime_mutex.acquire(...) yourself."
+        )
+
+        runtime = self._runtime_record(lab_id, node_id)
+        if runtime is None:
+            raise NodeRuntimeError(
+                f"Cannot hot-attach interface: node {node_id} in lab {lab_id} "
+                "is not running (no runtime record)."
+            )
+        if runtime.get("kind") != "qemu":
+            raise NodeRuntimeError(
+                f"Cannot hot-attach qemu interface: node {node_id} runtime kind "
+                f"is {runtime.get('kind')!r}, expected 'qemu'."
+            )
+
+        if not runtime.get("hotplug_capable", False):
+            raise NodeRuntimeError(
+                f"Cannot hot-attach interface on node {node_id}: template "
+                f"capabilities.hotplug is false or machine is not q35. "
+                "Restart the node with a hot-plug-capable template."
+            )
+
+        socket_path = runtime.get("qmp_socket") or ""
+        if not socket_path:
+            work_dir = runtime.get("work_dir")
+            socket_path = str(Path(work_dir) / "qmp.sock") if work_dir else ""
+        if not socket_path:
+            raise NodeRuntimeError(
+                f"Cannot hot-attach interface on node {node_id}: QMP socket "
+                "path is not set on the runtime record."
+            )
+
+        # Reject duplicate interface indices on the same node — the QMP
+        # ``id=net{interface_index}`` would collide with an existing one.
+        existing_attachments = runtime.get("interface_attachments") or []
+        for existing in existing_attachments:
+            if int(existing.get("interface_index", -1)) == int(interface_index):
+                raise NodeRuntimeError(
+                    f"interface_index={interface_index} already attached on "
+                    f"node {node_id}; detach before re-attaching."
+                )
+
+        bridge = bridge_name or host_net.bridge_name(lab_id, int(network_id))
+        if not host_net.bridge_exists(bridge):
+            raise NodeRuntimeError(
+                f"Bridge {bridge} for network_id={network_id} is not present on "
+                "the host; provision it via create_network (US-202) before "
+                "hot-attaching interfaces."
+            )
+
+        # Resolve the NIC model from the same source the boot path uses
+        # (Codex critic finding #4). Caller may override (link_service can
+        # plumb extras through), otherwise read from the runtime record's
+        # cached extras snapshot or default to ``e1000`` (matches boot
+        # default at ``_start_qemu_node`` line ~954).
+        if not nic_model:
+            nic_model = self._resolve_qemu_nic_model(lab_id, node_id, runtime)
+
+        # Resolve the planned MAC the same way the boot path does:
+        # ``firstmac`` + ``interface_index`` offset.
+        if not planned_mac:
+            planned_mac = self._resolve_qemu_planned_mac(
+                lab_id, node_id, runtime, int(interface_index)
+            )
+
+        max_nics = int(runtime.get("max_nics", 8) or 8)
+
+        # ----- Step 2: query-pci → find free pcie-root-port slot --------
+        try:
+            slot = self._find_free_pcie_slot(socket_path, max_nics)
+        except NodeRuntimeError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — typed below
+            raise NodeRuntimeError(
+                f"QMP query-pci failed during hot-add: {exc}"
+            ) from exc
+
+        if slot is None:
+            raise NodeRuntimeError(
+                f"All {max_nics} hot-plug slots in use on this VM. To grow the "
+                "pool, edit the template's `capabilities.max_nics` in "
+                "backend/templates/qemu/{type}/{template}.yml and restart "
+                "this node."
+            )
+
+        tap = host_net.tap_name(lab_id, int(node_id), int(interface_index))
+        netdev_id = f"net{int(interface_index)}"
+        device_id = f"dev{int(interface_index)}"
+
+        tap_provisioned = False
+        bridge_attached = False
+        netdev_added = False
+        try:
+            # ----- Step 3: tap_add ------------------------------------
+            host_net.tap_add(tap)
+            tap_provisioned = True
+
+            # ----- Step 4: link_master (TAP -> bridge) ----------------
+            host_net.link_master(tap, bridge)
+            bridge_attached = True
+            # Bring the host side of the TAP up so traffic can flow.
+            try:
+                host_net.link_up(tap)
+            except host_net.HostNetError:
+                # link_up failure does not leak kernel objects (TAP+master
+                # are already in place); roll back identically to step 4.
+                raise
+
+            # ----- Step 5: QMP netdev_add -----------------------------
+            netdev_response = self._qmp_command(
+                socket_path,
+                "netdev_add",
+                {
+                    "type": "tap",
+                    "id": netdev_id,
+                    "ifname": tap,
+                    "script": "no",
+                    "downscript": "no",
+                },
+            )
+            if isinstance(netdev_response, dict) and "error" in netdev_response:
+                raise NodeRuntimeError(
+                    f"QMP netdev_add failed: {netdev_response['error']}"
+                )
+            netdev_added = True
+
+            # ----- Step 6: QMP device_add -----------------------------
+            device_args: dict[str, Any] = {
+                "driver": nic_model,
+                "id": device_id,
+                "netdev": netdev_id,
+                "bus": f"rp{slot}",
+            }
+            if planned_mac:
+                device_args["mac"] = planned_mac
+            device_response = self._qmp_command(
+                socket_path, "device_add", device_args
+            )
+            if isinstance(device_response, dict) and "error" in device_response:
+                raise NodeRuntimeError(
+                    f"QMP device_add failed: {device_response['error']}"
+                )
+        except Exception:
+            # 6-step rollback per plan §US-303. Each cleanup is wrapped in
+            # try/except so a rollback failure logs but does not mask the
+            # original error.
+            if netdev_added:
+                try:
+                    self._qmp_command(
+                        socket_path, "netdev_del", {"id": netdev_id}
+                    )
+                except Exception:  # noqa: BLE001
+                    _logger.exception(
+                        "rollback: QMP netdev_del(%s) failed", netdev_id
+                    )
+            if bridge_attached:
+                try:
+                    host_net.link_set_nomaster(tap)
+                except Exception:  # noqa: BLE001
+                    _logger.exception(
+                        "rollback: link_set_nomaster(%s) failed", tap
+                    )
+            if tap_provisioned:
+                try:
+                    host_net.tap_del(tap)
+                except Exception:  # noqa: BLE001
+                    try:
+                        host_net.try_link_del(tap)
+                    except Exception:  # noqa: BLE001
+                        _logger.exception(
+                            "rollback: tap_del(%s) failed", tap
+                        )
+            raise
+
+        # ----- US-204b: bump current_attach_generation ----------------
+        new_generation = self._bump_interface_attach_generation(
+            runtime, int(interface_index)
+        )
+
+        new_attachment = {
+            "interface_index": int(interface_index),
+            "network_id": int(network_id),
+            "bridge_name": bridge,
+            "tap_name": tap,
+            "slot": int(slot),
+            "nic_model": nic_model,
+            "attach_generation": new_generation,
+        }
+
+        # Persist the new attachment + tap onto the runtime record so
+        # stop-time cleanup sweeps the TAP (matches initial-attach
+        # contract at ``_stop_qemu_runtime``).
+        with self._lock:
+            attachments_list = list(runtime.get("interface_attachments") or [])
+            attachments_list.append(new_attachment)
+            runtime["interface_attachments"] = attachments_list
+            tap_names = list(runtime.get("tap_names") or [])
+            if tap not in tap_names:
+                tap_names.append(tap)
+            runtime["tap_names"] = tap_names
+            allocated_slots = list(runtime.get("allocated_slots") or [])
+            if int(slot) not in allocated_slots:
+                allocated_slots.append(int(slot))
+            runtime["allocated_slots"] = allocated_slots
+        self._persist_runtime(runtime)
+
+        return new_attachment
+
+    def _qmp_command(
+        self, socket_path: str, command: str, arguments: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Send a QMP command with optional arguments and return the parsed
+        response dict. Wraps :func:`_default_qmp_client` so tests can
+        monkey-patch the underlying transport via ``self._qmp_client``.
+        """
+        # The default_qmp_client signature ``(socket_path, command)`` does
+        # not accept arguments; for commands needing arguments we go
+        # through a lightweight inline path (``netdev_add``, ``device_add``,
+        # ``netdev_del``, ``device_del``). Tests can monkey-patch
+        # ``self._qmp_client`` to a callable accepting
+        # ``(socket_path, command, arguments)`` to capture both pieces.
+        client = self._qmp_client
+        try:
+            # Test-injected client may accept a 3rd positional arg.
+            return client(socket_path, command, arguments) if arguments else client(socket_path, command)  # type: ignore[call-arg]
+        except TypeError:
+            # Fall back to default 2-arg signature: encode arguments inline
+            # via the bare socket protocol.
+            return _qmp_send_with_args(socket_path, command, arguments)
+
+    def _find_free_pcie_slot(
+        self, socket_path: str, max_nics: int
+    ) -> int | None:
+        """Scan ``query-pci`` for the highest free pcie-root-port (US-301
+        policy: hot-add scans descending so additions never collide with
+        the boot-time positional layout ``rp0..rp{N-1}``).
+
+        Returns the slot index (0-based, matching ``rp{i}`` ids) or
+        ``None`` if every pre-allocated slot is occupied.
+
+        QMP ``query-pci`` returns a list of bus dicts; each bus has
+        ``devices`` with the actual NIC devices, plus ``pci_bridge`` for
+        root ports. We walk the tree looking for ``rp{i}`` ids whose
+        ``pci_bridge.devices`` is empty.
+        """
+        response = self._qmp_client(socket_path, "query-pci")
+        if not isinstance(response, dict):
+            raise NodeRuntimeError("QMP query-pci returned non-dict response")
+        if "error" in response:
+            raise NodeRuntimeError(
+                f"QMP query-pci returned error: {response['error']}"
+            )
+        buses = response.get("return")
+        if not isinstance(buses, list):
+            raise NodeRuntimeError(
+                "QMP query-pci returned no bus data (return field missing)"
+            )
+
+        occupied: set[int] = set()
+        for bus in buses:
+            if not isinstance(bus, dict):
+                continue
+            for device in bus.get("devices") or []:
+                if not isinstance(device, dict):
+                    continue
+                qdev_id = device.get("qdev_id")
+                if isinstance(qdev_id, str) and qdev_id.startswith("rp"):
+                    bridge = device.get("pci_bridge")
+                    if isinstance(bridge, dict):
+                        children = bridge.get("devices") or []
+                        if children:
+                            try:
+                                occupied.add(int(qdev_id[2:]))
+                            except ValueError:
+                                continue
+
+        # Descending scan: pick the highest free slot.
+        for slot_index in range(int(max_nics) - 1, -1, -1):
+            if slot_index not in occupied:
+                return slot_index
+        return None
+
+    def _resolve_qemu_nic_model(
+        self, lab_id: str, node_id: int, runtime: dict[str, Any]
+    ) -> str:
+        """Resolve the QEMU NIC model from the lab.json node extras.
+
+        Mirrors the boot-path resolution at ``_start_qemu_node`` line ~954:
+        ``_extra_str(extras, "qemu_nic") or "e1000"``. Boot and hot-add
+        MUST use the same model — Codex critic finding #4 (mixing types
+        confuses guest interface ordering).
+
+        Reads lab.json on demand via :class:`LabService` to avoid stamping
+        the model into the runtime record at start-time (which would
+        require a migration for already-running VMs).
+        """
+        try:
+            from app.services.lab_service import LabService  # noqa: WPS433
+        except ImportError:
+            return "e1000"
+
+        # Locate the lab.json by lab_id. Walk LABS_DIR for a matching id.
+        try:
+            settings = get_settings()
+        except Exception:  # noqa: BLE001
+            return "e1000"
+
+        labs_dir = Path(settings.LABS_DIR)
+        if not labs_dir.exists():
+            return "e1000"
+
+        for path in labs_dir.glob("*.json"):
+            try:
+                data = LabService.read_lab_json_static(path.name)
+            except Exception:  # noqa: BLE001
+                continue
+            if str(data.get("id") or "") != lab_id:
+                continue
+            node = data.get("nodes", {}).get(str(node_id))
+            if not isinstance(node, dict):
+                return "e1000"
+            extras = _node_extras(node)
+            return _extra_str(extras, "qemu_nic") or "e1000"
+        return "e1000"
+
+    def _resolve_qemu_planned_mac(
+        self,
+        lab_id: str,
+        node_id: int,
+        runtime: dict[str, Any],
+        interface_index: int,
+    ) -> str:
+        """Resolve the planned MAC for a QEMU interface.
+
+        Resolution chain (mirrors the boot path):
+          1. ``node.interfaces[i].planned_mac`` if explicitly set.
+          2. ``_mac_for_index(node.firstmac, interface_index)``.
+        Returns "" if neither source is available — caller may pass an
+        empty string to QMP, in which case QEMU assigns a random MAC
+        (acceptable for tests; real callers should always have firstmac).
+        """
+        try:
+            from app.services.lab_service import LabService  # noqa: WPS433
+        except ImportError:
+            return ""
+
+        try:
+            settings = get_settings()
+        except Exception:  # noqa: BLE001
+            return ""
+
+        labs_dir = Path(settings.LABS_DIR)
+        if not labs_dir.exists():
+            return ""
+
+        for path in labs_dir.glob("*.json"):
+            try:
+                data = LabService.read_lab_json_static(path.name)
+            except Exception:  # noqa: BLE001
+                continue
+            if str(data.get("id") or "") != lab_id:
+                continue
+            node = data.get("nodes", {}).get(str(node_id))
+            if not isinstance(node, dict):
+                return ""
+            iface = self._lookup_interface(node, interface_index)
+            if iface and iface.get("planned_mac"):
+                return str(iface["planned_mac"])
+            extras = _node_extras(node)
+            first_mac = node.get("firstmac") or extras.get("firstmac")
+            return self._mac_for_index(first_mac, interface_index)
+        return ""
 
     def _docker_force_remove(self, docker_binary: str, container_name: str) -> None:
         """Force-remove a container, swallowing any error (best-effort cleanup)."""

--- a/backend/app/services/runtime_mutex.py
+++ b/backend/app/services/runtime_mutex.py
@@ -51,6 +51,39 @@ from typing import Dict, Tuple
 
 
 _MutexKey = Tuple[str, int, int]
+_NodeKey = Tuple[str, int]
+
+
+# US-303 codex iter1 MEDIUM: bounded contention window.
+DEFAULT_ACQUIRE_TIMEOUT_S = 2.0
+
+
+class RuntimeMutexContention(Exception):
+    """Raised when :meth:`RuntimeMutexRegistry.acquire` /
+    :meth:`acquire_sync` cannot grab the mutex within the bounded
+    timeout (default 2.0s).
+
+    Translated to HTTP 409 by ``link_service.create_link`` /
+    ``delete_link`` per the US-303 spec at
+    ``.omc/plans/network-runtime-wiring.md``.
+    """
+
+    def __init__(
+        self,
+        lab_id: str,
+        node_id: int,
+        interface_index: int,
+        timeout: float,
+    ) -> None:
+        self.lab_id = str(lab_id)
+        self.node_id = int(node_id)
+        self.interface_index = int(interface_index)
+        self.timeout = float(timeout)
+        super().__init__(
+            f"Hot-attach already in progress on (node={self.node_id}, "
+            f"iface={self.interface_index}); timed out after "
+            f"{self.timeout:.1f}s"
+        )
 
 
 class RuntimeMutexRegistry:
@@ -61,15 +94,26 @@ class RuntimeMutexRegistry:
     set of in-flight ``(lab, node, iface)`` keys is bounded by the lab's
     declared topology (max 999 nodes per lab × 99 interfaces per node)
     and the cost of a stale lock is negligible.
+
+    US-303 codex iter1 HIGH-2: also exposes a per-``(lab_id, node_id)``
+    "node-scoped" lock for serializing PCIe slot allocation
+    (``query-pci`` → ``device_add`` window). Without this, two concurrent
+    attaches to *different* interfaces on the same VM can both see the
+    same free ``rpN`` slot and race. The per-iface mutex is still
+    required for the US-204b delete-vs-attach contract.
     """
 
     def __init__(self) -> None:
-        # Guards ``_locks`` itself.
+        # Guards ``_locks`` / ``_node_locks`` themselves.
         self._registry_lock = threading.Lock()
         self._locks: Dict[_MutexKey, threading.Lock] = {}
+        self._node_locks: Dict[_NodeKey, threading.Lock] = {}
 
     def _key(self, lab_id: str, node_id: int, interface_index: int) -> _MutexKey:
         return (str(lab_id), int(node_id), int(interface_index))
+
+    def _node_key(self, lab_id: str, node_id: int) -> _NodeKey:
+        return (str(lab_id), int(node_id))
 
     def _get_or_create(
         self, lab_id: str, node_id: int, interface_index: int
@@ -82,16 +126,37 @@ class RuntimeMutexRegistry:
                 self._locks[key] = lock
             return lock
 
+    def _get_or_create_node_lock(
+        self, lab_id: str, node_id: int
+    ) -> threading.Lock:
+        key = self._node_key(lab_id, node_id)
+        with self._registry_lock:
+            lock = self._node_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._node_locks[key] = lock
+            return lock
+
     @contextmanager
     def acquire_sync(
-        self, lab_id: str, node_id: int, interface_index: int
+        self,
+        lab_id: str,
+        node_id: int,
+        interface_index: int,
+        *,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT_S,
     ):
         """Synchronous mutex acquire. Use from sync callers
         (``_start_docker_node``, ``_start_qemu_node``, the public
         ``attach_*_interface`` / ``detach_*_interface`` entrypoints).
+
+        ``timeout`` (seconds) bounds the wait; on expiry raises
+        :class:`RuntimeMutexContention` instead of blocking indefinitely
+        (US-303 spec).
         """
         lock = self._get_or_create(lab_id, node_id, interface_index)
-        lock.acquire()
+        if not lock.acquire(timeout=float(timeout)):
+            raise RuntimeMutexContention(lab_id, node_id, interface_index, timeout)
         try:
             yield
         finally:
@@ -99,7 +164,12 @@ class RuntimeMutexRegistry:
 
     @asynccontextmanager
     async def acquire(
-        self, lab_id: str, node_id: int, interface_index: int
+        self,
+        lab_id: str,
+        node_id: int,
+        interface_index: int,
+        *,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT_S,
     ):
         """Async mutex acquire. Use from async callers
         (``link_service.create_link`` / ``delete_link``). Internally
@@ -109,6 +179,9 @@ class RuntimeMutexRegistry:
         The ``threading.Lock.acquire(blocking=False)`` poll keeps the
         event loop responsive on contention; on success we return
         immediately without an executor hop.
+
+        ``timeout`` (seconds) bounds the wait; on expiry raises
+        :class:`RuntimeMutexContention`.
         """
         import asyncio
 
@@ -123,8 +196,39 @@ class RuntimeMutexRegistry:
                 lock.release()
 
         # Contended: hop to the default executor so blocking acquire does
-        # not stall the event loop.
-        await asyncio.get_running_loop().run_in_executor(None, lock.acquire)
+        # not stall the event loop. Bounded wait per US-303 spec.
+        acquired = await asyncio.get_running_loop().run_in_executor(
+            None, lambda: lock.acquire(timeout=float(timeout))
+        )
+        if not acquired:
+            raise RuntimeMutexContention(lab_id, node_id, interface_index, timeout)
+        try:
+            yield
+        finally:
+            lock.release()
+
+    @contextmanager
+    def acquire_node_sync(
+        self,
+        lab_id: str,
+        node_id: int,
+        *,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT_S,
+    ):
+        """US-303 codex iter1 HIGH-2: per-``(lab, node)`` slot-allocation
+        lock. Acquire AROUND the ``query-pci → device_add`` window so
+        concurrent attaches to different interfaces on the same VM
+        cannot pick the same ``rpN`` slot.
+
+        Bounded wait (raises :class:`RuntimeMutexContention` on expiry)
+        — slot pick is a millisecond-scale operation, anything longer
+        means the QMP socket itself is wedged.
+        """
+        lock = self._get_or_create_node_lock(lab_id, node_id)
+        if not lock.acquire(timeout=float(timeout)):
+            # interface_index=-1 sentinel marks "node-scoped" contention
+            # so the message is still informative.
+            raise RuntimeMutexContention(lab_id, node_id, -1, timeout)
         try:
             yield
         finally:
@@ -153,6 +257,7 @@ class RuntimeMutexRegistry:
         """
         with self._registry_lock:
             self._locks.clear()
+            self._node_locks.clear()
 
 
 # Module-level singleton mirrors the ``link_service`` / ``mac_registry``

--- a/backend/tests/test_us303_qemu_hot_add.py
+++ b/backend/tests/test_us303_qemu_hot_add.py
@@ -1,0 +1,968 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""US-303 — QMP-driven hot-add NIC (with attach lock + slot reservation).
+
+Acceptance criteria exercised here:
+
+  * ``link_service.create_link`` dispatches running QEMU nodes to
+    ``_attach_qemu_interface_locked`` (mirrors the docker hot-attach flow).
+  * Hot-add executes the 4 QMP/host steps in order:
+        query-pci → tap_add → link_master → netdev_add → device_add.
+  * The QMP ``id=`` is ``net{interface_index}`` (NOT slot number) so the
+    ``_read_qemu_live_mac`` invariant is preserved
+    (``node_runtime_service.py:_read_qemu_live_mac`` looks up
+    ``f"net{interface_index}"`` in ``query-rx-filter``).
+  * ``driver=`` for ``device_add`` comes from ``extras.qemu_nic`` (or
+    ``e1000`` default), NOT a hardcoded ``virtio-net-pci``.
+  * Slot allocation scans ``rp{max_nics-1}`` downward (US-301 policy).
+  * Per-(node, iface) runtime mutex is held end-to-end.
+  * ``Link.runtime.attach_generation`` is stamped atomically with the QMP
+    success (mirrors US-204).
+  * Slot exhaustion surfaces a user-actionable error.
+  * Six-step rollback enumerated in plan §US-303:
+      Step 2 (query-pci) fails  → no kernel objects created.
+      Step 3 (tap_add) fails    → nothing to clean.
+      Step 4 (link_master) fails → tap_del.
+      Step 5 (netdev_add) fails  → link_set_nomaster + tap_del.
+      Step 6 (device_add) fails  → netdev_del + link_set_nomaster + tap_del.
+  * Rollback step failure does not mask the original error.
+  * Hot-plug rejected when ``capabilities.hotplug == false`` /
+    ``machine != q35``.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.services import host_net
+from app.services.link_service import LinkService
+from app.services.node_runtime_service import (
+    NodeRuntimeError,
+    NodeRuntimeService,
+)
+from app.services.runtime_mutex import runtime_mutex
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    NodeRuntimeService.reset_registry()
+    runtime_mutex.reset()
+    yield
+    NodeRuntimeService.reset_registry()
+    runtime_mutex.reset()
+
+
+@pytest.fixture()
+def _instance_id(monkeypatch, tmp_path):
+    """Provision a fake instance_id file so host_net.tap_name works."""
+    instance_dir = tmp_path / "nova-ve-instance"
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    (instance_dir / "instance_id").write_text("test-instance-303")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    return "test-instance-303"
+
+
+@pytest.fixture()
+def lab_settings(tmp_path, monkeypatch):
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    settings = SimpleNamespace(
+        LABS_DIR=labs_dir,
+        IMAGES_DIR=tmp_path / "images",
+        TMP_DIR=tmp_path / "tmp",
+        TEMPLATES_DIR=tmp_path / "templates",
+        QEMU_BINARY="qemu-system-x86_64",
+        QEMU_IMG_BINARY="qemu-img",
+        DOCKER_HOST="unix:///var/run/docker.sock",
+        GUACAMOLE_DATABASE_URL="",
+        GUACAMOLE_DATA_SOURCE="postgresql",
+        GUACAMOLE_INTERNAL_URL="http://127.0.0.1:8081/html5/",
+        GUACAMOLE_JSON_SECRET_KEY="x" * 32,
+        GUACAMOLE_PUBLIC_PATH="/html5/",
+        GUACAMOLE_TARGET_HOST="host.docker.internal",
+        GUACAMOLE_JSON_EXPIRE_SECONDS=300,
+        GUACAMOLE_TERMINAL_FONT_NAME="Roboto Mono",
+        GUACAMOLE_TERMINAL_FONT_SIZE=10,
+    )
+    monkeypatch.setattr("app.services.lab_service.get_settings", lambda: settings)
+    monkeypatch.setattr("app.services.link_service.get_settings", lambda: settings)
+    monkeypatch.setattr(
+        "app.services.network_service.get_settings", lambda: settings
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.get_settings", lambda: settings
+    )
+    return settings
+
+
+def _seed_lab(labs_dir, lab_name: str, *, nodes=None, networks=None, links=None):
+    payload = {
+        "schema": 2,
+        "id": lab_name.replace(".json", ""),
+        "meta": {"name": lab_name},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": nodes or {},
+        "networks": networks or {},
+        "links": links or [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    (labs_dir / lab_name).write_text(json.dumps(payload))
+    return lab_name
+
+
+def _qemu_node(node_id: int, *, ethernet: int = 4, qemu_nic: str = "e1000") -> dict:
+    return {
+        "id": node_id,
+        "name": f"vm{node_id}",
+        "type": "qemu",
+        "template": "vyos",
+        "image": "vyos",
+        "console": "telnet",
+        "status": 0,
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": ethernet,
+        "left": 0,
+        "top": 0,
+        "icon": "Router.png",
+        "firstmac": "52:54:00:00:00:00",
+        "extras": {"qemu_nic": qemu_nic},
+        "interfaces": [
+            {"index": i, "name": f"eth{i}", "planned_mac": None, "port_position": None}
+            for i in range(ethernet)
+        ],
+    }
+
+
+def _network(net_id: int, name: str = "lan") -> dict:
+    return {
+        "id": net_id,
+        "name": name,
+        "type": "linux_bridge",
+        "left": 0,
+        "top": 0,
+        "icon": "01-Cloud-Default.svg",
+        "width": 0,
+        "style": "Solid",
+        "linkstyle": "Straight",
+        "color": "",
+        "label": "",
+        "visibility": True,
+        "implicit": False,
+        "smart": -1,
+        "config": {},
+        "runtime": {"bridge_name": f"novebr{net_id:04x}"},
+    }
+
+
+def _seed_qemu_runtime(
+    service: NodeRuntimeService,
+    *,
+    lab_id: str,
+    node_id: int,
+    qmp_socket: str = "/tmp/qmp.sock",
+    hotplug_capable: bool = True,
+    max_nics: int = 8,
+    boot_slots: int = 4,
+    iface_attachments=None,
+    tap_names=None,
+    monkeypatch=None,
+) -> dict:
+    """Seed a fake live qemu runtime record."""
+    runtime = {
+        "lab_id": lab_id,
+        "node_id": node_id,
+        "kind": "qemu",
+        "pid": 9000 + node_id,
+        "qmp_socket": qmp_socket,
+        "machine": "q35",
+        "max_nics": max_nics,
+        "hotplug_capable": hotplug_capable,
+        "allocated_slots": list(range(boot_slots)),
+        "tap_names": list(tap_names or []),
+        "interface_attachments": list(iface_attachments or []),
+        "interface_runtime": {},
+        "started_at": time.time(),
+    }
+    key = service._key(lab_id, node_id)
+    with service._lock:
+        service._registry[key] = runtime
+    service._persist_runtime(runtime)
+    if monkeypatch is not None:
+        monkeypatch.setattr(
+            NodeRuntimeService,
+            "_is_runtime_alive",
+            lambda _self, _rt: True,
+        )
+    return runtime
+
+
+class _FakeQmp:
+    """Records every QMP call in order; callers may register per-command
+    responses or raise on a specific command. Behaves like the
+    ``self._qmp_client`` callable that ``_qmp_command`` falls back to,
+    accepting either ``(socket, command)`` or ``(socket, command, args)``.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self.responses: dict[str, Any] = {}
+        self.raise_on: dict[str, Exception] = {}
+
+    def __call__(self, socket_path, command, arguments=None):
+        self.calls.append((socket_path, command, dict(arguments) if arguments else None))
+        if command in self.raise_on:
+            raise self.raise_on[command]
+        if command in self.responses:
+            return self.responses[command]
+        return {"return": {}}
+
+
+def _query_pci_response(occupied_slots: list[int]) -> dict:
+    """Mock a ``query-pci`` response with the given root-port slots
+    occupied (i.e. each ``rp{i}`` has a child device).
+    """
+    devices = []
+    for slot in range(8):
+        children = []
+        if slot in occupied_slots:
+            children.append({"qdev_id": f"dev{slot}"})
+        devices.append(
+            {
+                "qdev_id": f"rp{slot}",
+                "pci_bridge": {"devices": children},
+            }
+        )
+    return {"return": [{"devices": devices}]}
+
+
+def _patch_host_net(monkeypatch) -> dict[str, list]:
+    """Capture host_net side-effecting calls."""
+    calls: dict[str, list] = {
+        "tap_add": [],
+        "tap_del": [],
+        "link_master": [],
+        "link_set_nomaster": [],
+        "link_up": [],
+        "try_link_del": [],
+        "bridge_exists": [],
+    }
+
+    def _bridge_exists(name):
+        calls["bridge_exists"].append(name)
+        return True
+
+    monkeypatch.setattr(host_net, "tap_add", lambda n: calls["tap_add"].append(n))
+    monkeypatch.setattr(host_net, "tap_del", lambda n: calls["tap_del"].append(n))
+    monkeypatch.setattr(
+        host_net, "link_master", lambda i, b: calls["link_master"].append((i, b))
+    )
+    monkeypatch.setattr(
+        host_net, "link_set_nomaster", lambda i: calls["link_set_nomaster"].append(i)
+    )
+    monkeypatch.setattr(host_net, "link_up", lambda i: calls["link_up"].append(i))
+    monkeypatch.setattr(
+        host_net, "try_link_del", lambda n: calls["try_link_del"].append(n)
+    )
+    monkeypatch.setattr(host_net, "bridge_exists", _bridge_exists)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# attach_qemu_interface — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_us303_qmp_id_uses_interface_index_not_slot(
+    lab_settings, monkeypatch, _instance_id
+):
+    """The QMP ``id=`` MUST be ``net{interface_index}`` (NOT slot number).
+
+    This preserves the ``_read_qemu_live_mac`` invariant — line ~367 of
+    node_runtime_service.py looks up ``f"net{interface_index}"`` in the
+    ``query-rx-filter`` response. If hot-add used the slot number instead
+    (e.g. ``net5``), the live-MAC reads would silently break.
+    """
+    lab_id = "lab303"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1, qemu_nic="e1000")},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, max_nics=8, boot_slots=2, monkeypatch=monkeypatch)
+
+    # rp0 + rp1 occupied by the boot-time NICs; rp2..rp7 free → descending
+    # scan picks rp7.
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0, 1])
+    svc._qmp_client = fake_qmp
+
+    _patch_host_net(monkeypatch)
+
+    # Use interface_index=2 (the next slot beyond the 2 boot NICs).
+    attachment = svc.attach_qemu_interface(
+        lab_id, 1, network_id=5, interface_index=2,
+        bridge_name="novebr0005",
+    )
+
+    # Find the device_add call.
+    device_add = next(c for c in fake_qmp.calls if c[1] == "device_add")
+    netdev_add = next(c for c in fake_qmp.calls if c[1] == "netdev_add")
+
+    # CRITICAL: id MUST be net{interface_index}, NOT net{slot}.
+    assert netdev_add[2]["id"] == "net2", (
+        f"netdev_add id must be 'net2' (interface_index), got {netdev_add[2]['id']!r}"
+    )
+    assert device_add[2]["id"] == "dev2", (
+        f"device_add id must be 'dev2' (interface_index), got {device_add[2]['id']!r}"
+    )
+    # The slot is on bus= only.
+    assert device_add[2]["bus"] == "rp7", (
+        f"device_add bus must be 'rp7' (highest free slot), got {device_add[2]['bus']!r}"
+    )
+    # The driver MUST be the configured qemu_nic, not hardcoded virtio.
+    assert device_add[2]["driver"] == "e1000", (
+        f"driver must come from extras.qemu_nic (e1000), got {device_add[2]['driver']!r}"
+    )
+    # The netdev MUST point at the same id.
+    assert device_add[2]["netdev"] == "net2"
+    # Returned attachment captures slot + nic_model + attach_generation.
+    assert attachment["slot"] == 7
+    assert attachment["nic_model"] == "e1000"
+    assert attachment["attach_generation"] == 1
+
+
+def test_us303_driver_comes_from_extras_qemu_nic(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex critic finding #4: ``device_add driver=`` MUST come from
+    ``extras.qemu_nic`` (matching the boot-time choice). Mixing
+    ``virtio-net-pci`` hot-plug with ``e1000`` boot-time NICs confuses
+    the guest's interface ordering.
+    """
+    lab_id = "labdrv"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1, qemu_nic="virtio-net-pci")},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=1)
+
+    device_add = next(c for c in fake_qmp.calls if c[1] == "device_add")
+    assert device_add[2]["driver"] == "virtio-net-pci"
+
+
+def test_us303_descending_slot_scan_picks_highest_free(
+    lab_settings, monkeypatch, _instance_id
+):
+    """US-301 policy: hot-add scans ``rp{max_nics-1}`` downward so
+    additions never collide with the boot-time positional layout
+    ``rp0..rp{ethernet-1}``.
+    """
+    lab_id = "labslot"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, max_nics=8, boot_slots=4, monkeypatch=monkeypatch)
+
+    # rp0..rp3 occupied (boot), rp7 ALSO occupied — descending scan
+    # should skip rp7 and pick rp6.
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0, 1, 2, 3, 7])
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    attachment = svc.attach_qemu_interface(
+        lab_id, 1, network_id=5, interface_index=4
+    )
+    assert attachment["slot"] == 6
+
+
+def test_us303_slot_exhaustion_surfaces_user_actionable_error(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Plan §US-303 fallback: when ``max_nics`` slots are all occupied,
+    the error message tells the operator how to grow the pool.
+    """
+    lab_id = "labexh"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, max_nics=4, monkeypatch=monkeypatch)
+
+    # Every pre-allocated slot occupied.
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0, 1, 2, 3])
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    with pytest.raises(NodeRuntimeError) as exc_info:
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=4)
+
+    msg = str(exc_info.value)
+    assert "All 4 hot-plug slots in use" in msg, msg
+    assert "max_nics" in msg, msg
+
+
+def test_us303_rejects_when_hotplug_capable_false(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Plan §US-303: hot-plug rejected when template's
+    ``capabilities.hotplug == false`` (or machine is not q35).
+    """
+    lab_id = "labnohp"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, hotplug_capable=False, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    svc._qmp_client = fake_qmp
+
+    with pytest.raises(NodeRuntimeError) as exc_info:
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+    assert "hotplug" in str(exc_info.value).lower()
+    # No QMP traffic at all.
+    assert fake_qmp.calls == []
+
+
+def test_us303_rejects_duplicate_interface_index(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Re-attaching the same interface_index on an already-attached node
+    raises NodeRuntimeError (the QMP id collision would manifest as a
+    confusing kernel-side error otherwise).
+    """
+    lab_id = "labdup"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        iface_attachments=[
+            {"interface_index": 2, "network_id": 5, "tap_name": "nve0001d1i2"}
+        ],
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    svc._qmp_client = fake_qmp
+
+    with pytest.raises(NodeRuntimeError, match="already attached"):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+    assert fake_qmp.calls == []
+
+
+# ---------------------------------------------------------------------------
+# 6-step rollback (the regression test the plan calls out)
+# ---------------------------------------------------------------------------
+
+
+def test_us303_rollback_query_pci_failure_cleans_nothing(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Step 2 (query-pci) fails BEFORE any kernel object exists, so
+    rollback is a no-op (no tap_add, no link_master).
+    """
+    lab_id = "labrb2"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.raise_on["query-pci"] = OSError("connection refused")
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    with pytest.raises(NodeRuntimeError, match="query-pci failed"):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    assert calls["tap_add"] == []
+    assert calls["tap_del"] == []
+    assert calls["link_master"] == []
+    assert calls["link_set_nomaster"] == []
+
+
+def test_us303_rollback_link_master_failure_cleans_tap(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Step 4 (link_master) fails → tap_del (3 already ran)."""
+    lab_id = "labrb4"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=2, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0, 1])
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    def _failing_link_master(_iface, _bridge):
+        raise host_net.HostNetError("link_master failed", returncode=1, stderr="")
+
+    monkeypatch.setattr(host_net, "link_master", _failing_link_master)
+
+    with pytest.raises(host_net.HostNetError):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    # Step 3 (tap_add) ran; step 4 failed; rollback called tap_del.
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    assert calls["tap_add"] == [expected_tap]
+    assert calls["tap_del"] == [expected_tap]
+    # No link_set_nomaster needed (master never attached).
+    assert calls["link_set_nomaster"] == []
+    # No QMP netdev/device traffic.
+    assert not any(c[1] in ("netdev_add", "device_add", "netdev_del") for c in fake_qmp.calls)
+
+
+def test_us303_rollback_netdev_add_failure_cleans_master_then_tap(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Step 5 (QMP netdev_add) fails → link_set_nomaster + tap_del (in
+    that order: undo step 4, then step 3)."""
+    lab_id = "labrb5"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([])
+    fake_qmp.responses["netdev_add"] = {
+        "error": {"class": "GenericError", "desc": "tap open failed"}
+    }
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    with pytest.raises(NodeRuntimeError, match="netdev_add failed"):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    assert calls["tap_add"] == [expected_tap]
+    assert calls["link_set_nomaster"] == [expected_tap]
+    assert calls["tap_del"] == [expected_tap]
+    # device_add MUST NOT have run.
+    assert not any(c[1] == "device_add" for c in fake_qmp.calls)
+    # No netdev_del cleanup needed (netdev_add failed → nothing to delete).
+    assert not any(c[1] == "netdev_del" for c in fake_qmp.calls)
+
+
+def test_us303_rollback_device_add_failure_full_six_step(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Step 6 (QMP device_add) fails → full rollback:
+    netdev_del → link_set_nomaster → tap_del.
+
+    THIS is the regression test the plan calls out: the failing 6th step
+    must NOT leak the netdev, the bridge attachment, or the TAP. All
+    rollback steps wrapped in try/except so a rollback-side failure
+    doesn't mask the original error.
+    """
+    lab_id = "labrb6"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    fake_qmp.responses["netdev_add"] = {"return": {}}
+    fake_qmp.responses["device_add"] = {
+        "error": {"class": "GenericError", "desc": "no such bus"}
+    }
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    expected_bridge = host_net.bridge_name(lab_id, 5)
+    with pytest.raises(NodeRuntimeError, match="device_add failed"):
+        svc.attach_qemu_interface(
+            lab_id, 1, network_id=5, interface_index=3,
+            bridge_name=expected_bridge,
+        )
+
+    # All 4 host-side / QMP cleanup actions must have happened, in the
+    # correct order (reverse of attach order).
+    expected_tap = host_net.tap_name(lab_id, 1, 3)
+    assert calls["tap_add"] == [expected_tap]
+    assert calls["link_master"] == [(expected_tap, expected_bridge)]
+    assert calls["link_set_nomaster"] == [expected_tap]
+    assert calls["tap_del"] == [expected_tap]
+    # netdev_del was issued to undo netdev_add.
+    netdev_del = [c for c in fake_qmp.calls if c[1] == "netdev_del"]
+    assert len(netdev_del) == 1
+    assert netdev_del[0][2] == {"id": "net3"}
+
+    # CRITICAL: runtime record was NOT mutated (no leaked attachment).
+    runtime = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert runtime is not None
+    assert all(
+        int(a.get("interface_index", -1)) != 3
+        for a in runtime.get("interface_attachments") or []
+    ), "rolled-back attachment must not be persisted on the runtime record"
+    assert expected_tap not in (runtime.get("tap_names") or []), (
+        "rolled-back TAP must not be persisted on the runtime record"
+    )
+
+
+def test_us303_rollback_logs_but_does_not_mask_when_cleanup_fails(
+    lab_settings, monkeypatch, _instance_id, caplog
+):
+    """A failing rollback step must log but NOT mask the original error
+    (plan §US-303: ``All rollback steps wrapped in try/except so a
+    rollback failure logs but does not mask the original error``).
+    """
+    lab_id = "labrb6m"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    fake_qmp.responses["netdev_add"] = {"return": {}}
+    fake_qmp.responses["device_add"] = {
+        "error": {"class": "GenericError", "desc": "step 6 failure"}
+    }
+    fake_qmp.raise_on["netdev_del"] = OSError("rollback netdev_del cannot reach socket")
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    with pytest.raises(NodeRuntimeError, match="device_add failed"):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    # The original error is still raised even though netdev_del rollback
+    # itself raised. The host-side cleanup still ran.
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    assert expected_tap in calls["tap_del"]
+    assert expected_tap in calls["link_set_nomaster"]
+
+
+# ---------------------------------------------------------------------------
+# attach_qemu_interface mutex contract
+# ---------------------------------------------------------------------------
+
+
+def test_us303_locked_helper_asserts_mutex_held(
+    lab_settings, monkeypatch, _instance_id
+):
+    """``_attach_qemu_interface_locked`` MUST refuse to run without the
+    per-(lab, node, iface) mutex held (defensive contract — Codex v5
+    finding #1).
+    """
+    lab_id = "labmtx"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, monkeypatch=monkeypatch)
+
+    with pytest.raises(AssertionError, match="mutex held"):
+        svc._attach_qemu_interface_locked(
+            lab_id, 1, network_id=5, interface_index=2
+        )
+
+
+def test_us303_concurrent_attach_serializes_on_same_iface(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Two concurrent ``attach_qemu_interface`` calls on the same
+    ``(node, iface)`` MUST serialize via the runtime mutex — they cannot
+    both run their kernel sequence simultaneously (race risk: TAP name
+    collision, slot collision).
+    """
+    lab_id = "labconc"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    # Hold a small barrier inside the section — first thread to enter
+    # publishes "in", second thread must wait until first exits.
+    in_section = threading.Event()
+    proceed = threading.Event()
+    order: list[str] = []
+
+    original = svc._qmp_command
+
+    def _slow_qmp(socket_path, command, arguments=None):
+        if command == "device_add":
+            order.append("enter")
+            in_section.set()
+            proceed.wait(timeout=2.0)
+            order.append("exit")
+        return original(socket_path, command, arguments)
+
+    monkeypatch.setattr(svc, "_qmp_command", _slow_qmp)
+
+    results: list = []
+
+    def _attach():
+        try:
+            r = svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+            results.append(("ok", r))
+        except Exception as exc:  # noqa: BLE001
+            results.append(("err", exc))
+
+    t1 = threading.Thread(target=_attach)
+    t2 = threading.Thread(target=_attach)
+    t1.start()
+    in_section.wait(timeout=2.0)
+    t2.start()
+    # T2 must be blocked waiting for the mutex — it should not have
+    # entered the QMP section yet.
+    time.sleep(0.05)
+    assert order == ["enter"], (
+        f"second thread entered the critical section while the first held the mutex; order={order!r}"
+    )
+    proceed.set()
+    t1.join(timeout=2.0)
+    t2.join(timeout=2.0)
+    # First call succeeded; second sees the duplicate-iface guard.
+    statuses = [s for s, _ in results]
+    assert "ok" in statuses
+    assert "err" in statuses
+
+
+# ---------------------------------------------------------------------------
+# link_service.create_link → QEMU dispatch + generation stamp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_us303_create_link_dispatches_qemu_running_node(
+    lab_settings, monkeypatch, _instance_id
+):
+    """``link_service.create_link`` for a running QEMU node calls
+    ``_attach_qemu_interface_locked`` (NOT the docker path) and stamps
+    ``Link.runtime.attach_generation`` atomically with the QMP success.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "labcr"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+
+    # Patch the module-level default so every NodeRuntimeService() instance
+    # — including the one link_service constructs internally — uses the
+    # fake. The registry is class-level so the seeded runtime is visible
+    # across instances.
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client", fake_qmp
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    link_service = LinkService()
+    link, network, replayed = await link_service.create_link(
+        lab_name,
+        {"node_id": 1, "interface_index": 2},
+        {"network_id": 5},
+    )
+
+    # The QEMU path was used — query-pci + netdev_add + device_add issued.
+    cmds = [c[1] for c in fake_qmp.calls]
+    assert "query-pci" in cmds
+    assert "netdev_add" in cmds
+    assert "device_add" in cmds
+
+    # Generation stamped on the link payload.
+    assert link["runtime"]["attach_generation"] == 1
+
+    # Persisted on lab.json too.
+    saved = json.loads((lab_settings.LABS_DIR / f"{lab_id}.json").read_text())
+    persisted_link = saved["links"][0]
+    assert persisted_link["runtime"]["attach_generation"] == 1
+    # And on node.interfaces[2].runtime.current_attach_generation.
+    iface_runtime = saved["nodes"]["1"]["interfaces"][2].get("runtime") or {}
+    assert iface_runtime.get("current_attach_generation") == 1
+
+
+@pytest.mark.asyncio
+async def test_us303_create_link_skips_stopped_qemu_node(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Stopped QEMU nodes have no runtime record — create_link writes the
+    link to lab.json but does NOT touch QMP. The initial-attach at start
+    time will wire it up.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "labstop"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    fake_qmp = _FakeQmp()
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client", fake_qmp
+    )
+    svc = NodeRuntimeService()
+    # Note: NO seeded runtime → node is "stopped".
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    link_service = LinkService()
+    link, _, _ = await link_service.create_link(
+        lab_name,
+        {"node_id": 1, "interface_index": 2},
+        {"network_id": 5},
+    )
+    assert link["runtime"]["attach_generation"] == 0
+    assert fake_qmp.calls == []
+
+
+@pytest.mark.asyncio
+async def test_us303_create_link_rolls_back_lab_json_on_qmp_failure(
+    lab_settings, monkeypatch, _instance_id
+):
+    """When QMP device_add fails on a running QEMU node, link_service
+    MUST roll back lab.json (the link record is removed) so the JSON
+    file leads kernel state.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "labrbjs"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    fake_qmp.responses["netdev_add"] = {"return": {}}
+    fake_qmp.responses["device_add"] = {
+        "error": {"class": "GenericError", "desc": "device add bus rp7 not found"}
+    }
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client", fake_qmp
+    )
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    link_service = LinkService()
+    with pytest.raises(NodeRuntimeError):
+        await link_service.create_link(
+            lab_name,
+            {"node_id": 1, "interface_index": 2},
+            {"network_id": 5},
+        )
+
+    # lab.json reverted: no link record persisted.
+    saved = json.loads((lab_settings.LABS_DIR / f"{lab_id}.json").read_text())
+    assert saved["links"] == [], (
+        f"link must be rolled back from lab.json on QMP failure; got {saved['links']!r}"
+    )

--- a/backend/tests/test_us303_qemu_hot_add.py
+++ b/backend/tests/test_us303_qemu_hot_add.py
@@ -42,12 +42,13 @@ from typing import Any
 import pytest
 
 from app.services import host_net
-from app.services.link_service import LinkService
+from app.services.link_service import LinkContentionError, LinkService
 from app.services.node_runtime_service import (
     NodeRuntimeError,
+    NodeRuntimeQMPTimeout,
     NodeRuntimeService,
 )
-from app.services.runtime_mutex import runtime_mutex
+from app.services.runtime_mutex import RuntimeMutexContention, runtime_mutex
 
 
 # ---------------------------------------------------------------------------
@@ -740,13 +741,17 @@ def test_us303_locked_helper_asserts_mutex_held(
         )
 
 
-def test_us303_concurrent_attach_serializes_on_same_iface(
+def test_us303_concurrent_same_iface_second_caller_gets_contention_409(
     lab_settings, monkeypatch, _instance_id
 ):
-    """Two concurrent ``attach_qemu_interface`` calls on the same
-    ``(node, iface)`` MUST serialize via the runtime mutex — they cannot
-    both run their kernel sequence simultaneously (race risk: TAP name
-    collision, slot collision).
+    """US-303 codex iter1 MEDIUM (Step 1 of test backfill): the runtime
+    mutex enforces a BOUNDED wait (default 2.0s). Two concurrent attach
+    calls on the same ``(node, iface)`` — the second one MUST raise
+    :class:`RuntimeMutexContention` once the wait expires, NOT block
+    indefinitely.
+
+    Replaces the previous ``…_serializes_on_same_iface`` test which
+    asserted the wrong (unbounded) contract.
     """
     lab_id = "labconc"
     _seed_lab(
@@ -764,51 +769,69 @@ def test_us303_concurrent_attach_serializes_on_same_iface(
     svc._qmp_client = fake_qmp
     _patch_host_net(monkeypatch)
 
-    # Hold a small barrier inside the section — first thread to enter
-    # publishes "in", second thread must wait until first exits.
     in_section = threading.Event()
     proceed = threading.Event()
-    order: list[str] = []
 
     original = svc._qmp_command
 
     def _slow_qmp(socket_path, command, arguments=None):
         if command == "device_add":
-            order.append("enter")
             in_section.set()
-            proceed.wait(timeout=2.0)
-            order.append("exit")
+            # Hold past the second caller's bounded-wait window.
+            proceed.wait(timeout=5.0)
         return original(socket_path, command, arguments)
 
     monkeypatch.setattr(svc, "_qmp_command", _slow_qmp)
 
     results: list = []
 
-    def _attach():
+    def _attach_first():
         try:
             r = svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
             results.append(("ok", r))
         except Exception as exc:  # noqa: BLE001
             results.append(("err", exc))
 
-    t1 = threading.Thread(target=_attach)
-    t2 = threading.Thread(target=_attach)
+    def _attach_second():
+        try:
+            # Bounded wait: 0.2s — much shorter than the 2.0s default
+            # so the test runs in a few hundred ms.
+            from app.services.runtime_mutex import runtime_mutex as _m
+
+            with _m.acquire_sync(lab_id, 1, 2, timeout=0.2):
+                r = svc._attach_qemu_interface_locked(
+                    lab_id, 1, network_id=5, interface_index=2
+                )
+                results.append(("ok2", r))
+        except RuntimeMutexContention as exc:
+            results.append(("contention", exc))
+        except Exception as exc:  # noqa: BLE001
+            results.append(("err", exc))
+
+    t1 = threading.Thread(target=_attach_first)
     t1.start()
     in_section.wait(timeout=2.0)
+    # First thread is now blocked in the slow device_add, holding the
+    # per-iface mutex. Launch the second attempt with a short timeout.
+    t2 = threading.Thread(target=_attach_second)
     t2.start()
-    # T2 must be blocked waiting for the mutex — it should not have
-    # entered the QMP section yet.
-    time.sleep(0.05)
-    assert order == ["enter"], (
-        f"second thread entered the critical section while the first held the mutex; order={order!r}"
-    )
+    t2.join(timeout=2.0)
+    # Now release the first thread.
     proceed.set()
     t1.join(timeout=2.0)
-    t2.join(timeout=2.0)
-    # First call succeeded; second sees the duplicate-iface guard.
+
+    # The SECOND thread must have gotten contention, NOT serialized
+    # success — we want bounded wait + 409, not unbounded blocking.
     statuses = [s for s, _ in results]
+    assert "contention" in statuses, (
+        f"second thread must hit RuntimeMutexContention within bounded wait; "
+        f"got results={results!r}"
+    )
+    contention = next(v for s, v in results if s == "contention")
+    assert isinstance(contention, RuntimeMutexContention)
+    assert contention.timeout == 0.2
+    # Sanity: first attach succeeded.
     assert "ok" in statuses
-    assert "err" in statuses
 
 
 # ---------------------------------------------------------------------------
@@ -966,3 +989,643 @@ async def test_us303_create_link_rolls_back_lab_json_on_qmp_failure(
     assert saved["links"] == [], (
         f"link must be rolled back from lab.json on QMP failure; got {saved['links']!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex iter1 backfill — Step 3 (tap_add) failure
+# ---------------------------------------------------------------------------
+
+
+def test_us303_rollback_step3_tap_add_failure_runs_nothing_else(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #2: Step 3 (``tap_add``) failure must
+    leave NO kernel object behind and MUST NOT progress to step 4
+    (``link_master``), step 5 (``netdev_add``), or step 6
+    (``device_add``).
+    """
+    lab_id = "labrb3"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([])
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    def _failing_tap_add(_name):
+        raise host_net.HostNetError("tap_add EBUSY", returncode=1, stderr="")
+
+    monkeypatch.setattr(host_net, "tap_add", _failing_tap_add)
+
+    with pytest.raises(host_net.HostNetError):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    # Step 4..6 MUST NOT have run.
+    assert calls["link_master"] == []
+    assert calls["link_set_nomaster"] == []
+    assert calls["tap_del"] == []
+    cmds = [c[1] for c in fake_qmp.calls]
+    # query-pci ran (step 2 succeeded), but neither netdev_add nor
+    # device_add did.
+    assert "query-pci" in cmds
+    assert "netdev_add" not in cmds
+    assert "device_add" not in cmds
+    # Slot reservation was released so a retry can pick it up.
+    runtime = svc._runtime_record(lab_id, 1, include_stopped=True)
+    # ``boot_slots=4`` default → only the boot reservations remain.
+    assert sorted(runtime.get("allocated_slots") or []) == [0, 1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Codex iter1 backfill — Step 5 transport-timeout (HIGH-1 case)
+# ---------------------------------------------------------------------------
+
+
+def test_us303_rollback_step5_netdev_add_transport_timeout_runs_full_chain(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #3 / HIGH-1: a transport-level timeout
+    on ``netdev_add`` (vs an in-band command error) MUST cause rollback
+    to issue both ``device_del`` (no-op since device wasn't created) AND
+    ``netdev_del`` — we cannot tell whether QEMU applied the command
+    over the lost connection.
+
+    Without the fix, ``netdev_added`` stayed False on raw transport
+    failure and rollback skipped ``netdev_del`` entirely → leaked
+    netdev.
+    """
+    lab_id = "labrbtimeout5"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    # Inject a transport-level OSError on netdev_add — _qmp_command
+    # MUST wrap it in NodeRuntimeQMPTimeout.
+    fake_qmp.raise_on["netdev_add"] = OSError(
+        "qmp socket closed during read"
+    )
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    with pytest.raises(NodeRuntimeQMPTimeout, match="netdev_add transport"):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    # Steps 3 + 4 ran.
+    assert calls["tap_add"] == [expected_tap]
+    assert calls["link_master"]
+    # Rollback: link_set_nomaster + tap_del.
+    assert calls["link_set_nomaster"] == [expected_tap]
+    assert calls["tap_del"] == [expected_tap]
+    # CRITICAL: rollback issued netdev_del (idempotent) because we
+    # don't know whether QEMU applied the command.
+    netdev_del = [c for c in fake_qmp.calls if c[1] == "netdev_del"]
+    assert len(netdev_del) == 1, (
+        f"transport-timeout on netdev_add MUST issue idempotent "
+        f"netdev_del; calls={fake_qmp.calls!r}"
+    )
+    assert netdev_del[0][2] == {"id": "net2"}
+    # device_add must NOT have been issued (we didn't get past step 5).
+    assert not any(c[1] == "device_add" for c in fake_qmp.calls)
+
+    # Slot reservation released.
+    runtime = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert int(7) not in (runtime.get("allocated_slots") or [])
+
+
+# ---------------------------------------------------------------------------
+# Codex iter1 backfill — Step 6 transport-timeout (HIGH-1 case)
+# ---------------------------------------------------------------------------
+
+
+def test_us303_rollback_step6_device_add_transport_timeout_runs_full_chain(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #4 / HIGH-1: a transport-level timeout
+    on ``device_add`` MUST cause rollback to issue both ``device_del``
+    AND ``netdev_del``.
+
+    Without the fix, the catch clause only ran ``netdev_del`` (assumed
+    netdev_added=True, device_added=False) and silently leaked any
+    device QEMU may have created before the connection died.
+    """
+    lab_id = "labrbtimeout6"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    fake_qmp.responses["netdev_add"] = {"return": {}}
+    fake_qmp.raise_on["device_add"] = OSError("qmp socket reset")
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    with pytest.raises(NodeRuntimeQMPTimeout, match="device_add transport"):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    # Both device_del AND netdev_del must have been issued (full chain).
+    cmds = [c[1] for c in fake_qmp.calls]
+    assert "device_del" in cmds, (
+        "transport-timeout on device_add MUST issue idempotent device_del"
+    )
+    assert "netdev_del" in cmds, (
+        "transport-timeout on device_add MUST issue netdev_del"
+    )
+    # Order: device_del before netdev_del (reverse of attach order).
+    device_del_idx = cmds.index("device_del")
+    netdev_del_idx = cmds.index("netdev_del")
+    assert device_del_idx < netdev_del_idx
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    assert calls["link_set_nomaster"] == [expected_tap]
+    assert calls["tap_del"] == [expected_tap]
+
+
+def test_us303_rollback_step6_timeout_idempotent_when_device_del_returns_no_such_device(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #4 (idempotency): when the timeout
+    occurred BEFORE QEMU applied device_add, the follow-up rollback
+    ``device_del`` returns "no such device". Rollback must swallow this
+    and still issue ``netdev_del``.
+    """
+    lab_id = "labrbidem"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    fake_qmp.responses["netdev_add"] = {"return": {}}
+    fake_qmp.raise_on["device_add"] = OSError("qmp socket reset")
+    # device_del returns "no such device" — QEMU never applied device_add.
+    fake_qmp.responses["device_del"] = {
+        "error": {"class": "DeviceNotFound", "desc": "no device with id dev2"}
+    }
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    with pytest.raises(NodeRuntimeQMPTimeout):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    cmds = [c[1] for c in fake_qmp.calls]
+    # The "no such device" reply on device_del must NOT prevent
+    # netdev_del.
+    assert "device_del" in cmds
+    assert "netdev_del" in cmds
+
+
+# ---------------------------------------------------------------------------
+# Codex iter1 backfill — Multi-endpoint rollback on second-endpoint failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_us303_multi_endpoint_create_rolls_back_first_on_second_timeout(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #5 / HIGH-1: implicit-bridge node↔node
+    create must roll back endpoint A's successful attach when endpoint
+    B raises a transport timeout.
+
+    The pre-fix outer rollback only caught
+    ``(NodeRuntimeError, host_net.HostNetError)`` — a raw transport
+    timeout on the second endpoint bypassed rollback entirely and
+    leaked endpoint A's TAP/netdev/device.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "labmulti"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1), "2": _qemu_node(2)},
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    fake_qmp.responses["netdev_add"] = {"return": {}}
+    # device_add succeeds for the FIRST endpoint but raises a transport
+    # OSError on the SECOND endpoint. Wrap fake_qmp via a callable
+    # closure (monkeypatching __call__ on an instance does NOT work in
+    # Python — the type's __call__ is what bound calls dispatch to).
+    device_add_count = {"n": 0}
+
+    def _selective_qmp(socket_path, command, arguments=None):
+        if command == "device_add":
+            device_add_count["n"] += 1
+            if device_add_count["n"] == 2:
+                raise OSError("qmp socket closed mid-device_add")
+        return fake_qmp(socket_path, command, arguments)
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client",
+        _selective_qmp,
+    )
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=2, boot_slots=1, monkeypatch=monkeypatch)
+    # Use the selective wrapper as the per-instance client too so the
+    # test passes through the OSError → NodeRuntimeQMPTimeout wrapping
+    # in ``_qmp_command``.
+    svc._qmp_client = _selective_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    link_service = LinkService()
+    with pytest.raises(NodeRuntimeQMPTimeout):
+        await link_service.create_link(
+            lab_name,
+            {"node_id": 1, "interface_index": 2},
+            {"node_id": 2, "interface_index": 2},
+        )
+
+    # CRITICAL: endpoint A's QMP objects must have been torn down by
+    # the outer rollback in link_service. We expect a device_del +
+    # netdev_del with id derived from interface_index=2.
+    cmds = [c[1] for c in fake_qmp.calls]
+    assert "device_del" in cmds, (
+        "outer rollback MUST issue device_del for the first (succeeded) "
+        f"endpoint; calls={cmds!r}"
+    )
+    assert "netdev_del" in cmds, (
+        "outer rollback MUST issue netdev_del for the first (succeeded) "
+        f"endpoint; calls={cmds!r}"
+    )
+    # The host-side TAP for endpoint A must have been torn down too.
+    expected_tap_a = host_net.tap_name(lab_id, 1, 2)
+    assert expected_tap_a in calls["try_link_del"] or expected_tap_a in calls["link_set_nomaster"]
+
+
+# ---------------------------------------------------------------------------
+# Codex iter1 backfill — PCIe slot race regression (HIGH-2)
+# ---------------------------------------------------------------------------
+
+
+def test_us303_concurrent_attach_different_ifaces_get_different_slots(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #6 / HIGH-2: two concurrent attaches
+    to DIFFERENT interfaces on the same VM must NOT race on slot
+    allocation. Without the node-scoped lock both calls would see the
+    same free ``rpN`` from query-pci and try to attach to the same bus.
+
+    Pre-fix expected failure mode: both calls pick the same slot,
+    second device_add fails with "bus already in use" or both succeed
+    with corrupted topology.
+
+    Post-fix: the per-(lab, node) slot lock serializes the slot-pick →
+    device_add window so the two calls receive distinct slots.
+    """
+    lab_id = "labslotrace"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1, ethernet=8)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    # boot_slots=2 → rp0+rp1 occupied, rp2..rp7 free.
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, max_nics=8, boot_slots=2, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0, 1])
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    # Coordination: thread 1 enters the slot-pick window and holds
+    # there. Thread 2 races in concurrently — without the node-scoped
+    # lock it would call query-pci immediately and pick the SAME free
+    # slot (rp7). With the lock thread 2 blocks until thread 1 finishes
+    # and reserves its slot, then sees rp7 as taken and picks rp6.
+    thread1_in_slot_pick = threading.Event()
+    thread1_proceed = threading.Event()
+    pick_call_count = {"n": 0}
+    pick_call_lock = threading.Lock()
+
+    original_find = svc._find_free_pcie_slot
+
+    def _coordinated_find(socket_path, max_nics, *, reserved_slots=None):
+        with pick_call_lock:
+            pick_call_count["n"] += 1
+            n = pick_call_count["n"]
+        if n == 1:
+            # Thread 1 enters and signals; then waits for green light so
+            # we know thread 2 is parked at the node-lock.
+            thread1_in_slot_pick.set()
+            thread1_proceed.wait(timeout=5.0)
+        return original_find(socket_path, max_nics, reserved_slots=reserved_slots)
+
+    monkeypatch.setattr(svc, "_find_free_pcie_slot", _coordinated_find)
+
+    results: list = []
+    lock = threading.Lock()
+
+    def _attach(iface_index):
+        try:
+            r = svc.attach_qemu_interface(
+                lab_id, 1, network_id=5, interface_index=iface_index
+            )
+            with lock:
+                results.append(("ok", iface_index, r))
+        except Exception as exc:  # noqa: BLE001
+            with lock:
+                results.append(("err", iface_index, exc))
+
+    t1 = threading.Thread(target=_attach, args=(2,))
+    t1.start()
+    # Wait for thread 1 to enter the slot-pick window (already holding
+    # the node-scoped lock).
+    assert thread1_in_slot_pick.wait(timeout=2.0)
+    # Now launch thread 2 — it MUST block on the node-scoped lock.
+    t2 = threading.Thread(target=_attach, args=(3,))
+    t2.start()
+    # Give thread 2 a moment to attempt its slot-pick (it should be
+    # blocked, not progressed).
+    time.sleep(0.05)
+    with pick_call_lock:
+        # If the node lock is doing its job, only thread 1 has called
+        # _find_free_pcie_slot so far. If the lock is missing, thread 2
+        # would already have entered and picked the same rp7 → race.
+        observed_calls_before_release = pick_call_count["n"]
+    # Release thread 1.
+    thread1_proceed.set()
+    t1.join(timeout=10.0)
+    t2.join(timeout=10.0)
+
+    # CRITICAL: serialization — thread 2 MUST NOT have entered slot-pick
+    # while thread 1 was inside it. Pre-fix it would have entered
+    # immediately and the count would have been 2.
+    assert observed_calls_before_release == 1, (
+        f"node-scoped slot lock did not serialize slot-pick: thread 2 "
+        f"entered while thread 1 still held the window "
+        f"(observed_calls_before_release={observed_calls_before_release})"
+    )
+
+    statuses = [s for s, _, _ in results]
+    assert statuses.count("ok") == 2, f"both attaches must succeed; got {results!r}"
+
+    # CRITICAL: the two attaches must have received DIFFERENT slots.
+    # Pre-fix this would have been the same slot (the race).
+    slots = sorted(r["slot"] for s, _, r in results if s == "ok")
+    assert len(set(slots)) == 2, (
+        f"concurrent attaches to different ifaces on the same VM picked "
+        f"the SAME slot — slot allocation race! slots={slots!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Codex iter1 backfill — link_up failure branch
+# ---------------------------------------------------------------------------
+
+
+def test_us303_rollback_link_up_failure_cleans_master_and_tap(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #7: ``host_net.link_up`` runs between
+    step 4 (link_master) and step 5 (netdev_add) and was previously
+    untested. A failure here must roll back identically to a step-4
+    failure: undo link_master + tap_add, no QMP cleanup needed.
+    """
+    lab_id = "labrblinkup"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    def _failing_link_up(_iface):
+        raise host_net.HostNetError("link_up EBUSY", returncode=1, stderr="")
+
+    monkeypatch.setattr(host_net, "link_up", _failing_link_up)
+
+    with pytest.raises(host_net.HostNetError):
+        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    # Steps 3 + 4 ran (tap + master).
+    assert calls["tap_add"] == [expected_tap]
+    assert calls["link_master"]
+    # Rollback ran: link_set_nomaster + tap_del.
+    assert calls["link_set_nomaster"] == [expected_tap]
+    assert calls["tap_del"] == [expected_tap]
+    # No QMP traffic past query-pci (step 5/6 never ran).
+    cmds = [c[1] for c in fake_qmp.calls]
+    assert "netdev_add" not in cmds
+    assert "device_add" not in cmds
+    assert "netdev_del" not in cmds
+    assert "device_del" not in cmds
+
+
+# ---------------------------------------------------------------------------
+# Codex iter1 backfill — planned-MAC observability after hot-add
+# ---------------------------------------------------------------------------
+
+
+def test_us303_planned_mac_persisted_after_hot_add_for_firstmac_default(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #8: when ``interface.planned_mac`` is
+    None (default ``firstmac+offset`` case), the value computed at
+    hot-add time MUST be persisted onto ``node.interfaces[i].planned_mac``
+    so the live-MAC mismatch detector (``_read_qemu_live_mac``) has a
+    real value to compare against.
+
+    Pre-fix the default case left ``planned_mac=None`` in lab.json and
+    the mismatch detector silently compared the live MAC against an
+    empty string → always reported "confirmed" regardless of the actual
+    guest MAC.
+    """
+    lab_id = "labpm"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    # Hot-add interface_index=2.
+    attachment = svc.attach_qemu_interface(
+        lab_id, 1, network_id=5, interface_index=2
+    )
+    # The attachment record carries the computed planned_mac too.
+    assert attachment["planned_mac"], (
+        f"attachment must carry the planned_mac that was passed to "
+        f"device_add; got {attachment!r}"
+    )
+
+    # device_add was issued with mac=<planned_mac>.
+    device_add = next(c for c in fake_qmp.calls if c[1] == "device_add")
+    assert device_add[2].get("mac") == attachment["planned_mac"]
+
+    # CRITICAL: lab.json now has the planned_mac persisted on
+    # node.interfaces[2].planned_mac so the mismatch detector can read
+    # it back.
+    saved = json.loads((lab_settings.LABS_DIR / f"{lab_id}.json").read_text())
+    iface = saved["nodes"]["1"]["interfaces"][2]
+    assert iface["planned_mac"] == attachment["planned_mac"], (
+        f"planned_mac must be persisted on node.interfaces[2]; "
+        f"got iface={iface!r}"
+    )
+
+
+def test_us303_planned_mac_does_not_overwrite_explicit_operator_value(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #8 (idempotency): if the operator
+    explicitly set ``interface.planned_mac`` in lab.json, hot-add MUST
+    use that value AND must not overwrite it with a recomputed default.
+    """
+    lab_id = "labpmexp"
+    explicit_mac = "52:54:00:de:ad:42"
+    node = _qemu_node(1)
+    node["interfaces"][2]["planned_mac"] = explicit_mac
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": node},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    attachment = svc.attach_qemu_interface(
+        lab_id, 1, network_id=5, interface_index=2
+    )
+    assert attachment["planned_mac"].lower() == explicit_mac.lower()
+
+    # device_add used the explicit MAC.
+    device_add = next(c for c in fake_qmp.calls if c[1] == "device_add")
+    assert device_add[2]["mac"].lower() == explicit_mac.lower()
+
+    # lab.json still carries the operator's value (idempotent — not
+    # overwritten with a recomputed default).
+    saved = json.loads((lab_settings.LABS_DIR / f"{lab_id}.json").read_text())
+    assert saved["nodes"]["1"]["interfaces"][2]["planned_mac"] == explicit_mac
+
+
+# ---------------------------------------------------------------------------
+# Codex iter1 backfill — link_service 409 mapping for contention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_us303_link_service_create_link_409_on_mutex_contention(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Codex iter1 test backfill #1 (Step 1): when the per-(lab, node,
+    iface) mutex is already held by another in-flight call,
+    ``link_service.create_link`` must raise :class:`LinkContentionError`
+    so the router can return HTTP 409.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab409"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_qemu_runtime(svc, lab_id=lab_id, node_id=1, boot_slots=1, monkeypatch=monkeypatch)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["query-pci"] = _query_pci_response([0])
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client", fake_qmp
+    )
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    # Pre-acquire the mutex on another thread — release after the test
+    # has exercised the contention path.
+    proceed = threading.Event()
+    holder_started = threading.Event()
+
+    def _hold():
+        with runtime_mutex.acquire_sync(lab_id, 1, 2, timeout=5.0):
+            holder_started.set()
+            proceed.wait(timeout=5.0)
+
+    holder = threading.Thread(target=_hold)
+    holder.start()
+    assert holder_started.wait(timeout=2.0)
+
+    link_service = LinkService()
+    # Patch the mutex's acquire timeout via direct call: we cannot pass
+    # a custom timeout through link_service.create_link, so we monkey-
+    # patch the registry's default timeout for this test.
+    monkeypatch.setattr(
+        "app.services.runtime_mutex.DEFAULT_ACQUIRE_TIMEOUT_S", 0.2
+    )
+
+    try:
+        with pytest.raises(LinkContentionError):
+            await link_service.create_link(
+                lab_name,
+                {"node_id": 1, "interface_index": 2},
+                {"network_id": 5},
+            )
+    finally:
+        proceed.set()
+        holder.join(timeout=2.0)


### PR DESCRIPTION
## Summary

Implements **US-303 — QMP-driven hot-add NIC** for running QEMU nodes. `link_service.create_link` now performs a 4-step QMP/host sequence (after acquiring the per-(lab, node, iface) runtime mutex from US-204b) when an endpoint is a running QEMU VM:

  1. QMP `query-pci` → highest free `pcie-root-port` (descending scan per US-301).
  2. `host_net.tap_add` + `host_net.link_master` (TAP attached to the network's bridge per US-302) + `host_net.link_up`.
  3. QMP `netdev_add type=tap id=net{interface_index}` (id MUST be `net{interface_index}`, not slot — preserves the `_read_qemu_live_mac` invariant).
  4. QMP `device_add driver={qemu_nic} id=dev{interface_index} netdev=net{interface_index} bus=rp{slot} mac={planned_mac}` — `driver=` comes from `extras.qemu_nic`, NOT a hardcoded `virtio-net-pci`.

`Link.runtime.attach_generation` is stamped atomically with the QMP success (mirrors US-204) so US-204b's stale-detach guard composes correctly. The full 6-step rollback (each cleanup wrapped in try/except) is enumerated in plan §US-303.

## Files changed

- `backend/app/services/node_runtime_service.py` — adds `attach_qemu_interface` (PUBLIC), `_attach_qemu_interface_locked` (PRIVATE — mutex-asserted), `_qmp_command`, `_find_free_pcie_slot`, `_resolve_qemu_nic_model`, `_resolve_qemu_planned_mac`. Refactors `_default_qmp_client` to delegate to a new `_qmp_send_with_args` helper that supports QMP commands with arguments (`netdev_add`, `device_add`, etc.).
- `backend/app/services/link_service.py` — `_hot_attach_running_endpoints` now dispatches docker AND qemu kinds (was docker-only with a `# QEMU hot-attach is US-303` skip). Rollback handler tears down the right kernel objects per kind.
- `backend/tests/test_us303_qemu_hot_add.py` — **NEW**: 16 regression tests including the explicit 6-step rollback test the plan calls out.

## Plan reference

- `.omc/plans/network-runtime-wiring.md`, **US-303** at lines **417–435** (acceptance criteria, 6-step rollback, slot-exhaustion fallback).
- Cross-refs: US-301 (lines 392–403, slot pre-allocation policy), US-302 (lines 405–415, per-NIC TAP+bridge attach), US-204b (lines 320–334, runtime mutex + generation tokens).

## Tests proving acceptance

All 16 in `backend/tests/test_us303_qemu_hot_add.py`:

- `test_us303_qmp_id_uses_interface_index_not_slot` — `_read_qemu_live_mac` invariant (id=`net{interface_index}`, NOT slot)
- `test_us303_driver_comes_from_extras_qemu_nic` — Codex critic finding #4
- `test_us303_descending_slot_scan_picks_highest_free` — US-301 policy
- `test_us303_slot_exhaustion_surfaces_user_actionable_error` — Principle 4 fix
- `test_us303_rejects_when_hotplug_capable_false` — `capabilities.hotplug==false` gate
- `test_us303_rejects_duplicate_interface_index` — re-attach guard
- `test_us303_rollback_query_pci_failure_cleans_nothing` — step 2 rollback
- `test_us303_rollback_link_master_failure_cleans_tap` — step 4 rollback
- `test_us303_rollback_netdev_add_failure_cleans_master_then_tap` — step 5 rollback
- `test_us303_rollback_device_add_failure_full_six_step` — **the 6-step rollback test the plan explicitly calls out**
- `test_us303_rollback_logs_but_does_not_mask_when_cleanup_fails` — rollback failure does not mask original error
- `test_us303_locked_helper_asserts_mutex_held` — defensive contract (Codex v5 finding #1)
- `test_us303_concurrent_attach_serializes_on_same_iface` — runtime mutex serialisation
- `test_us303_create_link_dispatches_qemu_running_node` — end-to-end + generation stamp
- `test_us303_create_link_skips_stopped_qemu_node` — stopped-node no-op
- `test_us303_create_link_rolls_back_lab_json_on_qmp_failure` — JSON file leads kernel state

## Test plan

- [x] `cd backend && .venv/bin/python -m pytest tests/ --tb=short` → **589 passed, 1 skipped, 1 failed** (`test_migrate_continues_on_no_such_network_inspect_error` — pre-existing, unrelated to US-303, called out in the brief)
- [x] All 16 new US-303 tests pass
- [x] All 51 related existing tests still pass (`test_qemu_pcie_root_ports.py`, `test_qmp_query.py`, `test_link_service.py`, `test_runtime_mutex.py`, `test_us205_hot_detach.py`)
- [ ] Manual on test VM: drag-to-connect a running vyos-1 to a new network; observe the QMP `device_add` lands a new NIC in the guest (per the §US-303 manual verification step)

Refs #101, Refs #80