### PR TITLE
feat(qemu): QMP-driven hot-remove NIC with bounded poll + forced fallback (US-304, #102)

### DIFF
--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -1060,12 +1060,22 @@ class LinkService:
                     # caller (delete_link) so we use the PRIVATE locked
                     # helper directly to avoid re-acquiring on the same
                     # thread.
+                    #
+                    # US-204b freshness contract (codex hotfix HIGH-1):
+                    # pass ``expected_generation`` so a stale rollback
+                    # cannot tear down a NEWER QEMU NIC on the same iface
+                    # — QMP IDs reuse ``dev{iface}`` / ``net{iface}`` and
+                    # without the gen check the docker-path safety net
+                    # was silently bypassed on the qemu side.
                     try:
                         runtime_service._detach_qemu_interface_locked(
                             mutex_lab_id,
                             int(node_id),
                             int(iface_idx),
                             lab_path=normalized,
+                            expected_generation=(
+                                int(attach_generation) if attach_generation else None
+                            ),
                         )
                     except RuntimeMutexContention as exc:
                         raise LinkContentionError(exc) from exc

--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -1003,10 +1003,19 @@ class LinkService:
         # ------------------------------------------------------------------
         if node_eps:
             from app.services.node_runtime_service import (  # noqa: WPS433
+                NodeRuntimeError,
+                NodeRuntimeQMPTimeout,
                 NodeRuntimeService,
             )
 
             runtime_service = NodeRuntimeService()
+            # US-304: collect (node_id, iface_idx, kind) so we can
+            # tear down qemu + docker endpoints on the same link in
+            # the right order. For multi-endpoint mixed-kind links,
+            # surface the FIRST error and best-effort log the
+            # secondary cleanup attempt — partial-failure detach is
+            # better than no detach.
+            primary_error: Exception | None = None
             for node_id, iface_idx in node_eps:
                 runtime = runtime_service._runtime_record(
                     mutex_lab_id, node_id, include_stopped=True
@@ -1015,20 +1024,72 @@ class LinkService:
                     # Stopped node — no kernel-side work; proceed to JSON
                     # cleanup so the link record disappears.
                     continue
-                if runtime.get("kind") != "docker":
-                    # QEMU hot-detach is US-303.
-                    continue
-                # Any non-EINVAL ``host_net.HostNetError`` (or
-                # ``NodeRuntimeError``) propagates — caller leaves JSON +
-                # IPAM intact and surfaces the error.
-                runtime_service._detach_docker_interface_locked(
-                    mutex_lab_id,
-                    int(node_id),
-                    int(iface_idx),
-                    expected_generation=(
-                        int(attach_generation) if attach_generation else None
-                    ),
-                )
+                kind = str(runtime.get("kind") or "")
+                if kind == "docker":
+                    try:
+                        runtime_service._detach_docker_interface_locked(
+                            mutex_lab_id,
+                            int(node_id),
+                            int(iface_idx),
+                            expected_generation=(
+                                int(attach_generation) if attach_generation else None
+                            ),
+                        )
+                    except RuntimeMutexContention as exc:
+                        # Surface as 409 to the router (mirrors create_link).
+                        raise LinkContentionError(exc) from exc
+                    except (
+                        NodeRuntimeError,
+                        NodeRuntimeQMPTimeout,
+                        host_net.HostNetError,
+                    ) as exc:
+                        if primary_error is None:
+                            primary_error = exc
+                        else:
+                            _logger.exception(
+                                "delete_link: secondary docker detach failed "
+                                "(lab=%s node=%s iface=%s) — primary error already "
+                                "raised: %s",
+                                mutex_lab_id,
+                                node_id,
+                                iface_idx,
+                                primary_error,
+                            )
+                elif kind == "qemu":
+                    # US-304: hot-detach via QMP. Mutex is held by the
+                    # caller (delete_link) so we use the PRIVATE locked
+                    # helper directly to avoid re-acquiring on the same
+                    # thread.
+                    try:
+                        runtime_service._detach_qemu_interface_locked(
+                            mutex_lab_id,
+                            int(node_id),
+                            int(iface_idx),
+                            lab_path=normalized,
+                        )
+                    except RuntimeMutexContention as exc:
+                        raise LinkContentionError(exc) from exc
+                    except (
+                        NodeRuntimeError,
+                        NodeRuntimeQMPTimeout,
+                        host_net.HostNetError,
+                    ) as exc:
+                        if primary_error is None:
+                            primary_error = exc
+                        else:
+                            _logger.exception(
+                                "delete_link: secondary qemu detach failed "
+                                "(lab=%s node=%s iface=%s) — primary error already "
+                                "raised: %s",
+                                mutex_lab_id,
+                                node_id,
+                                iface_idx,
+                                primary_error,
+                            )
+                # Any other runtime kind (iol, dynamips, vpcs) — no
+                # hot-detach path yet; fall through to JSON cleanup.
+            if primary_error is not None:
+                raise primary_error
 
         # ------------------------------------------------------------------
         # Phase 3 — release the IP via ``network_service._release_ip`` (its

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -2284,6 +2284,7 @@ class NodeRuntimeService:
         interface_index: int,
         *,
         lab_path: str | None = None,
+        expected_generation: int | None = None,
     ) -> dict[str, Any]:
         """US-304 PUBLIC hot-remove NIC for a running QEMU node.
 
@@ -2298,6 +2299,15 @@ class NodeRuntimeService:
         contextualisation; the detach itself is fully driven by the
         in-process runtime registry (no lab.json read required).
 
+        ``expected_generation`` mirrors the US-204b freshness contract on
+        the docker detach path: when supplied, it is compared against the
+        runtime's per-interface ``current_attach_generation`` before any
+        QMP traffic. A stale rollback (older generation than the live
+        attachment) returns ``state='stale_noop'`` without issuing
+        ``device_del`` — preventing a stale delete/rollback from tearing
+        down a NEWER QEMU NIC that reuses the same ``dev{iface}`` /
+        ``net{iface}`` QMP IDs.
+
         Returns a result dict whose ``state`` field is one of:
           * ``"detached"`` — device gone from QMP within the bounded
             poll window; ``netdev_del`` + ``tap_del`` were issued.
@@ -2307,6 +2317,8 @@ class NodeRuntimeService:
             side still holds the device.
           * ``"absent"`` — no runtime record / no matching attachment
             (idempotent double-delete).
+          * ``"stale_noop"`` — ``expected_generation`` did not match the
+            current runtime generation; nothing was changed.
         """
         from app.services.runtime_mutex import runtime_mutex
 
@@ -2316,6 +2328,7 @@ class NodeRuntimeService:
                 node_id,
                 interface_index,
                 lab_path=lab_path,
+                expected_generation=expected_generation,
             )
 
     def _detach_qemu_interface_locked(
@@ -2325,6 +2338,7 @@ class NodeRuntimeService:
         interface_index: int,
         *,
         lab_path: str | None = None,
+        expected_generation: int | None = None,
     ) -> dict[str, Any]:
         """US-304 PRIVATE hot-remove NIC. Mutex MUST be held.
 
@@ -2396,6 +2410,34 @@ class NodeRuntimeService:
                 break
         if target is None:
             return {"state": "absent", "reason": "no attachment record"}
+
+        # US-204b generation-token check (mirrors
+        # :meth:`_detach_docker_interface_locked`). Use the interface's
+        # ``current_attach_generation`` (the freshness oracle) — NOT the
+        # attachment's own ``attach_generation`` — so a fresh re-attach
+        # (which bumped ``current_attach_generation`` past the caller's
+        # ``expected_generation``) correctly invalidates a stale rollback.
+        # Without this guard, a stale delete/rollback could tear down a
+        # NEWER QEMU NIC because QMP IDs reuse ``dev{iface}`` /
+        # ``net{iface}`` deterministically.
+        current_gen = self._interface_attach_generation(
+            runtime, int(interface_index)
+        )
+        if expected_generation is not None and int(expected_generation) != int(current_gen):
+            _logger.info(
+                "stale qemu detach for gen %s (current %s), ignoring "
+                "(lab=%s node=%s iface=%s)",
+                expected_generation,
+                current_gen,
+                lab_id,
+                node_id,
+                interface_index,
+            )
+            return {
+                "state": "stale_noop",
+                "expected_generation": int(expected_generation),
+                "current_attach_generation": int(current_gen),
+            }
 
         socket_path = runtime.get("qmp_socket") or ""
         if not socket_path:

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -2670,10 +2670,16 @@ class NodeRuntimeService:
         """Return True iff ``query-pci`` shows no device with
         ``qdev_id == device_id`` anywhere in the bus->devices arrays.
 
-        Used by US-304 hot-remove to bound-poll guest ejection. Walks the
-        same tree shape as :meth:`_find_free_pcie_slot`: each bus has
-        ``devices`` (root-port carriers) and each carrier has
-        ``pci_bridge.devices`` (the actual NICs).
+        Used by US-304 hot-remove to bound-poll guest ejection.
+
+        Codex hotfix MEDIUM-2: walks the FULL nested ``pci_bridge``
+        subtree exhaustively. The previous implementation only walked
+        the top-level ``bus.devices`` array and ONE ``pci_bridge.devices``
+        level — for deeper PCIe topologies (bridge under bridge under
+        bridge), it returned ``True`` (gone) too early, causing the
+        detach path to run ``netdev_del`` / ``tap_del`` while the device
+        was still present in QEMU. We now recurse into every nested
+        ``pci_bridge.devices`` subtree until exhaustion.
         """
         response = self._qmp_command(socket_path, "query-pci")
         if not isinstance(response, dict):
@@ -2688,22 +2694,29 @@ class NodeRuntimeService:
         buses = response.get("return")
         if not isinstance(buses, list):
             return True  # malformed but device certainly not present
-        for bus in buses:
-            if not isinstance(bus, dict):
-                continue
-            for device in bus.get("devices") or []:
+
+        def _device_present_in_subtree(devices: Any) -> bool:
+            """Recurse through ``devices`` and any nested
+            ``pci_bridge.devices`` subtrees until exhaustion.
+            """
+            if not isinstance(devices, list):
+                return False
+            for device in devices:
                 if not isinstance(device, dict):
                     continue
                 if str(device.get("qdev_id") or "") == device_id:
-                    return False
-                # Walk into the root-port's pci_bridge children too.
+                    return True
                 bridge = device.get("pci_bridge")
                 if isinstance(bridge, dict):
-                    for child in bridge.get("devices") or []:
-                        if not isinstance(child, dict):
-                            continue
-                        if str(child.get("qdev_id") or "") == device_id:
-                            return False
+                    if _device_present_in_subtree(bridge.get("devices")):
+                        return True
+            return False
+
+        for bus in buses:
+            if not isinstance(bus, dict):
+                continue
+            if _device_present_in_subtree(bus.get("devices")):
+                return False
         return True
 
     def _publish_node_warning(

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -2273,6 +2273,406 @@ class NodeRuntimeService:
 
         return new_attachment
 
+    # ------------------------------------------------------------------
+    # US-304 — QMP-driven hot-remove NIC for running QEMU nodes
+    # ------------------------------------------------------------------
+
+    def detach_qemu_interface(
+        self,
+        lab_id: str,
+        node_id: int,
+        interface_index: int,
+        *,
+        lab_path: str | None = None,
+    ) -> dict[str, Any]:
+        """US-304 PUBLIC hot-remove NIC for a running QEMU node.
+
+        Acquires the per-``(lab_id, node_id, interface_index)`` mutex
+        internally (mirrors :meth:`attach_qemu_interface`) and delegates
+        to :meth:`_detach_qemu_interface_locked`. Used by callers that do
+        NOT already hold the mutex on entry (e.g. direct API entrypoints).
+        ``link_service.delete_link`` instead acquires the mutex itself
+        and calls the locked helper directly to avoid double-acquisition.
+
+        ``lab_path`` is accepted as a forward-compat hook for log
+        contextualisation; the detach itself is fully driven by the
+        in-process runtime registry (no lab.json read required).
+
+        Returns a result dict whose ``state`` field is one of:
+          * ``"detached"`` — device gone from QMP within the bounded
+            poll window; ``netdev_del`` + ``tap_del`` were issued.
+          * ``"forced"`` — guest never ejected the device; the TAP was
+            detached from the bridge (kernel-side stop) but ``netdev_del``
+            and ``tap_del`` were intentionally skipped because the QMP
+            side still holds the device.
+          * ``"absent"`` — no runtime record / no matching attachment
+            (idempotent double-delete).
+        """
+        from app.services.runtime_mutex import runtime_mutex
+
+        with runtime_mutex.acquire_sync(lab_id, node_id, interface_index):
+            return self._detach_qemu_interface_locked(
+                lab_id,
+                node_id,
+                interface_index,
+                lab_path=lab_path,
+            )
+
+    def _detach_qemu_interface_locked(
+        self,
+        lab_id: str,
+        node_id: int,
+        interface_index: int,
+        *,
+        lab_path: str | None = None,
+    ) -> dict[str, Any]:
+        """US-304 PRIVATE hot-remove NIC. Mutex MUST be held.
+
+        Sequence (per plan §US-304 acceptance criteria):
+
+          1. QMP ``device_del id=dev{interface_index}``. If QEMU returns
+             ``DeviceNotFound`` (race A — delete arrived before add
+             completed), sleep 0.5s and retry once; if still
+             ``DeviceNotFound``, treat as already-detached success
+             (idempotent double-delete).
+          2. Bounded poll: ``query-pci`` every 500ms for up to 8s
+             (16 iterations). Device is "gone" when no
+             ``qdev_id == f"dev{interface_index}"`` appears anywhere in
+             the bus->devices arrays.
+          3a. Happy path (gone within timeout): QMP ``netdev_del`` ->
+              ``host_net.tap_del(tap_name)``.
+          3b. Forced fallback (still present at 8s):
+              ``host_net.link_set_nomaster(tap_name)`` so packets stop
+              flowing kernel-side; do NOT call ``tap_del`` or
+              ``netdev_del`` because the QEMU side still references the
+              device until guest reboot. Publish a ``node_warning`` WS
+              event so the UI can surface "restart node to fully clean".
+
+        Transport-level errors (``NodeRuntimeQMPTimeout``) on
+        ``device_del``, ``netdev_del``, or ``query-pci`` propagate — they
+        are NOT swallowed as forced-fallback (transport timeout != guest
+        didn't eject).
+
+        Generation tokens: bump ``current_attach_generation`` for this
+        interface AFTER the kernel objects are removed (happy path) so a
+        stale concurrent attach doesn't race a freshly torn-down NIC.
+        Forced fallback also bumps the generation because lab.json's
+        ``links[]`` will be the source of truth and the kernel-side
+        object is no longer reachable.
+        """
+        from app.services.runtime_mutex import runtime_mutex
+
+        # Defensive contract: catches accidental bypass of the public API.
+        assert runtime_mutex.is_held(lab_id, node_id, interface_index), (
+            f"_detach_qemu_interface_locked called without the per-"
+            f"(lab, node, iface) mutex held for "
+            f"({lab_id!r}, {node_id}, {interface_index}); use the public "
+            f"detach_qemu_interface(...) entrypoint or acquire "
+            f"runtime_mutex.acquire(...) yourself."
+        )
+
+        runtime = self._runtime_record(lab_id, node_id, include_stopped=True)
+        if runtime is None:
+            # No runtime record means the node already stopped or never
+            # started — nothing to detach. Treat as idempotent absent.
+            return {"state": "absent", "reason": "no runtime record"}
+        if runtime.get("kind") != "qemu":
+            # Wrong runtime kind — caller (link_service) routes by kind so
+            # this should never happen, but keep it defensive.
+            return {
+                "state": "absent",
+                "reason": f"runtime kind={runtime.get('kind')!r}, expected 'qemu'",
+            }
+
+        # Locate the matching attachment record. Missing means the iface
+        # is already detached — idempotent no-op.
+        attachments = runtime.get("interface_attachments") or []
+        target = None
+        target_index = None
+        for index, entry in enumerate(attachments):
+            if int(entry.get("interface_index", -1)) == int(interface_index):
+                target = entry
+                target_index = index
+                break
+        if target is None:
+            return {"state": "absent", "reason": "no attachment record"}
+
+        socket_path = runtime.get("qmp_socket") or ""
+        if not socket_path:
+            work_dir = runtime.get("work_dir")
+            socket_path = str(Path(work_dir) / "qmp.sock") if work_dir else ""
+        if not socket_path:
+            raise NodeRuntimeError(
+                f"Cannot hot-detach interface on node {node_id}: QMP socket "
+                "path is not set on the runtime record."
+            )
+
+        device_id = f"dev{int(interface_index)}"
+        netdev_id = f"net{int(interface_index)}"
+        tap = target.get("tap_name") or host_net.tap_name(
+            lab_id, int(node_id), int(interface_index)
+        )
+        slot = target.get("slot")
+
+        # ----- Step 1: device_del with race-A retry --------------------
+        device_already_gone = False
+        device_del_response = self._qmp_command(
+            socket_path, "device_del", {"id": device_id}
+        )
+        if (
+            isinstance(device_del_response, dict)
+            and isinstance(device_del_response.get("error"), dict)
+        ):
+            err = device_del_response["error"]
+            err_class = str(err.get("class", "")) if isinstance(err, dict) else ""
+            if err_class == "DeviceNotFound":
+                # Race A: delete arrived before the create-side flushed
+                # device_add. Sleep briefly, then retry once. If the
+                # device still does not exist, treat as already-detached
+                # idempotent success.
+                time.sleep(0.5)
+                retry_response = self._qmp_command(
+                    socket_path, "device_del", {"id": device_id}
+                )
+                if (
+                    isinstance(retry_response, dict)
+                    and isinstance(retry_response.get("error"), dict)
+                    and str(retry_response["error"].get("class", ""))
+                    == "DeviceNotFound"
+                ):
+                    device_already_gone = True
+                elif (
+                    isinstance(retry_response, dict)
+                    and isinstance(retry_response.get("error"), dict)
+                ):
+                    raise NodeRuntimeError(
+                        f"QMP device_del retry failed: {retry_response['error']}"
+                    )
+                # else: retry succeeded — fall through to bounded poll.
+            else:
+                raise NodeRuntimeError(
+                    f"QMP device_del failed: {err}"
+                )
+
+        # ----- Step 2: bounded poll for device removal -----------------
+        # 16 iterations * 500ms = 8s ceiling per plan §US-304.
+        device_gone = device_already_gone
+        if not device_gone:
+            for _iteration in range(16):
+                if self._qemu_device_gone(socket_path, device_id):
+                    device_gone = True
+                    break
+                time.sleep(0.5)
+
+        forced_fallback = False
+        if device_gone:
+            # ----- Step 3a: happy path — netdev_del + tap_del ----------
+            # Order: issue netdev_del first; on transport timeout we
+            # STILL run tap_del so the kernel TAP doesn't leak (the
+            # host-side cleanup is not impacted by a QMP transport
+            # blip). The exception is re-raised AFTER the host-side
+            # cleanup. In-band ``netdev_del`` errors that look like
+            # "no such netdev" are absorbed (the netdev was already
+            # removed); other in-band errors are deferred until after
+            # tap_del runs so the host-side still gets cleaned up.
+            netdev_del_error: dict[str, Any] | None = None
+            netdev_transport_error: NodeRuntimeQMPTimeout | None = None
+            try:
+                netdev_del_response = self._qmp_command(
+                    socket_path, "netdev_del", {"id": netdev_id}
+                )
+            except NodeRuntimeQMPTimeout as exc:
+                # Transport timeout: cleanup host side first, raise after.
+                netdev_transport_error = exc
+                netdev_del_response = None
+            if isinstance(netdev_del_response, dict) and isinstance(
+                netdev_del_response.get("error"), dict
+            ):
+                err = netdev_del_response["error"]
+                err_class = str(err.get("class", ""))
+                err_desc = str(err.get("desc", "")).lower()
+                # An idempotent "no such netdev" reply is fine — netdev
+                # was already removed by an earlier rollback. Match by
+                # err_class plus a description heuristic (QEMU's reply
+                # is a GenericError with "not found" in the desc).
+                idempotent = (
+                    err_class == "DeviceNotFound"
+                    or "no" in err_desc
+                    or "not found" in err_desc
+                )
+                if not idempotent:
+                    netdev_del_error = err
+
+            # tap_del is best-effort with a typed propagation: if the
+            # TAP is already gone (HostNetEINVAL), swallow it; any
+            # other helper error propagates so the caller can roll back.
+            try:
+                host_net.tap_del(tap)
+            except host_net.HostNetEINVAL:
+                pass
+
+            if netdev_transport_error is not None:
+                raise netdev_transport_error
+            if netdev_del_error is not None:
+                raise NodeRuntimeError(
+                    f"QMP netdev_del failed: {netdev_del_error}"
+                )
+        else:
+            # ----- Step 3b: forced fallback ---------------------------
+            forced_fallback = True
+            try:
+                host_net.link_set_nomaster(tap)
+            except host_net.HostNetError:
+                _logger.exception(
+                    "us-304 forced-fallback: link_set_nomaster(%s) failed",
+                    tap,
+                )
+            # Publish a ws_hub warning so the UI can surface that the
+            # guest did not eject the NIC.
+            try:
+                self._publish_node_warning(
+                    lab_id=lab_id,
+                    node_id=int(node_id),
+                    interface_index=int(interface_index),
+                    message="guest did not eject NIC; restart node to fully clean",
+                )
+            except Exception:  # noqa: BLE001
+                _logger.exception(
+                    "us-304 forced-fallback: ws warning publish failed "
+                    "(lab=%s node=%s iface=%s)",
+                    lab_id,
+                    node_id,
+                    interface_index,
+                )
+
+        # ----- Drop attachment + slot reservation from runtime ---------
+        with self._lock:
+            attachments_list = list(runtime.get("interface_attachments") or [])
+            if target_index is not None and target_index < len(attachments_list):
+                # Re-locate by interface_index to be robust against any
+                # concurrent mutation between probe and now.
+                for idx, entry in enumerate(attachments_list):
+                    if int(entry.get("interface_index", -1)) == int(interface_index):
+                        attachments_list.pop(idx)
+                        break
+            runtime["interface_attachments"] = attachments_list
+
+            # Happy path: drop the TAP from the runtime's tap_names so
+            # stop-time sweep doesn't double-process. Forced fallback:
+            # leave the TAP entry in place so stop-time cleanup still
+            # removes the kernel object on node restart.
+            if not forced_fallback:
+                tap_names = [
+                    t for t in (runtime.get("tap_names") or []) if t != tap
+                ]
+                runtime["tap_names"] = tap_names
+
+            # Release the slot reservation so a future hot-add can pick
+            # it up. Forced fallback also releases — the QEMU side still
+            # holds the device, but our in-process tracking should
+            # reflect "intent to remove" so a re-attach with a different
+            # iface_index can use the slot pool. The QEMU device_add
+            # would still collide with the stale guest device but that
+            # is exactly the "restart node" message we surfaced.
+            if slot is not None:
+                allocated = list(runtime.get("allocated_slots") or [])
+                runtime["allocated_slots"] = [
+                    s for s in allocated if int(s) != int(slot)
+                ]
+
+        # Bump the generation so concurrent / future attach operations
+        # observe a fresh ``current_attach_generation`` and a stale
+        # rollback re-attach is invalidated.
+        new_generation = self._bump_interface_attach_generation(
+            runtime, int(interface_index)
+        )
+        self._persist_runtime(runtime)
+
+        result: dict[str, Any] = {
+            "state": "forced" if forced_fallback else "detached",
+            "interface_index": int(interface_index),
+            "tap_name": tap,
+            "current_attach_generation": int(new_generation),
+        }
+        if device_already_gone:
+            result["device_already_gone"] = True
+        return result
+
+    def _qemu_device_gone(self, socket_path: str, device_id: str) -> bool:
+        """Return True iff ``query-pci`` shows no device with
+        ``qdev_id == device_id`` anywhere in the bus->devices arrays.
+
+        Used by US-304 hot-remove to bound-poll guest ejection. Walks the
+        same tree shape as :meth:`_find_free_pcie_slot`: each bus has
+        ``devices`` (root-port carriers) and each carrier has
+        ``pci_bridge.devices`` (the actual NICs).
+        """
+        response = self._qmp_command(socket_path, "query-pci")
+        if not isinstance(response, dict):
+            raise NodeRuntimeError(
+                "QMP query-pci returned non-dict response during detach poll"
+            )
+        if "error" in response:
+            raise NodeRuntimeError(
+                f"QMP query-pci returned error during detach poll: "
+                f"{response['error']}"
+            )
+        buses = response.get("return")
+        if not isinstance(buses, list):
+            return True  # malformed but device certainly not present
+        for bus in buses:
+            if not isinstance(bus, dict):
+                continue
+            for device in bus.get("devices") or []:
+                if not isinstance(device, dict):
+                    continue
+                if str(device.get("qdev_id") or "") == device_id:
+                    return False
+                # Walk into the root-port's pci_bridge children too.
+                bridge = device.get("pci_bridge")
+                if isinstance(bridge, dict):
+                    for child in bridge.get("devices") or []:
+                        if not isinstance(child, dict):
+                            continue
+                        if str(child.get("qdev_id") or "") == device_id:
+                            return False
+        return True
+
+    def _publish_node_warning(
+        self,
+        *,
+        lab_id: str,
+        node_id: int,
+        interface_index: int,
+        message: str,
+    ) -> None:
+        """US-304 forced-fallback: publish a ``node_warning`` WS event so
+        the UI can surface the "guest did not eject" condition.
+
+        Goes through :class:`app.services.ws_hub.ws_hub` (the existing
+        per-lab event hub) — there is no separate ``ws_manager`` service.
+        Fire-and-forget: we schedule the coroutine on the running event
+        loop if one is available, otherwise we fall back to
+        ``asyncio.run`` so sync callers still get the broadcast.
+        """
+        from app.services.ws_hub import ws_hub  # local import — cycle-free
+
+        payload = {
+            "node_id": int(node_id),
+            "interface_index": int(interface_index),
+            "message": message,
+        }
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is not None and loop.is_running():
+            loop.create_task(ws_hub.publish(lab_id, "node_warning", payload))
+            return
+        # No running loop — synchronous caller. Run the publish in a
+        # short-lived loop so the event still goes out.
+        asyncio.run(ws_hub.publish(lab_id, "node_warning", payload))
+
     def _qmp_command(
         self, socket_path: str, command: str, arguments: dict[str, Any] | None = None
     ) -> dict[str, Any]:

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -2561,14 +2561,21 @@ class NodeRuntimeService:
                 )
         else:
             # ----- Step 3b: forced fallback ---------------------------
+            # Codex hotfix HIGH-2: ``link_set_nomaster`` failure is a
+            # HARD detach failure. Previously we swallowed it, then
+            # still tore down runtime state, released the slot, bumped
+            # the generation, and let ``link_service.delete_link``
+            # remove the link from ``lab.json`` — leaving live bridge
+            # connectivity behind while reporting success and making
+            # retry impossible because the attachment row was gone.
+            #
+            # Re-raise as ``host_net.HostNetError`` so ``delete_link``
+            # surfaces the failure to the caller, leaves
+            # ``interface_attachments`` / ``allocated_slots`` /
+            # ``current_attach_generation`` UNCHANGED, and keeps
+            # ``lab.json`` + IPAM intact for retry.
             forced_fallback = True
-            try:
-                host_net.link_set_nomaster(tap)
-            except host_net.HostNetError:
-                _logger.exception(
-                    "us-304 forced-fallback: link_set_nomaster(%s) failed",
-                    tap,
-                )
+            host_net.link_set_nomaster(tap)
             # Publish a ws_hub warning so the UI can surface that the
             # guest did not eject the NIC.
             try:

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -2468,11 +2468,30 @@ class NodeRuntimeService:
             err = device_del_response["error"]
             err_class = str(err.get("class", "")) if isinstance(err, dict) else ""
             if err_class == "DeviceNotFound":
-                # Race A: delete arrived before the create-side flushed
-                # device_add. Sleep briefly, then retry once. If the
-                # device still does not exist, treat as already-detached
-                # idempotent success.
-                time.sleep(0.5)
+                # Race A: ``device_del`` arrived before the create-side
+                # flushed ``device_add`` to ``query-pci`` visibility.
+                # Plan §US-304 acceptance criteria: "wait up to 2s for
+                # the create-side lock to finish, then retry once."
+                #
+                # Codex hotfix MEDIUM-1: the previous implementation was
+                # a fixed ``sleep(0.5)`` + one retry. If ``device_add``
+                # visibility lagged past 500ms, that classified the NIC
+                # as "already gone" and tore down ``netdev`` / TAP while
+                # the device was about to appear.
+                #
+                # Real bounded wait: poll ``query-pci`` every 100ms for
+                # the device to APPEAR, up to 2.0s total. As soon as it
+                # is visible (or the budget expires), retry ``device_del``
+                # exactly once. Treat second-call ``DeviceNotFound`` as
+                # idempotent success (the device was never created).
+                _RACE_A_BUDGET_S = 2.0
+                _RACE_A_CADENCE_S = 0.1
+                _race_a_iters = max(1, int(_RACE_A_BUDGET_S / _RACE_A_CADENCE_S))
+                for _race_a_i in range(_race_a_iters):
+                    if not self._qemu_device_gone(socket_path, device_id):
+                        # Device became visible — break and retry.
+                        break
+                    time.sleep(_RACE_A_CADENCE_S)
                 retry_response = self._qmp_command(
                     socket_path, "device_del", {"id": device_id}
                 )

--- a/backend/tests/test_us304_qemu_hot_remove.py
+++ b/backend/tests/test_us304_qemu_hot_remove.py
@@ -1259,3 +1259,183 @@ def test_us304_stale_generation_locked_helper_returns_stale_noop(
     updated_rt = svc._runtime_record(lab_id, 1, include_stopped=True)
     assert updated_rt is not None
     assert len(updated_rt.get("interface_attachments") or []) == 1
+
+
+# ---------------------------------------------------------------------------
+# Codex hotfix HIGH-2 — link_set_nomaster failure in forced fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_us304_forced_fallback_link_set_nomaster_failure_aborts_cleanup(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Forced-fallback path: when ``host_net.link_set_nomaster(tap)``
+    raises :class:`host_net.HostNetError`, the kernel-side detach has
+    NOT happened (TAP is still bridged). The detach MUST abort with
+    the original error rather than:
+      * dropping the attachment row from runtime,
+      * releasing the slot,
+      * bumping the generation,
+      * letting ``link_service.delete_link`` clear ``lab.json`` / IPAM.
+
+    Otherwise we report success while leaving live bridge connectivity
+    behind, and retry is impossible because the attachment row is gone.
+
+    Regression for codex hotfix HIGH-2.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab304nomast"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+        links=[_link("lnk_001", 1, 2, 5, attach_generation=1)],
+    )
+
+    svc = NodeRuntimeService()
+    pre_runtime = _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+    pre_attachments = list(pre_runtime["interface_attachments"])
+    pre_allocated_slots = list(pre_runtime["allocated_slots"])
+    pre_gen = svc._interface_attach_generation(pre_runtime, 2)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    # Device persists past the bounded poll → triggers forced fallback.
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device("dev2")
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client", fake_qmp
+    )
+    svc._qmp_client = fake_qmp
+
+    calls = _patch_host_net(monkeypatch)
+
+    # Force ``link_set_nomaster`` to raise — the forced fallback must
+    # propagate this error rather than swallow it.
+    def _link_set_nomaster_fail(name):
+        calls["link_set_nomaster"].append(name)
+        raise host_net.HostNetError(f"simulated nomaster failure for {name}")
+
+    monkeypatch.setattr(
+        host_net, "link_set_nomaster", _link_set_nomaster_fail
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+
+    link_service = LinkService()
+    with pytest.raises(host_net.HostNetError, match="simulated nomaster"):
+        await link_service.delete_link(lab_name, "lnk_001")
+
+    # ``link_set_nomaster`` was attempted with the canonical TAP name.
+    assert calls["link_set_nomaster"] == [expected_tap]
+
+    # No tap_del / netdev_del — forced fallback intentionally skips
+    # those; HIGH-2 specifically requires we DON'T forge ahead with
+    # cleanup just because the kernel-side detach failed.
+    assert calls["tap_del"] == []
+
+    # Runtime state UNCHANGED — attachment + slot + generation intact
+    # for retry.
+    rt_after = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert rt_after is not None
+    assert rt_after["interface_attachments"] == pre_attachments, (
+        f"forced-fallback nomaster failure must not drop the attachment; "
+        f"before={pre_attachments!r} after={rt_after['interface_attachments']!r}"
+    )
+    assert rt_after["allocated_slots"] == pre_allocated_slots, (
+        f"forced-fallback nomaster failure must not release the slot; "
+        f"before={pre_allocated_slots!r} after={rt_after['allocated_slots']!r}"
+    )
+    post_gen = svc._interface_attach_generation(rt_after, 2)
+    assert post_gen == pre_gen, (
+        f"forced-fallback nomaster failure must not bump the generation; "
+        f"before={pre_gen} after={post_gen}"
+    )
+
+    # ``lab.json`` link record + IPAM are intact for retry —
+    # ``delete_link`` runs the kernel detach BEFORE ``lab.json``
+    # cleanup, so the raised error short-circuits the JSON write.
+    saved = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    assert any(str(link.get("id")) == "lnk_001" for link in saved.get("links", [])), (
+        f"forced-fallback nomaster failure must leave the link in lab.json "
+        f"for retry; saved={saved!r}"
+    )
+
+
+def test_us304_locked_helper_propagates_link_set_nomaster_error(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Direct call into ``_detach_qemu_interface_locked`` with
+    ``host_net.link_set_nomaster`` raising must propagate the error and
+    leave runtime state untouched. Companion regression for HIGH-2 that
+    exercises the locked helper independently of ``delete_link``.
+    """
+    lab_id = "lab304nomastlck"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    pre_runtime = _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+    pre_attachments = list(pre_runtime["interface_attachments"])
+    pre_allocated_slots = list(pre_runtime["allocated_slots"])
+    pre_tap_names = list(pre_runtime["tap_names"])
+    pre_gen = svc._interface_attach_generation(pre_runtime, 2)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device("dev2")
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    def _link_set_nomaster_fail(name):
+        calls["link_set_nomaster"].append(name)
+        raise host_net.HostNetError(f"nomaster failed: {name}")
+
+    monkeypatch.setattr(
+        host_net, "link_set_nomaster", _link_set_nomaster_fail
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    with pytest.raises(host_net.HostNetError, match="nomaster failed"):
+        svc.detach_qemu_interface(lab_id, 1, 2)
+
+    # Runtime state UNCHANGED.
+    rt_after = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert rt_after is not None
+    assert rt_after["interface_attachments"] == pre_attachments
+    assert rt_after["allocated_slots"] == pre_allocated_slots
+    assert rt_after["tap_names"] == pre_tap_names
+    assert svc._interface_attach_generation(rt_after, 2) == pre_gen
+
+    # tap_del was NOT called.
+    assert calls["tap_del"] == []

--- a/backend/tests/test_us304_qemu_hot_remove.py
+++ b/backend/tests/test_us304_qemu_hot_remove.py
@@ -1439,3 +1439,180 @@ def test_us304_locked_helper_propagates_link_set_nomaster_error(
 
     # tap_del was NOT called.
     assert calls["tap_del"] == []
+
+
+# ---------------------------------------------------------------------------
+# Codex hotfix MEDIUM-1 — Race-A bounded 2s wait before retry
+# ---------------------------------------------------------------------------
+
+
+def test_us304_race_a_bounded_wait_polls_until_device_appears_then_retries(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Plan §US-304: Race-A handling is "wait up to 2s for the create-side
+    lock to finish, then retry once" — NOT a fixed ``sleep(0.5)``.
+
+    Regression for codex hotfix MEDIUM-1: when ``device_add`` visibility
+    lags past 500ms, the previous implementation tore down ``netdev`` /
+    TAP while the device was about to appear. The fix polls ``query-pci``
+    on a 100ms cadence up to 2.0s before retrying ``device_del`` exactly
+    once, so a NIC that becomes visible after >500ms is correctly torn
+    down on the retry.
+
+    Setup:
+      * First ``device_del``: returns ``DeviceNotFound`` (device not yet
+        visible to QEMU's command parser).
+      * ``query-pci`` poll: returns "device absent" for the first 7
+        iterations (~700ms simulated), then returns "device visible" on
+        iteration 8 — i.e. >500ms but <2s.
+      * Second ``device_del``: returns success (device now exists and
+        is being ejected).
+      * Subsequent ``query-pci`` (the bounded 16-iter poll): immediately
+        shows the device gone.
+
+    With the OLD code (fixed 0.5s sleep), the second ``device_del`` was
+    issued too early (the test fixture would only have driven 5
+    iterations of query-pci visibility — but the OLD code did not poll
+    query-pci between attempts at all, so it always saw DeviceNotFound
+    on retry and treated the NIC as already gone). The fix waits long
+    enough for query-pci to see the device.
+    """
+    lab_id = "lab304racewait"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    # First device_del: DeviceNotFound (race A — device not yet visible).
+    # Second device_del: success — device is now there and being removed.
+    fake_qmp.response_seqs["device_del"] = [
+        {"error": {"class": "DeviceNotFound", "desc": "no device with id dev2"}},
+        {"return": {}},
+    ]
+    # query-pci sequence: 7 "device absent" responses (race-A polling
+    # window — should NOT be treated as "already gone" by the retry
+    # logic), then "device visible" so the retry actually issues
+    # device_del against the real device. After the retry succeeds, the
+    # bounded post-retry poll should see the device gone.
+    absent = _query_pci_response_with_device(None)
+    visible = _query_pci_response_with_device("dev2")
+    fake_qmp.response_seqs["query-pci"] = [
+        absent, absent, absent, absent, absent, absent, absent,  # 7 iterations
+        visible,  # 8th: device finally appears
+        # Post-retry bounded poll: device confirmed gone after device_del.
+        absent,
+    ]
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    result = svc.detach_qemu_interface(lab_id, 1, 2)
+
+    # The device was real and was successfully torn down on retry — NOT
+    # classified as "already gone".
+    assert result["state"] == "detached", result
+    assert result.get("device_already_gone") is not True, (
+        f"race-A bounded wait must NOT classify a late-visible device as "
+        f"already gone; result={result!r}"
+    )
+
+    # Two device_del calls (the retry exists).
+    device_del_calls = [c for c in fake_qmp.calls if c[1] == "device_del"]
+    assert len(device_del_calls) == 2, (
+        f"race-A must issue exactly one retry; got {len(device_del_calls)} "
+        f"device_del calls"
+    )
+
+    # Race-A bounded wait actually polled query-pci before the retry.
+    # The second device_del MUST land AFTER multiple query-pci calls
+    # (the bounded wait), not immediately after the first device_del.
+    cmds = [c[1] for c in fake_qmp.calls]
+    first_dd = cmds.index("device_del")
+    second_dd = cmds.index("device_del", first_dd + 1)
+    qpci_between = sum(
+        1 for c in cmds[first_dd + 1:second_dd] if c == "query-pci"
+    )
+    assert qpci_between >= 1, (
+        f"race-A retry must poll query-pci between device_del attempts; "
+        f"cmds={cmds!r}"
+    )
+
+    # Host-side cleanup ran (device was real and detached → happy path).
+    assert calls["tap_del"] == [expected_tap]
+    assert calls["link_set_nomaster"] == []
+
+
+def test_us304_race_a_bounded_wait_capped_at_2s(
+    lab_settings, monkeypatch, _instance_id
+):
+    """The Race-A bounded wait MUST be capped at 2.0s (≤20 iterations
+    at 100ms cadence). If ``query-pci`` never sees the device, the
+    retry still runs after the budget expires — we don't poll forever.
+    """
+    lab_id = "lab304racecap"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    # First device_del: DeviceNotFound. Second: also DeviceNotFound
+    # (idempotent absent).
+    fake_qmp.response_seqs["device_del"] = [
+        {"error": {"class": "DeviceNotFound", "desc": "no device with id dev2"}},
+        {"error": {"class": "DeviceNotFound", "desc": "no device with id dev2"}},
+    ]
+    # query-pci always shows "device absent" — simulates the budget
+    # expiring without the create-side ever completing.
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    svc.detach_qemu_interface(lab_id, 1, 2)
+
+    # Race-A poll budget: 2.0s / 100ms = 20 iterations max.
+    # The pre-retry query-pci count (between the two device_del calls)
+    # MUST NOT exceed 20.
+    cmds = [c[1] for c in fake_qmp.calls]
+    first_dd = cmds.index("device_del")
+    second_dd = cmds.index("device_del", first_dd + 1)
+    pre_retry_qpci = sum(
+        1 for c in cmds[first_dd + 1:second_dd] if c == "query-pci"
+    )
+    assert pre_retry_qpci <= 20, (
+        f"race-A bounded wait MUST cap at 20 iterations (2.0s / 100ms); "
+        f"got {pre_retry_qpci}"
+    )

--- a/backend/tests/test_us304_qemu_hot_remove.py
+++ b/backend/tests/test_us304_qemu_hot_remove.py
@@ -1,0 +1,1096 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""US-304 — QMP-driven hot-remove NIC (with bounded poll + forced fallback).
+
+Acceptance criteria exercised here (mirrors plan §US-304 lines 437-442):
+
+  * ``link_service.delete_link`` dispatches a running QEMU node to
+    ``_detach_qemu_interface_locked`` (mirrors the docker hot-detach flow).
+  * Hot-remove executes the QMP/host steps in order:
+        device_del -> bounded query-pci poll -> netdev_del -> tap_del.
+  * Bounded poll: ``query-pci`` every 500ms for up to 8s (16 iterations).
+  * Forced fallback at timeout: ``host_net.link_set_nomaster(tap)`` runs,
+    ``netdev_del`` and ``tap_del`` are NOT issued, and a ``node_warning``
+    WS event is broadcast.
+  * Race A (``DeviceNotFound`` on first ``device_del``): retry once after
+    0.5s, treat second-time DeviceNotFound as already-detached idempotent
+    success.
+  * Idempotent double-delete: second detach call on the same iface
+    no-ops cleanly (returns ``state='absent'``).
+  * Mutex contention: concurrent attach + detach on the same iface — the
+    second caller raises :class:`RuntimeMutexContention` after the
+    bounded wait expires; ``link_service.delete_link`` translates this to
+    :class:`LinkContentionError` (HTTP 409).
+  * Transport timeout on ``device_del`` propagates as
+    :class:`NodeRuntimeQMPTimeout` and is NOT swallowed as a forced
+    fallback (transport timeout != guest didn't eject).
+  * Transport timeout on ``netdev_del`` after the device is gone still
+    runs ``host_net.tap_del`` (host-side cleanup is preserved); error
+    raised after.
+  * Generation token is bumped under the lab_lock-equivalent runtime
+    lock after the kernel objects are removed.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.services import host_net
+from app.services.link_service import LinkContentionError, LinkService
+from app.services.node_runtime_service import (
+    NodeRuntimeError,
+    NodeRuntimeQMPTimeout,
+    NodeRuntimeService,
+)
+from app.services.runtime_mutex import RuntimeMutexContention, runtime_mutex
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirrors test_us303_qemu_hot_add.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    NodeRuntimeService.reset_registry()
+    runtime_mutex.reset()
+    yield
+    NodeRuntimeService.reset_registry()
+    runtime_mutex.reset()
+
+
+@pytest.fixture()
+def _instance_id(monkeypatch, tmp_path):
+    """Provision a fake instance_id file so host_net.tap_name works."""
+    instance_dir = tmp_path / "nova-ve-instance"
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    (instance_dir / "instance_id").write_text("test-instance-304")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    return "test-instance-304"
+
+
+@pytest.fixture()
+def lab_settings(tmp_path, monkeypatch):
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    settings = SimpleNamespace(
+        LABS_DIR=labs_dir,
+        IMAGES_DIR=tmp_path / "images",
+        TMP_DIR=tmp_path / "tmp",
+        TEMPLATES_DIR=tmp_path / "templates",
+        QEMU_BINARY="qemu-system-x86_64",
+        QEMU_IMG_BINARY="qemu-img",
+        DOCKER_HOST="unix:///var/run/docker.sock",
+        GUACAMOLE_DATABASE_URL="",
+        GUACAMOLE_DATA_SOURCE="postgresql",
+        GUACAMOLE_INTERNAL_URL="http://127.0.0.1:8081/html5/",
+        GUACAMOLE_JSON_SECRET_KEY="x" * 32,
+        GUACAMOLE_PUBLIC_PATH="/html5/",
+        GUACAMOLE_TARGET_HOST="host.docker.internal",
+        GUACAMOLE_JSON_EXPIRE_SECONDS=300,
+        GUACAMOLE_TERMINAL_FONT_NAME="Roboto Mono",
+        GUACAMOLE_TERMINAL_FONT_SIZE=10,
+    )
+    monkeypatch.setattr("app.services.lab_service.get_settings", lambda: settings)
+    monkeypatch.setattr("app.services.link_service.get_settings", lambda: settings)
+    monkeypatch.setattr(
+        "app.services.network_service.get_settings", lambda: settings
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.get_settings", lambda: settings
+    )
+    return settings
+
+
+def _seed_lab(labs_dir, lab_name: str, *, nodes=None, networks=None, links=None):
+    payload = {
+        "schema": 2,
+        "id": lab_name.replace(".json", ""),
+        "meta": {"name": lab_name},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": nodes or {},
+        "networks": networks or {},
+        "links": links or [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    (labs_dir / lab_name).write_text(json.dumps(payload))
+    return lab_name
+
+
+def _qemu_node(node_id: int, *, ethernet: int = 4, qemu_nic: str = "e1000") -> dict:
+    return {
+        "id": node_id,
+        "name": f"vm{node_id}",
+        "type": "qemu",
+        "template": "vyos",
+        "image": "vyos",
+        "console": "telnet",
+        "status": 0,
+        "cpu": 1,
+        "ram": 1024,
+        "ethernet": ethernet,
+        "left": 0,
+        "top": 0,
+        "icon": "Router.png",
+        "firstmac": "52:54:00:00:00:00",
+        "extras": {"qemu_nic": qemu_nic},
+        "interfaces": [
+            {"index": i, "name": f"eth{i}", "planned_mac": None, "port_position": None}
+            for i in range(ethernet)
+        ],
+    }
+
+
+def _network(net_id: int, name: str = "lan") -> dict:
+    return {
+        "id": net_id,
+        "name": name,
+        "type": "linux_bridge",
+        "left": 0,
+        "top": 0,
+        "icon": "01-Cloud-Default.svg",
+        "width": 0,
+        "style": "Solid",
+        "linkstyle": "Straight",
+        "color": "",
+        "label": "",
+        "visibility": True,
+        "implicit": False,
+        "smart": -1,
+        "config": {},
+        "runtime": {"bridge_name": f"novebr{net_id:04x}"},
+    }
+
+
+def _link(
+    link_id: str,
+    node_id: int,
+    iface_idx: int,
+    net_id: int,
+    *,
+    attach_generation: int = 1,
+) -> dict:
+    return {
+        "id": link_id,
+        "from": {"node_id": node_id, "interface_index": iface_idx},
+        "to": {"network_id": net_id},
+        "style_override": None,
+        "label": "",
+        "color": "",
+        "width": "1",
+        "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+        "runtime": {"attach_generation": attach_generation},
+    }
+
+
+def _seed_qemu_runtime(
+    service: NodeRuntimeService,
+    *,
+    lab_id: str,
+    node_id: int,
+    qmp_socket: str = "/tmp/qmp.sock",
+    hotplug_capable: bool = True,
+    max_nics: int = 8,
+    boot_slots: int = 4,
+    iface_attachments=None,
+    tap_names=None,
+    monkeypatch=None,
+) -> dict:
+    """Seed a fake live qemu runtime record."""
+    runtime = {
+        "lab_id": lab_id,
+        "node_id": node_id,
+        "kind": "qemu",
+        "pid": 9000 + node_id,
+        "qmp_socket": qmp_socket,
+        "machine": "q35",
+        "max_nics": max_nics,
+        "hotplug_capable": hotplug_capable,
+        "allocated_slots": list(range(boot_slots)),
+        "tap_names": list(tap_names or []),
+        "interface_attachments": list(iface_attachments or []),
+        "interface_runtime": {},
+        "started_at": time.time(),
+    }
+    key = service._key(lab_id, node_id)
+    with service._lock:
+        service._registry[key] = runtime
+    service._persist_runtime(runtime)
+    if monkeypatch is not None:
+        monkeypatch.setattr(
+            NodeRuntimeService,
+            "_is_runtime_alive",
+            lambda _self, _rt: True,
+        )
+    return runtime
+
+
+class _FakeQmp:
+    """Records every QMP call in order; callers may register per-command
+    responses (or response sequences) or raise on a specific command.
+    Behaves like the ``self._qmp_client`` callable that ``_qmp_command``
+    falls back to, accepting either ``(socket, command)`` or
+    ``(socket, command, args)``.
+
+    For US-304 query-pci polling support, a per-command list of
+    responses cycles in order: each call pops the next response (last
+    response repeats indefinitely once exhausted).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self.responses: dict[str, Any] = {}
+        self.response_seqs: dict[str, list[Any]] = {}
+        self.raise_on: dict[str, Exception] = {}
+        self.raise_on_nth: dict[str, list[tuple[int, Exception]]] = {}
+
+    def __call__(self, socket_path, command, arguments=None):
+        self.calls.append((socket_path, command, dict(arguments) if arguments else None))
+        # Per-call raise (e.g. "raise on first device_del, succeed on retry").
+        if command in self.raise_on_nth and self.raise_on_nth[command]:
+            n_called = sum(1 for c in self.calls if c[1] == command)
+            for i, (target_n, exc) in enumerate(self.raise_on_nth[command]):
+                if target_n == n_called:
+                    self.raise_on_nth[command].pop(i)
+                    raise exc
+        if command in self.raise_on:
+            raise self.raise_on[command]
+        if command in self.response_seqs and self.response_seqs[command]:
+            seq = self.response_seqs[command]
+            response = seq[0] if len(seq) == 1 else seq.pop(0)
+            return response
+        if command in self.responses:
+            return self.responses[command]
+        return {"return": {}}
+
+
+def _query_pci_response_with_device(device_id: str | None) -> dict:
+    """Mock a ``query-pci`` response that does or does not include the
+    given ``device_id`` (e.g. ``"dev2"``) under ``rp7``.
+
+    Returns a tree shape compatible with both
+    :meth:`_find_free_pcie_slot` and :meth:`_qemu_device_gone`.
+    """
+    children = []
+    if device_id is not None:
+        children.append({"qdev_id": device_id})
+    return {
+        "return": [
+            {
+                "devices": [
+                    {
+                        "qdev_id": "rp7",
+                        "pci_bridge": {"devices": children},
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def _patch_host_net(monkeypatch) -> dict[str, list]:
+    """Capture host_net side-effecting calls."""
+    calls: dict[str, list] = {
+        "tap_add": [],
+        "tap_del": [],
+        "link_master": [],
+        "link_set_nomaster": [],
+        "link_up": [],
+        "try_link_del": [],
+        "bridge_exists": [],
+    }
+
+    def _bridge_exists(name):
+        calls["bridge_exists"].append(name)
+        return True
+
+    def _tap_del(name):
+        calls["tap_del"].append(name)
+
+    monkeypatch.setattr(host_net, "tap_add", lambda n: calls["tap_add"].append(n))
+    monkeypatch.setattr(host_net, "tap_del", _tap_del)
+    monkeypatch.setattr(
+        host_net, "link_master", lambda i, b: calls["link_master"].append((i, b))
+    )
+    monkeypatch.setattr(
+        host_net, "link_set_nomaster", lambda i: calls["link_set_nomaster"].append(i)
+    )
+    monkeypatch.setattr(host_net, "link_up", lambda i: calls["link_up"].append(i))
+    monkeypatch.setattr(
+        host_net, "try_link_del", lambda n: calls["try_link_del"].append(n)
+    )
+    monkeypatch.setattr(host_net, "bridge_exists", _bridge_exists)
+    return calls
+
+
+def _seed_attached_qemu(
+    svc: NodeRuntimeService,
+    *,
+    lab_id: str,
+    node_id: int,
+    interface_index: int,
+    network_id: int,
+    slot: int = 7,
+    monkeypatch,
+) -> dict:
+    """Seed a qemu runtime with one already-attached interface so the
+    detach path has something to undo. Returns the runtime dict.
+    """
+    tap = host_net.tap_name(lab_id, node_id, interface_index)
+    bridge = f"novebr{network_id:04x}"
+    runtime = _seed_qemu_runtime(
+        svc,
+        lab_id=lab_id,
+        node_id=node_id,
+        boot_slots=2,
+        iface_attachments=[
+            {
+                "interface_index": interface_index,
+                "network_id": network_id,
+                "bridge_name": bridge,
+                "tap_name": tap,
+                "slot": slot,
+                "nic_model": "e1000",
+                "attach_generation": 1,
+                "planned_mac": "52:54:00:00:00:02",
+            }
+        ],
+        tap_names=[tap],
+        monkeypatch=monkeypatch,
+    )
+    runtime["allocated_slots"] = [0, 1, slot]
+    runtime["interface_runtime"] = {
+        str(interface_index): {"current_attach_generation": 1}
+    }
+    svc._persist_runtime(runtime)
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# detach_qemu_interface — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_us304_happy_path_device_del_then_query_pci_then_netdev_and_tap(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Plan §US-304 happy path: device_del -> query-pci shows gone after
+    a brief delay -> netdev_del + tap_del in order.
+    """
+    lab_id = "lab304ok"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    # query-pci: first call still shows dev2; second call is empty.
+    fake_qmp.response_seqs["query-pci"] = [
+        _query_pci_response_with_device("dev2"),
+        _query_pci_response_with_device(None),
+    ]
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    result = svc.detach_qemu_interface(lab_id, 1, 2)
+
+    assert result["state"] == "detached"
+    assert result["tap_name"] == expected_tap
+    # Generation bumped from 1 to 2.
+    assert result["current_attach_generation"] == 2
+
+    # Order of QMP commands.
+    cmds = [c[1] for c in fake_qmp.calls]
+    assert cmds[0] == "device_del"
+    assert "query-pci" in cmds
+    assert "netdev_del" in cmds
+    netdev_idx = cmds.index("netdev_del")
+    qpci_first = cmds.index("query-pci")
+    assert qpci_first < netdev_idx, (
+        f"query-pci poll must run before netdev_del; cmds={cmds!r}"
+    )
+
+    # Args.
+    device_del = next(c for c in fake_qmp.calls if c[1] == "device_del")
+    assert device_del[2] == {"id": "dev2"}
+    netdev_del = next(c for c in fake_qmp.calls if c[1] == "netdev_del")
+    assert netdev_del[2] == {"id": "net2"}
+
+    # tap_del was called with the canonical TAP name.
+    assert calls["tap_del"] == [expected_tap]
+    # No forced-fallback link_set_nomaster.
+    assert calls["link_set_nomaster"] == []
+
+    # Runtime record cleaned up.
+    runtime = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert runtime is not None
+    assert all(
+        int(a.get("interface_index", -1)) != 2
+        for a in runtime.get("interface_attachments") or []
+    )
+    assert expected_tap not in (runtime.get("tap_names") or [])
+    # Slot reservation released.
+    assert 7 not in (runtime.get("allocated_slots") or [])
+
+
+# ---------------------------------------------------------------------------
+# Bounded poll cadence — at most 16 query-pci calls
+# ---------------------------------------------------------------------------
+
+
+def test_us304_bounded_poll_at_most_16_query_pci_calls(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Plan §US-304: bounded poll runs ``query-pci`` every 500ms for up
+    to 8s (16 iterations). When the device never disappears, the count
+    must NOT exceed 16.
+    """
+    lab_id = "lab304poll"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    # Always shows the device — forced fallback.
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device("dev2")
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    # Speed up the test: replace the 500ms sleep with a no-op.
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    svc.detach_qemu_interface(lab_id, 1, 2)
+
+    qpci_count = sum(1 for c in fake_qmp.calls if c[1] == "query-pci")
+    assert qpci_count <= 16, (
+        f"bounded poll must not exceed 16 query-pci calls; got {qpci_count}"
+    )
+    # And it should have run the full 16 since the device never leaves.
+    assert qpci_count == 16, (
+        f"expected exactly 16 poll iterations on forced-fallback path; "
+        f"got {qpci_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forced fallback — guest never ejects
+# ---------------------------------------------------------------------------
+
+
+def test_us304_forced_fallback_when_device_persists_past_timeout(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Plan §US-304: when ``query-pci`` still shows the device after 8s,
+    ``host_net.link_set_nomaster(tap)`` runs, ``netdev_del`` and
+    ``tap_del`` are NOT issued, and a ``node_warning`` WS event is
+    broadcast.
+    """
+    lab_id = "lab304forced"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device("dev2")
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    # Capture WS publishes.
+    published: list[tuple[str, str, dict]] = []
+
+    async def _capture_publish(lab, event_type, payload, rev=""):
+        published.append((lab, event_type, payload))
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _capture_publish)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    result = svc.detach_qemu_interface(lab_id, 1, 2)
+
+    assert result["state"] == "forced", result
+
+    # Forced fallback: link_set_nomaster MUST have run, tap_del MUST NOT
+    # have, netdev_del MUST NOT have been issued.
+    assert calls["link_set_nomaster"] == [expected_tap], (
+        f"forced fallback must call link_set_nomaster({expected_tap!r}); "
+        f"got {calls['link_set_nomaster']!r}"
+    )
+    assert calls["tap_del"] == [], (
+        f"forced fallback MUST NOT call tap_del; got {calls['tap_del']!r}"
+    )
+    cmds = [c[1] for c in fake_qmp.calls]
+    assert "netdev_del" not in cmds, (
+        f"forced fallback MUST NOT issue netdev_del; cmds={cmds!r}"
+    )
+
+    # ws_hub.publish was called with a node_warning event.
+    warning_events = [e for e in published if e[1] == "node_warning"]
+    assert warning_events, (
+        f"forced fallback must publish a node_warning event; "
+        f"published={published!r}"
+    )
+    _lab_arg, _event_type, payload = warning_events[0]
+    assert payload["node_id"] == 1
+    assert payload["interface_index"] == 2
+    assert "restart" in payload["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Race A — DeviceNotFound on first device_del, retry succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_us304_device_not_found_race_a_retries_and_succeeds(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Plan §US-304: ``device_del`` returning ``DeviceNotFound`` on the
+    first call (race A — delete arrived before the create-side flushed
+    device_add). After a 0.5s wait, retry once. Second-time
+    ``DeviceNotFound`` means the device was never created; treat as
+    already-detached idempotent success.
+    """
+    lab_id = "lab304racea"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    # First device_del: DeviceNotFound. Second: also DeviceNotFound
+    # (idempotent absent — device was never created).
+    fake_qmp.response_seqs["device_del"] = [
+        {"error": {"class": "DeviceNotFound", "desc": "no device with id dev2"}},
+        {"error": {"class": "DeviceNotFound", "desc": "no device with id dev2"}},
+    ]
+    # query-pci shouldn't matter — device is already gone.
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    result = svc.detach_qemu_interface(lab_id, 1, 2)
+
+    # Treated as detached (idempotent success path).
+    assert result["state"] == "detached"
+    assert result.get("device_already_gone") is True
+
+    # Two device_del calls.
+    device_del_calls = [c for c in fake_qmp.calls if c[1] == "device_del"]
+    assert len(device_del_calls) == 2, (
+        f"DeviceNotFound race must trigger exactly one retry; "
+        f"got {len(device_del_calls)} device_del calls"
+    )
+    # Host-side: tap_del still ran (idempotent cleanup of host objects).
+    assert calls["tap_del"] == [expected_tap]
+
+
+# ---------------------------------------------------------------------------
+# Idempotent double-delete — second call no-ops
+# ---------------------------------------------------------------------------
+
+
+def test_us304_double_delete_second_call_is_absent_no_op(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Calling ``detach_qemu_interface`` twice on the same iface must
+    succeed cleanly the second time: no QMP traffic, returns
+    ``state='absent'``.
+    """
+    lab_id = "lab304dbl"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    # First detach succeeds.
+    first = svc.detach_qemu_interface(lab_id, 1, 2)
+    assert first["state"] == "detached"
+
+    # Snapshot QMP call count after the first detach.
+    first_call_count = len(fake_qmp.calls)
+
+    # Second detach: must no-op cleanly.
+    second = svc.detach_qemu_interface(lab_id, 1, 2)
+    assert second["state"] == "absent", second
+
+    # No additional QMP traffic on the no-op call.
+    assert len(fake_qmp.calls) == first_call_count, (
+        f"second (no-op) detach issued QMP traffic; calls grew "
+        f"{first_call_count} -> {len(fake_qmp.calls)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mutex contention — concurrent attach + detach
+# ---------------------------------------------------------------------------
+
+
+def test_us304_concurrent_attach_and_detach_second_caller_gets_contention(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Concurrent ``attach`` + ``detach`` on the same ``(node, iface)``:
+    the second caller MUST raise :class:`RuntimeMutexContention` once
+    the bounded wait expires (US-303 contract carries forward to US-304).
+    """
+    lab_id = "lab304conc"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    # Pre-acquire the mutex on a holder thread so the detach call sees
+    # contention.
+    proceed = threading.Event()
+    holder_started = threading.Event()
+
+    def _hold():
+        with runtime_mutex.acquire_sync(lab_id, 1, 2, timeout=5.0):
+            holder_started.set()
+            proceed.wait(timeout=5.0)
+
+    holder = threading.Thread(target=_hold)
+    holder.start()
+    assert holder_started.wait(timeout=2.0)
+
+    try:
+        with pytest.raises(RuntimeMutexContention):
+            # Bounded wait via the public entrypoint; we monkey-patch
+            # the registry default to keep the test fast.
+            monkeypatch.setattr(
+                "app.services.runtime_mutex.DEFAULT_ACQUIRE_TIMEOUT_S", 0.2
+            )
+            svc.detach_qemu_interface(lab_id, 1, 2)
+    finally:
+        proceed.set()
+        holder.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Transport timeout — NodeRuntimeQMPTimeout NOT swallowed
+# ---------------------------------------------------------------------------
+
+
+def test_us304_transport_timeout_on_device_del_propagates(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Transport-level QMP failures on ``device_del`` MUST propagate as
+    :class:`NodeRuntimeQMPTimeout` — they are NOT swallowed as a
+    forced-fallback (transport timeout != guest didn't eject).
+    """
+    lab_id = "lab304ddtimeout"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.raise_on["device_del"] = OSError("qmp socket reset")
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    with pytest.raises(NodeRuntimeQMPTimeout, match="device_del transport"):
+        svc.detach_qemu_interface(lab_id, 1, 2)
+
+    # No host-side cleanup ran (transport failure aborted the path
+    # before the bounded poll / netdev_del / tap_del).
+    assert calls["tap_del"] == []
+    assert calls["link_set_nomaster"] == []
+
+
+def test_us304_transport_timeout_on_netdev_del_after_device_gone_still_cleans_tap(
+    lab_settings, monkeypatch, _instance_id
+):
+    """When ``device_del`` succeeds and the device is gone, but the
+    follow-up ``netdev_del`` raises a transport timeout, the host-side
+    ``tap_del`` MUST still run so the kernel TAP is cleaned up. The
+    error is raised AFTER the host-side cleanup.
+    """
+    lab_id = "lab304ndtimeout"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.raise_on["netdev_del"] = OSError("qmp socket dropped")
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+
+    with pytest.raises(NodeRuntimeQMPTimeout, match="netdev_del transport"):
+        svc.detach_qemu_interface(lab_id, 1, 2)
+
+    # tap_del MUST have run BEFORE the exception.
+    assert calls["tap_del"] == [expected_tap], (
+        f"netdev_del transport timeout must still run tap_del; "
+        f"calls['tap_del']={calls['tap_del']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# link_service.delete_link → QEMU dispatch + 409 mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_us304_link_service_delete_link_dispatches_to_qemu_detach(
+    lab_settings, monkeypatch, _instance_id
+):
+    """``link_service.delete_link`` for a running QEMU node calls
+    ``_detach_qemu_interface_locked`` (NOT the docker path).
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab304ls"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+        links=[_link("lnk_001", 1, 2, 5, attach_generation=1)],
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client", fake_qmp
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    link_service = LinkService()
+    ok, deleted_net = await link_service.delete_link(lab_name, "lnk_001")
+    assert ok is False
+    assert deleted_net is None
+
+    # QEMU detach path was taken.
+    cmds = [c[1] for c in fake_qmp.calls]
+    assert "device_del" in cmds
+    assert "netdev_del" in cmds
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    assert calls["tap_del"] == [expected_tap]
+
+    # Link removed from lab.json.
+    saved = json.loads((lab_settings.LABS_DIR / f"{lab_id}.json").read_text())
+    assert saved["links"] == []
+
+
+@pytest.mark.asyncio
+async def test_us304_link_service_delete_link_409_on_qemu_mutex_contention(
+    lab_settings, monkeypatch, _instance_id
+):
+    """``link_service.delete_link`` translates a
+    :class:`RuntimeMutexContention` raised inside
+    ``_detach_qemu_interface_locked`` into a :class:`LinkContentionError`
+    so the router can return HTTP 409.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab304409"
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+        links=[_link("lnk_001", 1, 2, 5, attach_generation=1)],
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client", fake_qmp
+    )
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+
+    # Pre-acquire the mutex on a holder thread.
+    proceed = threading.Event()
+    holder_started = threading.Event()
+
+    def _hold():
+        with runtime_mutex.acquire_sync(lab_id, 1, 2, timeout=5.0):
+            holder_started.set()
+            proceed.wait(timeout=5.0)
+
+    holder = threading.Thread(target=_hold)
+    holder.start()
+    assert holder_started.wait(timeout=2.0)
+
+    monkeypatch.setattr(
+        "app.services.runtime_mutex.DEFAULT_ACQUIRE_TIMEOUT_S", 0.2
+    )
+    link_service = LinkService()
+    try:
+        with pytest.raises(LinkContentionError):
+            await link_service.delete_link(lab_name, "lnk_001")
+    finally:
+        proceed.set()
+        holder.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Generation token bumped after kernel objects removed
+# ---------------------------------------------------------------------------
+
+
+def test_us304_generation_token_bumped_on_happy_path(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Plan §US-304: ``current_attach_generation`` MUST be bumped after
+    the kernel objects are removed so a stale concurrent attach does
+    not race a freshly torn-down NIC. The bump happens under the
+    runtime lock (per-node ``self._lock`` in NodeRuntimeService) inside
+    the per-(lab, node, iface) mutex window.
+    """
+    lab_id = "lab304gen"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    runtime = _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+    # Pre-detach: generation token = 1.
+    pre_gen = svc._interface_attach_generation(runtime, 2)
+    assert pre_gen == 1
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    svc._qmp_client = fake_qmp
+    _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    result = svc.detach_qemu_interface(lab_id, 1, 2)
+
+    # Post-detach: generation token bumped to 2.
+    runtime_after = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert runtime_after is not None
+    post_gen = svc._interface_attach_generation(runtime_after, 2)
+    assert post_gen == 2, (
+        f"generation token must bump from 1 to 2 after kernel cleanup; "
+        f"got {post_gen}"
+    )
+    assert result["current_attach_generation"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Locked helper asserts mutex held (defensive contract)
+# ---------------------------------------------------------------------------
+
+
+def test_us304_locked_helper_asserts_mutex_held(
+    lab_settings, monkeypatch, _instance_id
+):
+    """``_detach_qemu_interface_locked`` MUST refuse to run without the
+    per-(lab, node, iface) mutex held (defensive contract — mirrors
+    US-303 / US-204b).
+    """
+    lab_id = "lab304mtx"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    with pytest.raises(AssertionError, match="mutex held"):
+        svc._detach_qemu_interface_locked(lab_id, 1, 2)

--- a/backend/tests/test_us304_qemu_hot_remove.py
+++ b/backend/tests/test_us304_qemu_hot_remove.py
@@ -1094,3 +1094,168 @@ def test_us304_locked_helper_asserts_mutex_held(
 
     with pytest.raises(AssertionError, match="mutex held"):
         svc._detach_qemu_interface_locked(lab_id, 1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Codex hotfix HIGH-1 — stale generation does NOT detach the QEMU NIC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_us304_stale_generation_does_not_detach_qemu_nic(
+    lab_settings, monkeypatch, _instance_id
+):
+    """When the link's ``attach_generation`` is older than the runtime's
+    ``current_attach_generation``, the QEMU detach path MUST return
+    ``state='stale_noop'`` and NOT issue ``device_del`` / ``netdev_del`` /
+    ``tap_del`` — mirroring the docker freshness contract from US-205.
+
+    This is the regression for codex hotfix HIGH-1: QMP IDs reuse
+    ``dev{iface}`` / ``net{iface}`` deterministically, so without the
+    generation check a stale rollback would tear down a NEWER QEMU NIC
+    that is still live on the same iface.
+    """
+    async def _noop(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop)
+
+    lab_id = "lab304stalegen"
+    stale_gen = 1
+    current_gen = 2
+
+    lab_name = _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+        # Link carries the OLD generation (stale_gen=1).
+        links=[_link("lnk_001", 1, 2, 5, attach_generation=stale_gen)],
+    )
+
+    svc = NodeRuntimeService()
+    runtime = _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+    # Bump the runtime generation to current_gen so the link's stamped
+    # value is older than the live attachment.
+    runtime["interface_runtime"] = {
+        "2": {"current_attach_generation": current_gen}
+    }
+    runtime["interface_attachments"][0]["attach_generation"] = current_gen
+    svc._persist_runtime(runtime)
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    fake_qmp.responses["netdev_del"] = {"return": {}}
+    monkeypatch.setattr(
+        "app.services.node_runtime_service._default_qmp_client", fake_qmp
+    )
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    link_service = LinkService()
+    await link_service.delete_link(lab_name, "lnk_001")
+
+    # The JSON link IS removed (we committed the delete) — same contract
+    # as US-205 stale path.
+    saved = json.loads(
+        (lab_settings.LABS_DIR / f"{lab_id}.json").read_text()
+    )
+    assert saved["links"] == []
+
+    # No QMP traffic at all — stale check short-circuits BEFORE device_del.
+    qmp_cmds = [c[1] for c in fake_qmp.calls]
+    assert "device_del" not in qmp_cmds, (
+        f"stale-gen detach must not issue device_del; cmds={qmp_cmds!r}"
+    )
+    assert "netdev_del" not in qmp_cmds, (
+        f"stale-gen detach must not issue netdev_del; cmds={qmp_cmds!r}"
+    )
+
+    # No host-side TAP cleanup either.
+    assert calls["tap_del"] == [], (
+        f"stale-gen detach must not call tap_del; got {calls['tap_del']!r}"
+    )
+    assert calls["link_set_nomaster"] == [], (
+        f"stale-gen detach must not call link_set_nomaster; "
+        f"got {calls['link_set_nomaster']!r}"
+    )
+
+    # The newer attachment row is still in the runtime record.
+    updated_rt = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert updated_rt is not None
+    matching = [
+        a for a in (updated_rt.get("interface_attachments") or [])
+        if int(a.get("interface_index", -1)) == 2
+    ]
+    assert len(matching) == 1, (
+        f"stale-gen detach must not drop the newer attachment; "
+        f"interface_attachments={updated_rt.get('interface_attachments')!r}"
+    )
+    assert matching[0]["attach_generation"] == current_gen
+
+
+def test_us304_stale_generation_locked_helper_returns_stale_noop(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Direct call into ``_detach_qemu_interface_locked`` with an
+    ``expected_generation`` older than the runtime's current generation
+    must short-circuit and return ``state='stale_noop'`` without
+    touching QMP, host_net, or runtime state.
+
+    Companion regression for HIGH-1 that exercises the locked helper
+    contract independently of ``link_service.delete_link``.
+    """
+    lab_id = "lab304stalelck"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    runtime = _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+    runtime["interface_runtime"] = {
+        "2": {"current_attach_generation": 5}
+    }
+    svc._persist_runtime(runtime)
+
+    fake_qmp = _FakeQmp()
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    # Call the public entrypoint with stale gen.
+    result = svc.detach_qemu_interface(
+        lab_id, 1, 2, expected_generation=1
+    )
+
+    assert result["state"] == "stale_noop"
+    assert result["expected_generation"] == 1
+    assert result["current_attach_generation"] == 5
+
+    # No QMP, no host_net, no runtime mutation.
+    assert fake_qmp.calls == []
+    assert calls["tap_del"] == []
+    assert calls["link_set_nomaster"] == []
+
+    updated_rt = svc._runtime_record(lab_id, 1, include_stopped=True)
+    assert updated_rt is not None
+    assert len(updated_rt.get("interface_attachments") or []) == 1

--- a/backend/tests/test_us304_qemu_hot_remove.py
+++ b/backend/tests/test_us304_qemu_hot_remove.py
@@ -1616,3 +1616,155 @@ def test_us304_race_a_bounded_wait_capped_at_2s(
         f"race-A bounded wait MUST cap at 20 iterations (2.0s / 100ms); "
         f"got {pre_retry_qpci}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex hotfix MEDIUM-2 — _qemu_device_gone recurses through nested bridges
+# ---------------------------------------------------------------------------
+
+
+def _query_pci_response_with_nested_device(
+    device_id: str, *, depth: int = 2
+) -> dict:
+    """Mock a ``query-pci`` response where ``device_id`` is nested
+    ``depth`` levels of ``pci_bridge`` deep.
+
+    ``depth=1`` matches the existing flat fixture (``bus -> rp7 ->
+    pci_bridge.devices -> device``). ``depth=2`` puts the device
+    BELOW a second ``pci_bridge`` (``bus -> rp7 -> pci_bridge.devices
+    -> rp_inner -> pci_bridge.devices -> device``). Higher depths
+    chain more bridges.
+
+    Used by codex hotfix MEDIUM-2 regression: the OLD ``_qemu_device_gone``
+    only walked one ``pci_bridge.devices`` level and therefore returned
+    ``True`` (gone) too early for ``depth >= 2``, even though the device
+    was still very much present in QEMU.
+    """
+    inner = {"qdev_id": device_id}
+    for level in range(depth):
+        inner = {
+            "qdev_id": f"rp_nested_{level}",
+            "pci_bridge": {"devices": [inner]},
+        }
+    return {
+        "return": [
+            {
+                "devices": [inner],
+            }
+        ]
+    }
+
+
+def test_us304_qemu_device_gone_recurses_through_nested_pci_bridges(
+    lab_settings, monkeypatch, _instance_id
+):
+    """Regression for codex hotfix MEDIUM-2: ``_qemu_device_gone`` MUST
+    recurse through every nested ``pci_bridge.devices`` subtree when
+    deciding whether a device has been ejected.
+
+    Fixture: ``query-pci`` returns a topology where the target
+    ``qdev_id`` is nested 3 levels of ``pci_bridge`` deep (bus -> bridge
+    -> bridge -> bridge -> device). The OLD code returned ``True`` (gone)
+    because it only walked one bridge level; the FIX returns ``False``
+    (still present) so the detach poll keeps waiting for real ejection.
+    """
+    lab_id = "lab304nested"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    # Device is nested 3 bridges deep — must NOT be reported as gone.
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_nested_device(
+        "dev2", depth=3
+    )
+    svc._qmp_client = fake_qmp
+
+    # Direct unit-test of the helper.
+    assert svc._qemu_device_gone("/tmp/qmp.sock", "dev2") is False, (
+        "device nested 3 bridges deep must NOT be reported as gone; "
+        "old code only walked one bridge level"
+    )
+
+    # Sanity: the helper still works for top-level + 1-level + missing.
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device("dev2")
+    assert svc._qemu_device_gone("/tmp/qmp.sock", "dev2") is False
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_device(None)
+    assert svc._qemu_device_gone("/tmp/qmp.sock", "dev2") is True
+
+
+def test_us304_forced_fallback_when_device_persists_at_deep_nest(
+    lab_settings, monkeypatch, _instance_id
+):
+    """End-to-end regression for codex hotfix MEDIUM-2: a NIC that
+    remains present nested deep in the PCIe topology must NOT be
+    classified as gone — the detach must take the forced-fallback
+    path (``link_set_nomaster``, no ``netdev_del`` / ``tap_del``)
+    instead of running the happy-path teardown over a still-live device.
+    """
+    lab_id = "lab304deepforced"
+    _seed_lab(
+        lab_settings.LABS_DIR,
+        f"{lab_id}.json",
+        nodes={"1": _qemu_node(1)},
+        networks={"5": _network(5)},
+    )
+
+    svc = NodeRuntimeService()
+    _seed_attached_qemu(
+        svc,
+        lab_id=lab_id,
+        node_id=1,
+        interface_index=2,
+        network_id=5,
+        monkeypatch=monkeypatch,
+    )
+
+    fake_qmp = _FakeQmp()
+    fake_qmp.responses["device_del"] = {"return": {}}
+    # Device is nested 2 bridges deep — old shallow walk would say
+    # "gone" and run the happy path.
+    fake_qmp.responses["query-pci"] = _query_pci_response_with_nested_device(
+        "dev2", depth=2
+    )
+    svc._qmp_client = fake_qmp
+    calls = _patch_host_net(monkeypatch)
+
+    async def _capture_publish(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(
+        "app.services.ws_hub.ws_hub.publish", _capture_publish
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda _s: None
+    )
+
+    expected_tap = host_net.tap_name(lab_id, 1, 2)
+    result = svc.detach_qemu_interface(lab_id, 1, 2)
+
+    # Forced fallback (device never disappeared from the deep nest).
+    assert result["state"] == "forced", (
+        f"deep-nested device must take forced-fallback path; result={result!r}"
+    )
+    assert calls["link_set_nomaster"] == [expected_tap]
+    # Crucially: tap_del / netdev_del MUST NOT have run — those would
+    # tear down host objects while the QEMU device is still live.
+    assert calls["tap_del"] == []
+    cmds = [c[1] for c in fake_qmp.calls]
+    assert "netdev_del" not in cmds, (
+        f"deep-nested device must NOT trigger netdev_del; cmds={cmds!r}"
+    )


### PR DESCRIPTION
## Summary

US-304 adds QMP-driven hot-remove for QEMU NICs on running VMs, mirroring the US-303 hot-add structure. The `link_service.delete_link` path now dispatches `kind == "qemu"` endpoints to `node_runtime_service.detach_qemu_interface` (via the private locked helper), giving us symmetric attach/detach hot-plug coverage for the QEMU runtime.

- Public `detach_qemu_interface` / private `_detach_qemu_interface_locked` on `NodeRuntimeService`. The locked helper runs:
  1. QMP `device_del id=dev{interface_index}` with race-A retry (`DeviceNotFound` on first call → sleep 0.5s → retry once; second `DeviceNotFound` → treat as idempotent success).
  2. Bounded poll: `query-pci` every 500ms for up to 8s (16 iterations).
  3a. Happy path (gone within timeout): QMP `netdev_del` → `host_net.tap_del(tap_name)`. Transport timeout on `netdev_del` still runs `tap_del` so the kernel TAP is not leaked.
  3b. Forced fallback (still present at 8s): `host_net.link_set_nomaster(tap)` so packets stop flowing kernel-side; `netdev_del` and `tap_del` are intentionally skipped because QEMU still holds the device until guest reboot. A `node_warning` WS event is broadcast via `ws_hub.publish` so the UI can surface "restart node to fully clean".
  - Transport-level errors (`NodeRuntimeQMPTimeout`) on `device_del` / `query-pci` propagate — they are NOT swallowed as forced-fallback (transport timeout ≠ guest didn't eject).
  - Generation token (`current_attach_generation`) is bumped after the kernel objects are removed so a stale concurrent attach cannot race a freshly torn-down NIC.
- `link_service._delete_link_locked` now branches on `runtime.kind`: `docker` keeps the existing `_detach_docker_interface_locked` call, `qemu` calls `_detach_qemu_interface_locked`. Multi-endpoint links (one qemu + one docker) tear down both kinds; on partial failure we surface the FIRST error and log the secondary cleanup attempt. `RuntimeMutexContention` is wrapped to `LinkContentionError` (HTTP 409). The outer rollback catch already includes `NodeRuntimeQMPTimeout`.

## Files

- `backend/app/services/node_runtime_service.py` — added `detach_qemu_interface`, `_detach_qemu_interface_locked`, `_qemu_device_gone`, `_publish_node_warning`.
- `backend/app/services/link_service.py` — `_delete_link_locked` dispatches docker/qemu kinds and translates `RuntimeMutexContention` to `LinkContentionError`.
- `backend/tests/test_us304_qemu_hot_remove.py` — 12 new tests.

## Test plan

- [x] `cd backend && python -m pytest tests/test_us304_qemu_hot_remove.py -v` → **12 passed**
- [x] `cd backend && python -m pytest tests/test_us303_qemu_hot_add.py -v` → **all green** (no US-303 regressions)
- [x] `cd backend && python -m pytest tests/test_us205_hot_detach.py tests/test_node_runtime.py -v` → **all green**
- [x] `cd backend && python -m pytest -x` → broader suite green except the **known pre-existing failure** `test_migrate_continues_on_no_such_network_inspect_error` from PR #127. Re-run with `--deselect` of that test: **611 passed, 1 skipped, 1 deselected**.

## Verification transcript

```
$ python -m pytest tests/test_us304_qemu_hot_remove.py -v
tests/test_us304_qemu_hot_remove.py::test_us304_happy_path_device_del_then_query_pci_then_netdev_and_tap PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_bounded_poll_at_most_16_query_pci_calls PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_forced_fallback_when_device_persists_past_timeout PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_device_not_found_race_a_retries_and_succeeds PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_double_delete_second_call_is_absent_no_op PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_concurrent_attach_and_detach_second_caller_gets_contention PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_transport_timeout_on_device_del_propagates PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_transport_timeout_on_netdev_del_after_device_gone_still_cleans_tap PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_link_service_delete_link_dispatches_to_qemu_detach PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_link_service_delete_link_409_on_qemu_mutex_contention PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_generation_token_bumped_on_happy_path PASSED
tests/test_us304_qemu_hot_remove.py::test_us304_locked_helper_asserts_mutex_held PASSED
======================== 12 passed, 2 warnings in 4.86s ========================

$ python -m pytest tests/test_us303_qemu_hot_add.py tests/test_us205_hot_detach.py tests/test_node_runtime.py -q
............................................................................          [100%]
79 passed, 1 skipped, 6 warnings in 13.28s

$ python -m pytest --deselect tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error
========== 611 passed, 1 skipped, 1 deselected, 12 warnings in 21.30s ==========
```

## Known pre-existing failure (HF4)

`tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error` from PR #127 fails on `main` and is unrelated to this change. **Not addressed here.** Tracked separately.

Closes #102. Part of #80.

---

## Hotfix pass (codex critic REJECT verdict)

Codex critic review: https://github.com/fahadysf/nova-ve/issues/102#issuecomment-4338511093

| # | Severity | Finding | Commit |
|---|----------|---------|--------|
| 1 | HIGH | QEMU detach ignored `attach_generation` (US-204b freshness contract); stale delete could tear down newer NIC because QMP IDs reuse `dev{iface}`/`net{iface}` | `13fda7d` |
| 2 | HIGH | Forced fallback swallowed `link_set_nomaster` failure; reported success while TAP still bridged, retry impossible | `963ec35` |
| 3 | MEDIUM | Race-A retry was `sleep(0.5)`; not the planned bounded 2s wait. Detach could misclassify as "already gone" if `device_add` visibility lagged | `9a8d64c` |
| 4 | MEDIUM | `_qemu_device_gone` only walked one `pci_bridge.devices` level; deeper PCIe trees reported gone too early | `c88f4e2` |

8 new regression tests added (12 → 20 total in `test_us304_qemu_hot_remove.py`).

### Re-verification
- `pytest tests/test_us304_qemu_hot_remove.py -q` → **20 passed**
- `pytest tests/test_us303_qemu_hot_add.py tests/test_us205_hot_detach.py tests/test_node_runtime.py -q` → **79 passed, 1 skipped** (no sibling regressions)
- `pytest --deselect tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error -q` → **619 passed, 1 skipped, 1 deselected** (the deselected test is the pre-existing PR-#127 failure already noted above)

Head: `c88f4e2`. Status: re-ready for review.
