### PR TITLE
feat(net): persist network runtime metadata (bridge_name, driver, created_at) (US-401, #104)

### DIFF
--- a/backend/app/schemas/network.py
+++ b/backend/app/schemas/network.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
@@ -36,13 +37,19 @@ class NetworkRuntime(BaseModel):
 
     Persisted under ``networks[i].runtime`` in lab.json. Owned by
     ``network_service`` (bridge name from US-202; IPAM free-list from
-    US-204c). The IPAM free-list is intentionally NOT a monotonic
+    US-204c; ``driver``/``created_at`` reconciliation metadata from
+    US-401). The IPAM free-list is intentionally NOT a monotonic
     counter — see plan §US-204c "IPAM data model (free-list, NOT a
     counter)" for why.
     """
 
     bridge_name: Optional[str] = None
+    # US-401: ``driver`` records which provisioning backend created the
+    # bridge (currently always ``"linux_bridge"``). ``created_at`` is the
+    # ISO-8601 UTC timestamp of provisioning. Both feed reconciliation in
+    # US-402.
     driver: Optional[str] = None
+    created_at: Optional[datetime] = None
     used_ips: List[str] = Field(default_factory=list)
     # First host offset usable for allocation (skips network address and
     # the conventional .1 gateway reservation). Operators may bump this

--- a/backend/app/services/network_service.py
+++ b/backend/app/services/network_service.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import ipaddress
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from app.config import get_settings
@@ -161,6 +162,12 @@ class NetworkService:
                 "config": dict(raw_config),
                 "runtime": {
                     "bridge_name": bridge,
+                    # US-401: provisioning-backend metadata for the
+                    # reconciliation loop (US-402). ``driver`` mirrors
+                    # the network's ``type`` vocabulary; ``created_at``
+                    # is an ISO-8601 UTC timestamp.
+                    "driver": "linux_bridge",
+                    "created_at": datetime.now(timezone.utc).isoformat(),
                     # US-204c: seed an empty free-list. Counter-based
                     # allocation would exhaust a /24 in 250 cycles even
                     # with one container; the free-list does not.

--- a/backend/tests/test_network_service.py
+++ b/backend/tests/test_network_service.py
@@ -165,6 +165,40 @@ async def test_create_network_bridge_name_uses_helper_format(
 
 
 # ---------------------------------------------------------------------------
+# US-401 — runtime.{driver, created_at} reconciliation metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_network_stamps_runtime_driver_and_created_at(
+    instance_id, settings, helper_mocks, stub_publish, labs_dir
+):
+    """US-401: ``create_network`` stamps ``runtime.driver`` and
+    ``runtime.created_at`` so the reconciliation loop (US-402) and the
+    backfill migration (US-202b) have a target to verify against."""
+    from datetime import datetime as _dt, timezone as _tz
+
+    lab_name = _seed_lab(labs_dir, lab_id="lab-runtime-meta")
+
+    payload = await NetworkService().create_network(lab_name, {"name": "lan"})
+
+    assert payload["runtime"]["driver"] == "linux_bridge"
+    created_at = payload["runtime"]["created_at"]
+    assert isinstance(created_at, str) and created_at, "created_at must be a non-empty ISO string"
+    parsed = _dt.fromisoformat(created_at)
+    assert parsed.tzinfo is not None, "created_at must be timezone-aware"
+    # Sanity: must not be in the past beyond a reasonable bound.
+    delta = (_dt.now(_tz.utc) - parsed).total_seconds()
+    assert -5.0 < delta < 60.0, f"created_at {created_at!r} not close to now"
+
+    # Round-trip: lab.json holds exactly what the API returned.
+    saved = json.loads((labs_dir / lab_name).read_text())
+    saved_runtime = saved["networks"]["1"]["runtime"]
+    assert saved_runtime["driver"] == "linux_bridge"
+    assert saved_runtime["created_at"] == created_at
+
+
+# ---------------------------------------------------------------------------
 # Cross-host collision resistance
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #104. Part of #80.

US-401's acceptance criterion (plan `.omc/plans/network-runtime-wiring.md` lines 455-458) is that `network` JSON records gain `runtime: {bridge_name, driver, created_at}` so the reconciliation loop (US-402) and the backfill migration (US-202b) have a fingerprint to verify against.

## What was already there from US-204c (sha aea4115/4c68165)

- `NetworkRuntime` Pydantic model in `backend/app/schemas/network.py` with `bridge_name`, `driver: Optional[str]` (declared but never populated), `used_ips`, `first_offset`.
- `create_network` already stamped `runtime.bridge_name` (from US-202).
- Backfill migration `scripts/migrate_runtime_network.py` already fills `bridge_name` on pre-Wave-6 records.

## What this PR adds (the US-401 gap)

1. `backend/app/schemas/network.py`: add `created_at: Optional[datetime] = None` to `NetworkRuntime` alongside the existing `driver`. Both feed reconciliation.
2. `backend/app/services/network_service.py`: `create_network` now stamps `runtime.driver = "linux_bridge"` (matches the `type` vocabulary) and `runtime.created_at = datetime.now(timezone.utc).isoformat()` at provisioning time. Persisted under `lab_lock` together with `bridge_name`.
3. `backend/tests/test_network_service.py`: new `test_create_network_stamps_runtime_driver_and_created_at` asserts the payload + on-disk round-trip. Verifies `driver == "linux_bridge"` and `created_at` parses as a timezone-aware ISO-8601 string within a wall-clock bound of "now".

## Verification

```
$ cd backend && python -m pytest tests/test_network_service.py -v
============================== 20 passed in 0.52s ==============================

$ cd backend && python -m pytest --deselect \
    tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error \
    -q
620 passed, 1 skipped, 1 deselected, 12 warnings in 22.56s
```

The deselected test is a pre-existing PR-#127 failure already documented across multiple Wave 6/7/8 PRs (HF4 baseline).

## Test plan

- [x] `tests/test_network_service.py` — new test asserts `runtime.driver` and `runtime.created_at` are stamped + persisted.
- [x] `tests/test_migrate_runtime_network.py` — existing US-202b backfill tests still pass; the migration is unaffected because `driver`/`created_at` are optional and absent fields are tolerated by the Pydantic model.
- [x] Broader pytest suite — 620 passed, no regressions vs the HF4 baseline.
- [ ] Manual on test VM 192.168.100.212: `curl -X POST .../networks` and verify `runtime.driver == "linux_bridge"` and `runtime.created_at` is a recent ISO-8601 timestamp in the response.