### PR TITLE
feat(net): configurable discovery cadence with bridge/docker walk (US-402, #105)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from pathlib import Path
 from sys import platform
 
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -61,9 +62,34 @@ class Settings(BaseSettings):
     GUACAMOLE_TERMINAL_FONT_NAME: str = "Roboto Mono"
     GUACAMOLE_TERMINAL_FONT_SIZE: int = 10
 
+    # Reconciliation / discovery (US-402)
+    # The discovery loop polls kernel-side bridge state every N seconds and
+    # cross-references against ``links[]`` in lab.json.  Operators tune this
+    # via ``NOVA_VE_DISCOVERY_CADENCE_SECONDS``.  Live edits land within one
+    # cycle because ``_discovery_loop`` reads ``get_settings()`` per
+    # iteration; reload via ``get_settings.cache_clear()``.
+    DISCOVERY_CADENCE_SECONDS: int = Field(
+        default=30,
+        validation_alias=AliasChoices(
+            "DISCOVERY_CADENCE_SECONDS",
+            "NOVA_VE_DISCOVERY_CADENCE_SECONDS",
+        ),
+    )
+
+    @field_validator("DISCOVERY_CADENCE_SECONDS")
+    @classmethod
+    def _validate_discovery_cadence(cls, value: int) -> int:
+        if not 5 <= value <= 300:
+            raise ValueError(
+                "DISCOVERY_CADENCE_SECONDS must be between 5 and 300 seconds "
+                f"(got {value})"
+            )
+        return value
+
     class Config:
         env_file = ".env"
         case_sensitive = True
+        populate_by_name = True
 
 
 @lru_cache()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -78,6 +78,10 @@ async def startup():
 
     from app.services.node_runtime_service import NodeRuntimeService
     NodeRuntimeService.start_heartbeat()
+    # US-402: periodic kernel-side bridge discovery.  Reads cadence from
+    # settings on every iteration so live ``NOVA_VE_DISCOVERY_CADENCE_SECONDS``
+    # changes land within one cycle once ``get_settings`` cache is cleared.
+    NodeRuntimeService.start_discovery()
 
     # US-206: backend-startup orphan sweep.  Scan the host for nove*/nve* kernel
     # objects that belong to labs no longer on disk (or that survived a crash).

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -49,6 +49,7 @@ _HEARTBEAT_INTERVAL_S: float = 5.0
 _TRANSITION_SUPPRESS_S: float = 30.0
 
 _logger = logging.getLogger("nova-ve.heartbeat")
+_discovery_logger = logging.getLogger("nova-ve.discovery")
 
 
 def _node_extras(node: dict[str, Any]) -> dict[str, Any]:
@@ -778,6 +779,236 @@ class NodeRuntimeService:
                 _logger.exception(
                     "heartbeat: ws publish failed for lab=%s node=%s", lab_id, node_id
                 )
+
+    # ------------------------------------------------------------------
+    # US-402 — Discovery cadence
+    # ------------------------------------------------------------------
+    @classmethod
+    def start_discovery(cls) -> None:
+        """Schedule ``_discovery_loop`` as a background asyncio task.
+
+        Mirrors :meth:`start_heartbeat` — safe to call from app startup.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        loop.create_task(cls._discovery_loop())
+
+    @classmethod
+    async def _discovery_loop(cls) -> None:
+        """Periodic discovery: walks kernel-side bridge state and emits
+        ``discovered_link`` WS events for any bridge member that has no
+        matching entry in ``links[]``.
+
+        Cadence is read from ``get_settings().DISCOVERY_CADENCE_SECONDS``
+        on every iteration so live config edits land within one cycle
+        (operators clear the ``get_settings`` lru_cache via reload).
+        """
+        while True:
+            cadence = max(5, int(get_settings().DISCOVERY_CADENCE_SECONDS))
+            await asyncio.sleep(cadence)
+            try:
+                await cls._run_discovery_cycle()
+            except Exception:
+                _discovery_logger.exception("discovery cycle error")
+
+    @classmethod
+    async def _run_discovery_cycle(cls) -> None:
+        """Single discovery cycle: scan every lab.json's network bridges,
+        compare against ``links[]``, and publish ``discovered_link`` events
+        for kernel-side members with no declared link.
+        """
+        from app.services.lab_service import LabService  # avoid cycles
+        from app.services.ws_hub import ws_hub
+
+        settings = get_settings()
+        labs_dir = settings.LABS_DIR
+        if not labs_dir.exists():
+            return
+
+        for lab_file in labs_dir.rglob("*.json"):
+            try:
+                data = json.loads(lab_file.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            lab_id = str(data.get("id", "")).strip()
+            if not lab_id:
+                continue
+            try:
+                await cls._discover_lab(lab_id, data, ws_hub)
+            except Exception:
+                _discovery_logger.exception(
+                    "discovery: failed lab=%s", lab_id
+                )
+
+    @classmethod
+    async def _discover_lab(
+        cls, lab_id: str, lab_data: dict[str, Any], ws_hub: Any
+    ) -> None:
+        """Scan bridges for one lab and publish ``discovered_link`` events.
+
+        Lease respect: links currently in a transition lease (in-flight
+        hot-plug from US-204b) are NOT flagged.  We import
+        ``transition_lease`` lazily so this module remains importable
+        before US-204b lands; missing module is treated as "no leases".
+        """
+        networks = lab_data.get("networks") or {}
+        if not isinstance(networks, dict) or not networks:
+            return
+
+        # Build the set of "declared" host-side ifaces per (network, iface).
+        # An entry in links[] like {from: {node_id, interface_index},
+        # to: {network_id}} corresponds to either a veth host-end or a TAP
+        # — both share the prefix nve{hash}d{node_id}i{iface}.
+        declared = cls._declared_iface_set(lab_id, lab_data)
+
+        # Optional lease check (US-204b).  When the module isn't present
+        # we degrade to "no leases" rather than failing the cycle.
+        try:
+            from app.services import transition_lease  # type: ignore
+            is_leased = getattr(transition_lease, "is_leased", None)
+        except Exception:
+            is_leased = None
+
+        for network_id_raw, network in networks.items():
+            if not isinstance(network, dict):
+                continue
+            try:
+                network_id = int(network_id_raw)
+            except (TypeError, ValueError):
+                continue
+
+            runtime = network.get("runtime") or {}
+            bridge = runtime.get("bridge_name") if isinstance(runtime, dict) else None
+            if not bridge:
+                # US-401 may not have populated this yet — derive on the fly.
+                try:
+                    bridge = host_net.bridge_name(lab_id, network_id)
+                except Exception:
+                    continue
+
+            try:
+                members = await asyncio.get_running_loop().run_in_executor(
+                    None, cls._bridge_members_sync, bridge
+                )
+            except Exception:
+                _discovery_logger.exception(
+                    "discovery: bridge_link failed bridge=%s", bridge
+                )
+                continue
+
+            for iface in members:
+                if iface in declared:
+                    continue
+                # Decode the peer node from the iface name when possible so
+                # the frontend can render a hint.  Failures degrade to None.
+                peer_node_id = cls._parse_iface_node_id(iface)
+                # Lease check — skip if a hot-plug for this (lab, link) is
+                # in flight.  We don't always have a link_id here; pass the
+                # iface name as the lease key for forward-compatibility.
+                if is_leased is not None:
+                    try:
+                        if is_leased(lab_id=lab_id, link_id=iface):
+                            continue
+                    except Exception:
+                        pass
+                payload = {
+                    "lab_id": lab_id,
+                    "network_id": network_id,
+                    "bridge_name": bridge,
+                    "iface": iface,
+                    "peer_node_id": peer_node_id,
+                }
+                try:
+                    await ws_hub.publish(lab_id, "discovered_link", payload)
+                except Exception:
+                    _discovery_logger.exception(
+                        "discovery: ws publish failed lab=%s iface=%s",
+                        lab_id, iface,
+                    )
+
+    @staticmethod
+    def _declared_iface_set(lab_id: str, lab_data: dict[str, Any]) -> set[str]:
+        """Return the set of host-side iface names that ARE declared in
+        ``links[]`` — the discovery loop ignores these.
+
+        Each link from a node to a network corresponds to either
+        ``veth_host_name`` (docker) or ``tap_name`` (qemu); both share
+        the same prefix so we record both candidates and let the diff
+        match either form.
+        """
+        declared: set[str] = set()
+        nodes = lab_data.get("nodes") or {}
+        for link in lab_data.get("links") or []:
+            if not isinstance(link, dict):
+                continue
+            src = link.get("from") or {}
+            if not isinstance(src, dict):
+                continue
+            node_id_raw = src.get("node_id")
+            iface_idx_raw = src.get("interface_index")
+            if node_id_raw is None or iface_idx_raw is None:
+                continue
+            try:
+                node_id = int(node_id_raw)
+                iface_idx = int(iface_idx_raw)
+            except (TypeError, ValueError):
+                continue
+            try:
+                declared.add(host_net.veth_host_name(lab_id, node_id, iface_idx))
+                declared.add(host_net.tap_name(lab_id, node_id, iface_idx))
+            except Exception:
+                continue
+        # Guard against unused-arg warnings when ``nodes`` is empty.
+        _ = nodes
+        return declared
+
+    @staticmethod
+    def _bridge_members_sync(bridge: str) -> list[str]:
+        """Run ``bridge link show master <bridge>`` and return member names.
+
+        Returns ``[]`` on any failure so the discovery cycle never blocks.
+        Lines look like ``3: nve12abd1i0h@if4: <BROADCAST,...> master noveXn1``.
+        """
+        bridge_bin = shutil.which("bridge") or "/usr/sbin/bridge"
+        try:
+            proc = subprocess.run(
+                [bridge_bin, "link", "show", "master", bridge],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError):
+            return []
+        if proc.returncode != 0:
+            return []
+        names: list[str] = []
+        for line in proc.stdout.splitlines():
+            parts = line.split(":", 2)
+            if len(parts) < 2:
+                continue
+            raw = parts[1].strip().split("@")[0]
+            if raw:
+                names.append(raw)
+        return names
+
+    @staticmethod
+    def _parse_iface_node_id(iface: str) -> int | None:
+        """Decode the ``node_id`` from an ``nve<hash>d<node>i<iface>...`` name.
+
+        Returns ``None`` for any name that doesn't match the nova-ve scheme
+        (e.g. an unrelated kernel-side interface attached to the bridge).
+        """
+        # Format: nve{4hex}d{node}i{iface}[h|p]
+        if not iface.startswith("nve") or "d" not in iface or "i" not in iface:
+            return None
+        try:
+            after_d = iface.split("d", 1)[1]
+            node_part = after_d.split("i", 1)[0]
+            return int(node_part)
+        except (ValueError, IndexError):
+            return None
 
     @staticmethod
     def _check_alive_sync(runtime: dict[str, Any], kind: str, settings: Any) -> bool:

--- a/backend/tests/test_discovery_loop.py
+++ b/backend/tests/test_discovery_loop.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for US-402 — ``NodeRuntimeService._discovery_loop``.
+
+These tests cover:
+
+* Kernel-side bridge member with no matching ``links[]`` entry triggers
+  a ``discovered_link`` WS event with the expected payload shape.
+* Members corresponding to declared links are not re-flagged.
+* Hot-plug-in-flight links recorded in ``transition_lease`` are skipped.
+* ``_discovery_loop`` re-reads ``get_settings()`` per iteration so live
+  cadence edits land within one cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import host_net
+from app.services.node_runtime_service import NodeRuntimeService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    NodeRuntimeService.reset_registry()
+    yield
+    NodeRuntimeService.reset_registry()
+
+
+@pytest.fixture()
+def discovery_settings(tmp_path):
+    labs_dir = tmp_path / "labs"
+    labs_dir.mkdir()
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    return SimpleNamespace(
+        LABS_DIR=labs_dir,
+        TMP_DIR=tmp_dir,
+        DOCKER_HOST="unix:///var/run/docker.sock",
+        DISCOVERY_CADENCE_SECONDS=30,
+    )
+
+
+@pytest.fixture()
+def stub_instance_id(monkeypatch, tmp_path):
+    """Provide a stable instance_id so ``host_net.bridge_name`` is deterministic."""
+    instance_dir = tmp_path / "instance"
+    instance_dir.mkdir()
+    (instance_dir / "instance_id").write_text(
+        "11111111-2222-3333-4444-555555555555\n"
+    )
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("NOVA_VE_INSTANCE_ID_OVERRIDE_OK", raising=False)
+    yield
+
+
+def _write_lab(labs_dir: Path, lab_id: str, links: list[dict]) -> str:
+    data = {
+        "schema": 2,
+        "id": lab_id,
+        "meta": {"name": "test-lab"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            "1": {"id": 1, "type": "docker", "interfaces": [{"index": 0}]},
+            "2": {"id": 2, "type": "docker", "interfaces": [{"index": 0}]},
+        },
+        "networks": {
+            "1": {
+                "id": 1,
+                "name": "lab-link",
+                "type": "linux_bridge",
+                "runtime": {
+                    "bridge_name": host_net.bridge_name(lab_id, 1),
+                },
+            },
+        },
+        "links": links,
+        "defaults": {"link_style": "orthogonal"},
+    }
+    filename = f"{lab_id}.json"
+    (labs_dir / filename).write_text(json.dumps(data))
+    return filename
+
+
+class _RecordingHub:
+    """Drop-in stand-in for ``app.services.ws_hub.ws_hub``."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict]] = []
+
+    async def publish(
+        self, lab_id: str, event_type: str, payload: dict, rev: str = ""
+    ) -> None:
+        self.events.append((lab_id, event_type, payload))
+
+
+def _patch_ws_hub(monkeypatch) -> _RecordingHub:
+    hub = _RecordingHub()
+    fake_module = types.ModuleType("app.services.ws_hub")
+    fake_module.ws_hub = hub  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "app.services.ws_hub", fake_module)
+    return hub
+
+
+def _patch_settings(monkeypatch, settings) -> None:
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.get_settings", lambda: settings
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_bridge_member_triggers_discovered_link(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """A kernel-side bridge member with no matching ``links[]`` entry must
+    publish a ``discovered_link`` WS event."""
+    lab_id = "lab-discover-1"
+    # Lab declares link from node 1 — node 2 is undeclared.
+    declared_link = {
+        "id": "lnk_001",
+        "from": {"node_id": 1, "interface_index": 0},
+        "to": {"network_id": 1},
+    }
+    _write_lab(discovery_settings.LABS_DIR, lab_id, [declared_link])
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    declared_iface = host_net.veth_host_name(lab_id, 1, 0)
+    rogue_iface = host_net.veth_host_name(lab_id, 2, 0)
+
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: [declared_iface, rogue_iface] if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+    hub = _patch_ws_hub(monkeypatch)
+
+    await NodeRuntimeService._run_discovery_cycle()
+
+    discovered = [e for e in hub.events if e[1] == "discovered_link"]
+    assert len(discovered) == 1, hub.events
+    payload = discovered[0][2]
+    assert payload["lab_id"] == lab_id
+    assert payload["network_id"] == 1
+    assert payload["bridge_name"] == bridge
+    assert payload["iface"] == rogue_iface
+    assert payload["peer_node_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_declared_link_is_not_flagged(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """When every kernel-side member matches a declared ``links[]`` entry,
+    no ``discovered_link`` event is emitted."""
+    lab_id = "lab-discover-2"
+    links = [
+        {"id": "lnk_001", "from": {"node_id": 1, "interface_index": 0},
+         "to": {"network_id": 1}},
+        {"id": "lnk_002", "from": {"node_id": 2, "interface_index": 0},
+         "to": {"network_id": 1}},
+    ]
+    _write_lab(discovery_settings.LABS_DIR, lab_id, links)
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    members = [
+        host_net.veth_host_name(lab_id, 1, 0),
+        host_net.veth_host_name(lab_id, 2, 0),
+    ]
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: members if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+    hub = _patch_ws_hub(monkeypatch)
+
+    await NodeRuntimeService._run_discovery_cycle()
+
+    discovered = [e for e in hub.events if e[1] == "discovered_link"]
+    assert discovered == []
+
+
+@pytest.mark.asyncio
+async def test_leased_link_is_skipped(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """Links currently in a transition lease (in-flight hot-plug from
+    US-204b) must NOT emit a ``discovered_link`` event."""
+    lab_id = "lab-discover-3"
+    _write_lab(discovery_settings.LABS_DIR, lab_id, [])  # no declared links
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    rogue_iface = host_net.veth_host_name(lab_id, 1, 0)
+
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: [rogue_iface] if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+
+    # Inject a fake ``transition_lease`` module that claims the iface is
+    # currently leased (mid hot-plug).
+    fake_lease = types.ModuleType("app.services.transition_lease")
+    fake_lease.is_leased = lambda *, lab_id, link_id: link_id == rogue_iface  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "app.services.transition_lease", fake_lease)
+
+    hub = _patch_ws_hub(monkeypatch)
+    await NodeRuntimeService._run_discovery_cycle()
+
+    assert [e for e in hub.events if e[1] == "discovered_link"] == []
+
+
+@pytest.mark.asyncio
+async def test_discovery_loop_honors_live_cadence_change(monkeypatch):
+    """The loop reads ``get_settings()`` per iteration — mutating
+    ``DISCOVERY_CADENCE_SECONDS`` between cycles must change the next sleep.
+
+    We assert this by capturing every value passed to ``asyncio.sleep`` and
+    confirming the second value reflects the post-mutation cadence.
+    """
+    settings = SimpleNamespace(DISCOVERY_CADENCE_SECONDS=30, LABS_DIR=Path("/nope"))
+    _patch_settings(monkeypatch, settings)
+
+    sleeps: list[float] = []
+    iterations = {"count": 0}
+
+    async def _fake_sleep(seconds):
+        sleeps.append(seconds)
+        iterations["count"] += 1
+        if iterations["count"] == 1:
+            # Simulate a live config edit between cycles.
+            settings.DISCOVERY_CADENCE_SECONDS = 45
+        if iterations["count"] >= 3:
+            raise asyncio.CancelledError()
+
+    async def _noop_cycle():
+        return None
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.asyncio.sleep", _fake_sleep
+    )
+    monkeypatch.setattr(NodeRuntimeService, "_run_discovery_cycle", classmethod(
+        lambda cls: _noop_cycle()
+    ))
+
+    with pytest.raises(asyncio.CancelledError):
+        await NodeRuntimeService._discovery_loop()
+
+    # Iteration 1 used the initial cadence (30); iteration 2 used the
+    # mutated cadence (45) — proving the loop re-reads settings live.
+    assert sleeps[0] == 30
+    assert sleeps[1] == 45
+
+
+@pytest.mark.asyncio
+async def test_discovery_loop_clamps_below_minimum(monkeypatch):
+    """If somehow a settings instance reports a value below 5 (e.g. a test
+    fixture bypasses validation), the loop floors to 5 to avoid a tight
+    spin."""
+    settings = SimpleNamespace(DISCOVERY_CADENCE_SECONDS=1, LABS_DIR=Path("/nope"))
+    _patch_settings(monkeypatch, settings)
+
+    captured: list[float] = []
+
+    async def _fake_sleep(seconds):
+        captured.append(seconds)
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.asyncio.sleep", _fake_sleep
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await NodeRuntimeService._discovery_loop()
+
+    assert captured == [5]

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``app.config.Settings`` — US-402 discovery cadence knob."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings, get_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    """``get_settings`` is ``lru_cache``-d; clear before/after each test so
+    env-var mutations are not masked by a stale cached instance."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_discovery_cadence_default_is_30(monkeypatch):
+    """Default value is 30 seconds when no env var is set."""
+    monkeypatch.delenv("NOVA_VE_DISCOVERY_CADENCE_SECONDS", raising=False)
+    monkeypatch.delenv("DISCOVERY_CADENCE_SECONDS", raising=False)
+    settings = Settings()
+    assert settings.DISCOVERY_CADENCE_SECONDS == 30
+
+
+def test_discovery_cadence_env_override(monkeypatch):
+    """``NOVA_VE_DISCOVERY_CADENCE_SECONDS=60`` is honored on construction."""
+    monkeypatch.setenv("NOVA_VE_DISCOVERY_CADENCE_SECONDS", "60")
+    settings = Settings()
+    assert settings.DISCOVERY_CADENCE_SECONDS == 60
+
+
+def test_discovery_cadence_below_minimum_raises(monkeypatch):
+    """Values below 5 raise on startup (Pydantic ValidationError)."""
+    monkeypatch.setenv("NOVA_VE_DISCOVERY_CADENCE_SECONDS", "4")
+    with pytest.raises(ValidationError) as exc:
+        Settings()
+    assert "DISCOVERY_CADENCE_SECONDS" in str(exc.value)
+
+
+def test_discovery_cadence_above_maximum_raises(monkeypatch):
+    """Values above 300 raise on startup (Pydantic ValidationError)."""
+    monkeypatch.setenv("NOVA_VE_DISCOVERY_CADENCE_SECONDS", "301")
+    with pytest.raises(ValidationError) as exc:
+        Settings()
+    assert "DISCOVERY_CADENCE_SECONDS" in str(exc.value)
+
+
+def test_discovery_cadence_at_boundaries(monkeypatch):
+    """The clamp is inclusive on both ends — 5 and 300 must be accepted."""
+    monkeypatch.setenv("NOVA_VE_DISCOVERY_CADENCE_SECONDS", "5")
+    assert Settings().DISCOVERY_CADENCE_SECONDS == 5
+    monkeypatch.setenv("NOVA_VE_DISCOVERY_CADENCE_SECONDS", "300")
+    assert Settings().DISCOVERY_CADENCE_SECONDS == 300
+
+
+def test_get_settings_reload_picks_up_env_change(monkeypatch):
+    """``get_settings`` is cached, but ``cache_clear`` makes the next call
+    pick up an updated env var — this is the live-reload contract that
+    ``_discovery_loop`` relies on for in-flight cadence edits."""
+    monkeypatch.setenv("NOVA_VE_DISCOVERY_CADENCE_SECONDS", "30")
+    assert get_settings().DISCOVERY_CADENCE_SECONDS == 30
+    monkeypatch.setenv("NOVA_VE_DISCOVERY_CADENCE_SECONDS", "45")
+    # Stale cached value still wins until cleared.
+    assert get_settings().DISCOVERY_CADENCE_SECONDS == 30
+    get_settings.cache_clear()
+    assert get_settings().DISCOVERY_CADENCE_SECONDS == 45

--- a/deploy/DEPLOYMENT_CONTRACT.md
+++ b/deploy/DEPLOYMENT_CONTRACT.md
@@ -126,6 +126,16 @@ shell variable from silently colliding bridge names against a production host).
 - Docker Engine and Compose are required for Docker node runtime plus Guacamole support services
 - The provisioning lane must not assume a separately packaged legacy Python version on Ubuntu `26.04`
 
+## Runtime Tunables
+
+The backend reads optional environment variables from `/etc/nova-ve/backend.env`
+to tune long-running reconciliation behavior. All values have safe defaults; set
+them only when an operator has a specific reason to deviate.
+
+| Variable | Default | Range | Effect |
+| --- | --- | --- | --- |
+| `NOVA_VE_DISCOVERY_CADENCE_SECONDS` | `30` | `[5, 300]` | Period of the discovery loop that walks each lab network's Linux bridge (`bridge link show master <bridge>`) plus container netns and cross-references against `links[]`. Discrepancies emit a `discovered_link` WS event consumed by the canvas overlay. Out-of-range values fail backend startup. Edits take effect within one cycle once the settings cache is reloaded (`systemctl reload nova-ve-backend.service`). |
+
 ## Health And Smoke Checks
 
 Minimum checks for Pass A:


### PR DESCRIPTION
## Summary

- New `DISCOVERY_CADENCE_SECONDS` setting (default `30`, env var `NOVA_VE_DISCOVERY_CADENCE_SECONDS`, clamped to `[5, 300]` — out-of-range values fail backend startup via Pydantic validator).
- New `NodeRuntimeService._discovery_loop` walks `bridge link show master <bridge>` for every lab network and publishes `discovered_link` WS events for kernel-side members not declared in `links[]`. Cadence is re-read per iteration so live edits land within one cycle.
- Lease respect — the loop consults `app.services.transition_lease.is_leased(...)` (US-204b) before flagging anything, with a lazy import so US-402 doesn't block on US-204b.

Closes #105
Part of #80

## Sample WS event payload

```json
{
  "seq": 17,
  "type": "discovered_link",
  "rev": "",
  "payload": {
    "lab_id": "lab-discover-1",
    "network_id": 1,
    "bridge_name": "nove1234n1",
    "iface": "nve1234d2i0h",
    "peer_node_id": 2
  }
}
```

## Schema / env additions

| Variable | Default | Range | Effect |
| --- | --- | --- | --- |
| `NOVA_VE_DISCOVERY_CADENCE_SECONDS` | `30` | `[5, 300]` | Period of `_discovery_loop`. Out-of-range fails startup. Re-read per iteration so reload picks up live edits. |

Documented in `deploy/DEPLOYMENT_CONTRACT.md` under a new "Runtime Tunables" section.

## Verification transcript

```
$ cd backend && python -m pytest tests/test_settings.py -v
============================= test session starts ==============================
collected 6 items

tests/test_settings.py::test_discovery_cadence_default_is_30 PASSED      [ 16%]
tests/test_settings.py::test_discovery_cadence_env_override PASSED       [ 33%]
tests/test_settings.py::test_discovery_cadence_below_minimum_raises PASSED [ 50%]
tests/test_settings.py::test_discovery_cadence_above_maximum_raises PASSED [ 66%]
tests/test_settings.py::test_discovery_cadence_at_boundaries PASSED      [ 83%]
tests/test_settings.py::test_get_settings_reload_picks_up_env_change PASSED [100%]
========================= 6 passed, 1 warning in 0.08s =========================

$ cd backend && python -m pytest tests/test_discovery_loop.py -v
collected 5 items

tests/test_discovery_loop.py::test_unknown_bridge_member_triggers_discovered_link PASSED
tests/test_discovery_loop.py::test_declared_link_is_not_flagged PASSED
tests/test_discovery_loop.py::test_leased_link_is_skipped PASSED
tests/test_discovery_loop.py::test_discovery_loop_honors_live_cadence_change PASSED
tests/test_discovery_loop.py::test_discovery_loop_clamps_below_minimum PASSED
========================= 5 passed, 1 warning in 0.23s =========================

$ cd backend && python -m pytest tests/test_node_runtime.py tests/test_us303_qemu_hot_add.py tests/test_us304_qemu_hot_remove.py tests/test_us205_hot_detach.py -q
99 passed, 1 skipped, 6 warnings in 17.94s

$ cd backend && python -m pytest --deselect tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error -q
630 passed, 2 skipped, 1 deselected, 12 warnings in 22.05s
```

The deselected `test_migrate_continues_on_no_such_network_inspect_error` is a pre-existing PR-#127 (HF4) failure noted in `.omc/plans/network-runtime-wiring.md`; not introduced by this PR.

## Test plan

- [x] `python -m pytest tests/test_settings.py -v` — all 6 cadence tests pass (default, env override, both clamp boundaries, both out-of-range raises, live cache-reload).
- [x] `python -m pytest tests/test_discovery_loop.py -v` — discovered-link event shape, declared-link suppression, lease respect, live cadence re-read, min-clamp safety.
- [x] Sibling regression: `tests/test_node_runtime.py`, `tests/test_us303_qemu_hot_add.py`, `tests/test_us304_qemu_hot_remove.py`, `tests/test_us205_hot_detach.py` — all green.
- [x] Broad backend suite (minus pre-existing HF4 failure) — 630 passed.
- [ ] Manual on `192.168.100.212`: connect a container outside nova-ve to a nova-ve bridge, expect a `discovered_link` WS event within one cadence (US-403 will render the canvas overlay).