### PR TITLE
feat(canvas+net): overlay + WS event for divergent links with lease-respect (US-404, #107)

### DIFF
--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -846,7 +846,13 @@ class NodeRuntimeService:
     async def _discover_lab(
         cls, lab_id: str, lab_data: dict[str, Any], ws_hub: Any
     ) -> None:
-        """Scan bridges for one lab and publish ``discovered_link`` events.
+        """Scan bridges for one lab and publish ``discovered_link`` /
+        ``link_divergent`` WS events.
+
+        - ``discovered_link``: kernel-side bridge member with no matching
+          ``links[]`` entry (US-402).
+        - ``link_divergent``: ``links[]`` entry whose declared veth/TAP is
+          NOT present on any of this lab's bridges (US-404).
 
         Lease respect: links currently in a transition lease (in-flight
         hot-plug from US-204b) are NOT flagged.  We import
@@ -870,6 +876,12 @@ class NodeRuntimeService:
             is_leased = getattr(transition_lease, "is_leased", None)
         except Exception:
             is_leased = None
+
+        # Aggregate kernel-side bridge members across this lab so the
+        # divergent-link check (US-404) below can answer "does the kernel
+        # have any veth/TAP for this declared link?" without a second
+        # bridge-scan pass.
+        kernel_members: set[str] = set()
 
         for network_id_raw, network in networks.items():
             if not isinstance(network, dict):
@@ -897,6 +909,8 @@ class NodeRuntimeService:
                     "discovery: bridge_link failed bridge=%s", bridge
                 )
                 continue
+
+            kernel_members.update(members)
 
             for iface in members:
                 if iface in declared:
@@ -927,6 +941,103 @@ class NodeRuntimeService:
                         "discovery: ws publish failed lab=%s iface=%s",
                         lab_id, iface,
                     )
+
+        # ------------------------------------------------------------------
+        # US-404 — Divergent links (declared in lab.json but kernel says no)
+        # ------------------------------------------------------------------
+        await cls._publish_divergent_links(
+            lab_id=lab_id,
+            lab_data=lab_data,
+            kernel_members=kernel_members,
+            is_leased=is_leased,
+            ws_hub=ws_hub,
+        )
+
+    @classmethod
+    async def _publish_divergent_links(
+        cls,
+        *,
+        lab_id: str,
+        lab_data: dict[str, Any],
+        kernel_members: set[str],
+        is_leased: Callable[..., bool] | None,
+        ws_hub: Any,
+    ) -> None:
+        """For each entry in ``links[]`` whose declared veth/TAP host-side
+        name is missing from ``kernel_members``, publish a
+        ``link_divergent`` WS event with payload ``{link_id, lab_id, reason,
+        last_checked}``.
+
+        Lease respect: a link currently held by ``transition_lease.is_leased``
+        is in the middle of a hot-plug operation and MUST NOT be flagged
+        divergent.
+        """
+        links = lab_data.get("links") or []
+        if not isinstance(links, list) or not links:
+            return
+
+        from datetime import datetime, timezone
+
+        last_checked = datetime.now(timezone.utc).isoformat()
+
+        for link in links:
+            if not isinstance(link, dict):
+                continue
+            link_id = link.get("id")
+            if not isinstance(link_id, str) or not link_id:
+                continue
+            src = link.get("from") or {}
+            if not isinstance(src, dict):
+                continue
+            node_id_raw = src.get("node_id")
+            iface_idx_raw = src.get("interface_index")
+            if node_id_raw is None or iface_idx_raw is None:
+                continue
+            try:
+                node_id = int(node_id_raw)
+                iface_idx = int(iface_idx_raw)
+            except (TypeError, ValueError):
+                continue
+
+            try:
+                veth_iface = host_net.veth_host_name(lab_id, node_id, iface_idx)
+                tap_iface = host_net.tap_name(lab_id, node_id, iface_idx)
+            except Exception:
+                continue
+
+            # If either the veth host-end OR the TAP exists on any bridge
+            # this lab owns, the kernel state is consistent — not divergent.
+            if veth_iface in kernel_members or tap_iface in kernel_members:
+                continue
+
+            # Lease respect — skip if a hot-plug is currently in flight for
+            # this link.  We probe by both the link_id and the iface names
+            # so leases registered under either key are honored.
+            if is_leased is not None:
+                leased = False
+                for lease_key in (link_id, veth_iface, tap_iface):
+                    try:
+                        if is_leased(lab_id=lab_id, link_id=lease_key):
+                            leased = True
+                            break
+                    except Exception:
+                        continue
+                if leased:
+                    continue
+
+            payload = {
+                "link_id": link_id,
+                "lab_id": lab_id,
+                "reason": "declared in lab.json but no matching veth/TAP found in kernel",
+                "last_checked": last_checked,
+            }
+            try:
+                await ws_hub.publish(lab_id, "link_divergent", payload)
+            except Exception:
+                _discovery_logger.exception(
+                    "discovery: ws publish failed lab=%s link_id=%s",
+                    lab_id, link_id,
+                )
 
     @staticmethod
     def _declared_iface_set(lab_id: str, lab_data: dict[str, Any]) -> set[str]:

--- a/backend/tests/test_discovery_loop.py
+++ b/backend/tests/test_discovery_loop.py
@@ -1,15 +1,20 @@
 # Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for US-402 — ``NodeRuntimeService._discovery_loop``.
+"""Tests for US-402 / US-404 — ``NodeRuntimeService._discovery_loop``.
 
 These tests cover:
 
 * Kernel-side bridge member with no matching ``links[]`` entry triggers
-  a ``discovered_link`` WS event with the expected payload shape.
-* Members corresponding to declared links are not re-flagged.
-* Hot-plug-in-flight links recorded in ``transition_lease`` are skipped.
+  a ``discovered_link`` WS event with the expected payload shape (US-402).
+* Members corresponding to declared links are not re-flagged (US-402).
+* Hot-plug-in-flight links recorded in ``transition_lease`` are skipped
+  (US-402 + US-404).
 * ``_discovery_loop`` re-reads ``get_settings()`` per iteration so live
-  cadence edits land within one cycle.
+  cadence edits land within one cycle (US-402).
+* US-404: declared links whose veth/TAP is missing from the kernel emit
+  a ``link_divergent`` WS event with ``link_id``, ``lab_id``, ``reason``
+  and ISO-8601 ``last_checked`` timestamp; declared links that ARE present
+  in the kernel are not flagged; leased divergent links are skipped.
 """
 
 from __future__ import annotations
@@ -294,3 +299,175 @@ async def test_discovery_loop_clamps_below_minimum(monkeypatch):
         await NodeRuntimeService._discovery_loop()
 
     assert captured == [5]
+
+
+# ---------------------------------------------------------------------------
+# US-404 — Divergent link tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_divergent_link_emits_link_divergent(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """A link declared in ``links[]`` whose veth/TAP host-side name is NOT
+    present on any bridge for the lab MUST trigger a ``link_divergent`` WS
+    event whose payload includes ``link_id``, ``lab_id``, ``reason`` and an
+    ISO-8601 ``last_checked`` timestamp."""
+    lab_id = "lab-divergent-1"
+    declared_link = {
+        "id": "lnk_001",
+        "from": {"node_id": 1, "interface_index": 0},
+        "to": {"network_id": 1},
+    }
+    _write_lab(discovery_settings.LABS_DIR, lab_id, [declared_link])
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    # Kernel reports an empty bridge — declared link is divergent.
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: [] if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+    hub = _patch_ws_hub(monkeypatch)
+
+    await NodeRuntimeService._run_discovery_cycle()
+
+    divergent = [e for e in hub.events if e[1] == "link_divergent"]
+    assert len(divergent) == 1, hub.events
+    payload = divergent[0][2]
+    assert payload["link_id"] == "lnk_001"
+    assert payload["lab_id"] == lab_id
+    assert isinstance(payload["reason"], str) and payload["reason"]
+    assert "last_checked" in payload
+    # ISO-8601 round-trip — bare smoke check.
+    from datetime import datetime
+    parsed = datetime.fromisoformat(payload["last_checked"])
+    assert parsed.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_present_declared_link_is_not_divergent(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """When the declared link's veth IS present on the bridge, no
+    ``link_divergent`` event is emitted."""
+    lab_id = "lab-divergent-2"
+    declared_link = {
+        "id": "lnk_present",
+        "from": {"node_id": 1, "interface_index": 0},
+        "to": {"network_id": 1},
+    }
+    _write_lab(discovery_settings.LABS_DIR, lab_id, [declared_link])
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    veth = host_net.veth_host_name(lab_id, 1, 0)
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: [veth] if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+    hub = _patch_ws_hub(monkeypatch)
+
+    await NodeRuntimeService._run_discovery_cycle()
+
+    assert [e for e in hub.events if e[1] == "link_divergent"] == []
+
+
+@pytest.mark.asyncio
+async def test_present_declared_link_via_tap_is_not_divergent(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """A QEMU-style TAP whose name matches the declared link is also
+    considered present (not divergent)."""
+    lab_id = "lab-divergent-3"
+    declared_link = {
+        "id": "lnk_tap",
+        "from": {"node_id": 2, "interface_index": 0},
+        "to": {"network_id": 1},
+    }
+    _write_lab(discovery_settings.LABS_DIR, lab_id, [declared_link])
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    tap = host_net.tap_name(lab_id, 2, 0)
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: [tap] if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+    hub = _patch_ws_hub(monkeypatch)
+
+    await NodeRuntimeService._run_discovery_cycle()
+
+    assert [e for e in hub.events if e[1] == "link_divergent"] == []
+
+
+@pytest.mark.asyncio
+async def test_leased_divergent_link_is_skipped(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """A divergent link held by ``transition_lease`` (in-flight hot-plug
+    from US-204b) MUST NOT emit a ``link_divergent`` event — in-flight
+    hot-plug is not a divergence."""
+    lab_id = "lab-divergent-4"
+    declared_link = {
+        "id": "lnk_leased",
+        "from": {"node_id": 1, "interface_index": 0},
+        "to": {"network_id": 1},
+    }
+    _write_lab(discovery_settings.LABS_DIR, lab_id, [declared_link])
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: [] if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+
+    # Lease registered under the link_id — divergent flagging must back off.
+    fake_lease = types.ModuleType("app.services.transition_lease")
+    fake_lease.is_leased = lambda *, lab_id, link_id: link_id == "lnk_leased"  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "app.services.transition_lease", fake_lease)
+
+    hub = _patch_ws_hub(monkeypatch)
+    await NodeRuntimeService._run_discovery_cycle()
+
+    assert [e for e in hub.events if e[1] == "link_divergent"] == []
+
+
+@pytest.mark.asyncio
+async def test_leased_divergent_link_via_iface_key_is_skipped(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """A lease registered under the iface name (rather than the link_id)
+    must also suppress ``link_divergent`` — forward-compatible with the
+    iface-keyed lease scheme used by ``discovered_link``."""
+    lab_id = "lab-divergent-5"
+    declared_link = {
+        "id": "lnk_iface_leased",
+        "from": {"node_id": 3, "interface_index": 0},
+        "to": {"network_id": 1},
+    }
+    _write_lab(discovery_settings.LABS_DIR, lab_id, [declared_link])
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    veth = host_net.veth_host_name(lab_id, 3, 0)
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: [] if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+
+    fake_lease = types.ModuleType("app.services.transition_lease")
+    fake_lease.is_leased = lambda *, lab_id, link_id: link_id == veth  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "app.services.transition_lease", fake_lease)
+
+    hub = _patch_ws_hub(monkeypatch)
+    await NodeRuntimeService._run_discovery_cycle()
+
+    assert [e for e in hub.events if e[1] == "link_divergent"] == []

--- a/frontend/src/lib/components/canvas/LinkEdge.svelte
+++ b/frontend/src/lib/components/canvas/LinkEdge.svelte
@@ -30,6 +30,9 @@
     style_override?: LinkStyle | null;
     default_style?: LinkStyle;
     obstacles?: Obstacle[];
+    discovered?: boolean;
+    divergent?: boolean;
+    last_checked?: string | null;
   } | undefined = undefined;
 
   let result: RouteResult | null = null;
@@ -98,6 +101,10 @@
   $: dAttr = result?.d ?? `M ${from.x},${from.y} L ${to.x},${to.y}`;
   $: midX = (from.x + to.x) / 2;
   $: midY = (from.y + to.y) / 2;
+  $: isDivergent = data?.divergent === true;
+  $: divergentTooltip = isDivergent
+    ? `Declared in lab.json but not present in kernel. Last checked ${data?.last_checked ?? 'unknown'}.`
+    : '';
 </script>
 
 <path
@@ -120,5 +127,20 @@
     class="svelte-flow__edge-label"
   >
     {label}
+  </text>
+{/if}
+
+{#if isDivergent}
+  <text
+    class="svelte-flow__edge-divergent-glyph"
+    data-testid="divergent-glyph"
+    x={midX}
+    y={midY}
+    text-anchor="middle"
+    dominant-baseline="middle"
+    style="fill: #f87171; font-size: 14px; font-weight: bold; pointer-events: all;"
+  >
+    {'⚠'}
+    <title>{divergentTooltip}</title>
   </text>
 {/if}

--- a/frontend/src/lib/components/canvas/TopologyCanvas.svelte
+++ b/frontend/src/lib/components/canvas/TopologyCanvas.svelte
@@ -485,7 +485,24 @@
   }
 
   function buildFlowEdges(): Edge[] {
-    return deriveEdges(localLinks, localDefaults);
+    // US-404: enrich each Link with the latest ``link_divergent`` state
+    // captured by the WS store so canvasEdges can render the red overlay
+    // + warning glyph.  When the store is unavailable (SSR, pre-mount)
+    // links pass through unchanged.
+    const divergentSnapshot = labWsStores ? get(labWsStores.divergentLinks) : {};
+    const enrichedLinks =
+      Object.keys(divergentSnapshot).length === 0
+        ? localLinks
+        : localLinks.map((link) => {
+            const state = divergentSnapshot[link.id];
+            if (!state) return link;
+            return {
+              ...link,
+              divergent: true,
+              last_checked: state.last_checked,
+            };
+          });
+    return deriveEdges(enrichedLinks, localDefaults);
   }
 
   $: {
@@ -1074,6 +1091,7 @@
   // ── lifecycle: WS hub flush hook & cleanup ───────────────────────────────
   let wsClient: WsClient | null = null;
   let labWsStores: LabWsStores | null = null;
+  let divergentLinksUnsub: (() => void) | null = null;
 
   onMount(() => {
     if (typeof window !== 'undefined') {
@@ -1089,6 +1107,19 @@
       client.on('lab_topology', (_msg: WsMessage) => {
         void layoutDebouncer.flush();
       });
+      // US-404: re-publish edges whenever a ``link_divergent`` event lands
+      // so the canvas repaints the affected edge with the red overlay +
+      // warning glyph.  Skip the priming first emission (Svelte stores fire
+      // synchronously on subscribe) since publishFlowState already runs via
+      // the reactive $: block above.
+      let primed = false;
+      divergentLinksUnsub = labWsStores.divergentLinks.subscribe(() => {
+        if (!primed) {
+          primed = true;
+          return;
+        }
+        publishFlowState();
+      });
       if (import.meta.env.DEV) {
         (window as unknown as { __novaWsClient?: WsClient }).__novaWsClient = client;
       }
@@ -1102,6 +1133,10 @@
         window.removeEventListener('keydown', handleWindowKeyDown);
       }
       void layoutDebouncer.flush();
+      if (divergentLinksUnsub) {
+        divergentLinksUnsub();
+        divergentLinksUnsub = null;
+      }
       if (wsClient) {
         wsClient.close();
         if (typeof window !== 'undefined' && import.meta.env.DEV) {

--- a/frontend/src/lib/services/canvasEdges.ts
+++ b/frontend/src/lib/services/canvasEdges.ts
@@ -87,6 +87,17 @@ export function deriveEdges(
     const strokeWidth = Number.isFinite(widthValue) && widthValue > 0 ? widthValue : 1;
     const strokeColor = link.color && link.color.length > 0 ? link.color : '#9ca3af';
 
+    // US-404: declared-but-not-discovered overlay (red dashed, glyph at midpoint).
+    // US-403: discovered-but-not-declared overlay (amber dashed).
+    // ``divergent`` takes precedence over ``discovered`` when both are set —
+    // a link cannot simultaneously be missing AND extra in the kernel.
+    let edgeStyle = `stroke: ${strokeColor}; stroke-width: ${strokeWidth}px;`;
+    if (link.divergent === true) {
+      edgeStyle = 'stroke: #f87171; stroke-dasharray: 2 2; opacity: 0.7;';
+    } else if (link.discovered === true) {
+      edgeStyle = 'stroke: #fbbf24; stroke-dasharray: 6 4;';
+    }
+
     const edge: Edge = {
       id: `link:${link.id}`,
       source: `node${fromNodeId}`,
@@ -96,7 +107,7 @@ export function deriveEdges(
       type: 'link',
       animated: false,
       label: link.label && link.label.length > 0 ? link.label : undefined,
-      style: `stroke: ${strokeColor}; stroke-width: ${strokeWidth}px;`,
+      style: edgeStyle,
       labelStyle: 'fill: #d1d5db; font-size: 10px; font-family: var(--font-mono);',
       data: {
         style_override: link.style_override ?? null,
@@ -104,6 +115,9 @@ export function deriveEdges(
         label: link.label ?? '',
         color: link.color ?? '',
         width: link.width ?? '1',
+        discovered: link.discovered === true,
+        divergent: link.divergent === true,
+        last_checked: link.last_checked ?? null,
       },
     };
 

--- a/frontend/src/lib/stores/labWs.ts
+++ b/frontend/src/lib/stores/labWs.ts
@@ -2,16 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * labWs — US-073. Svelte stores derived from a {@link WsClient}, tracking
- * granular live state surfaced via WS events:
+ * labWs — US-073 / US-404. Svelte stores derived from a {@link WsClient},
+ * tracking granular live state surfaced via WS events:
  *
- *  - ``liveMacs``     keyed by ``${nodeId}:${interfaceIndex}`` from
- *                      ``interface_live_mac`` events.
- *  - ``linkStates``   keyed by ``link_id`` (numeric) from ``link_state`` events.
- *  - ``nodeStates``   keyed by ``node_id`` (numeric) from ``node_state`` events.
- *  - ``connected``    reflects ``client.isOpen``; updated on every event.
+ *  - ``liveMacs``        keyed by ``${nodeId}:${interfaceIndex}`` from
+ *                         ``interface_live_mac`` events.
+ *  - ``linkStates``      keyed by ``link_id`` (numeric) from ``link_state``
+ *                         events.
+ *  - ``nodeStates``      keyed by ``node_id`` (numeric) from ``node_state``
+ *                         events.
+ *  - ``divergentLinks``  keyed by ``link_id`` (string) from US-404
+ *                         ``link_divergent`` events; values capture the
+ *                         ``last_checked`` timestamp + ``reason`` so the
+ *                         canvas can surface a tooltip on hover.
+ *  - ``connected``       reflects ``client.isOpen``; updated on every event.
  *
- * On ``lab_topology`` snapshots all three derived stores are cleared — the
+ * On ``lab_topology`` snapshots all derived stores are cleared — the
  * snapshot resets the world; subsequent granular events repopulate.
  */
 
@@ -20,10 +26,16 @@ import { readable, writable, type Readable } from 'svelte/store';
 import type { WsClient, WsMessage } from '$lib/services/wsClient';
 import type { LiveMacState } from '$lib/types';
 
+export interface DivergentLinkState {
+  last_checked: string;
+  reason: string;
+}
+
 export type LabWsStores = {
   liveMacs: Readable<Record<string, LiveMacState>>;
   linkStates: Readable<Record<number, string>>;
   nodeStates: Readable<Record<number, string>>;
+  divergentLinks: Readable<Record<string, DivergentLinkState>>;
   connected: Readable<boolean>;
 };
 
@@ -46,6 +58,13 @@ interface NodeStatePayload {
   state: string;
 }
 
+interface LinkDivergentPayload {
+  link_id: string;
+  lab_id: string;
+  reason: string;
+  last_checked: string;
+}
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -54,6 +73,7 @@ export function createLabWsStores(client: WsClient): LabWsStores {
   const liveMacs = writable<Record<string, LiveMacState>>({});
   const linkStates = writable<Record<number, string>>({});
   const nodeStates = writable<Record<number, string>>({});
+  const divergentLinks = writable<Record<string, DivergentLinkState>>({});
 
   const connected = readable<boolean>(client.isOpen, (set) => {
     const sync = () => set(client.isOpen);
@@ -99,16 +119,30 @@ export function createLabWsStores(client: WsClient): LabWsStores {
     nodeStates.update((current) => ({ ...current, [payload.node_id as number]: payload.state as string }));
   });
 
+  client.on('link_divergent', (msg: WsMessage) => {
+    if (!isObject(msg.payload)) return;
+    const payload = msg.payload as Partial<LinkDivergentPayload>;
+    if (typeof payload.link_id !== 'string' || payload.link_id.length === 0) return;
+    if (typeof payload.last_checked !== 'string') return;
+    const next: DivergentLinkState = {
+      last_checked: payload.last_checked,
+      reason: typeof payload.reason === 'string' ? payload.reason : '',
+    };
+    divergentLinks.update((current) => ({ ...current, [payload.link_id as string]: next }));
+  });
+
   client.on('lab_topology', () => {
     liveMacs.set({});
     linkStates.set({});
     nodeStates.set({});
+    divergentLinks.set({});
   });
 
   return {
     liveMacs: { subscribe: liveMacs.subscribe },
     linkStates: { subscribe: linkStates.subscribe },
     nodeStates: { subscribe: nodeStates.subscribe },
+    divergentLinks: { subscribe: divergentLinks.subscribe },
     connected,
   };
 }

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -127,6 +127,19 @@ export interface Link {
   color?: string;
   width?: string;
   metrics?: LinkMetrics;
+  /**
+   * US-403: kernel reports a veth/TAP for this link but it is not (yet)
+   * declared in ``links[]``.  Rendered with an amber dashed overlay.
+   */
+  discovered?: boolean;
+  /**
+   * US-404: declared in ``links[]`` but the kernel has no matching
+   * veth/TAP.  Rendered with a red dashed overlay + warning glyph at the
+   * edge midpoint.  Tooltip surfaces the ``last_checked`` timestamp.
+   */
+  divergent?: boolean;
+  /** US-404: ISO-8601 timestamp from the latest ``link_divergent`` event. */
+  last_checked?: string;
 }
 
 export interface Network {

--- a/frontend/tests/TopologyCanvas.test.ts
+++ b/frontend/tests/TopologyCanvas.test.ts
@@ -68,6 +68,10 @@ vi.mock('$lib/services/wsClient', () => ({
 vi.mock('$lib/stores/labWs', () => ({
   createLabWsStores: () => ({
     liveMacs: writable({}),
+    linkStates: writable({}),
+    nodeStates: writable({}),
+    divergentLinks: writable({}),
+    connected: writable(false),
   }),
 }));
 

--- a/frontend/tests/canvasEdges.test.ts
+++ b/frontend/tests/canvasEdges.test.ts
@@ -129,6 +129,96 @@ describe('canvasEdges.deriveEdges', () => {
   });
 });
 
+describe('canvasEdges.deriveEdges — overlay branches (US-403 / US-404)', () => {
+  const DIVERGENT_LINK: Link = {
+    id: 'lnk_divergent',
+    from: { node_id: 1, interface_index: 0 },
+    to: { network_id: 1 },
+    style_override: null,
+    label: '',
+    color: '',
+    width: '1',
+    divergent: true,
+    last_checked: '2026-04-28T12:34:56+00:00',
+  };
+
+  const DISCOVERED_LINK: Link = {
+    id: 'lnk_discovered',
+    from: { node_id: 2, interface_index: 0 },
+    to: { network_id: 1 },
+    style_override: null,
+    label: '',
+    color: '',
+    width: '1',
+    discovered: true,
+  };
+
+  it('renders divergent: true with the red dashed overlay', () => {
+    const edges = deriveEdges([DIVERGENT_LINK], { link_style: 'orthogonal' });
+    expect(edges).toHaveLength(1);
+    const edge = edges[0];
+    expect(edge.style).toContain('stroke: #f87171');
+    expect(edge.style).toContain('stroke-dasharray: 2 2');
+    expect(edge.style).toContain('opacity: 0.7');
+    const data = edge.data as { divergent?: boolean; last_checked?: string | null };
+    expect(data.divergent).toBe(true);
+    expect(data.last_checked).toBe('2026-04-28T12:34:56+00:00');
+  });
+
+  it('renders discovered: true with the amber dashed overlay (US-403 contract)', () => {
+    const edges = deriveEdges([DISCOVERED_LINK], { link_style: 'orthogonal' });
+    expect(edges).toHaveLength(1);
+    const edge = edges[0];
+    expect(edge.style).toContain('stroke: #fbbf24');
+    expect(edge.style).toContain('stroke-dasharray: 6 4');
+    const data = edge.data as { discovered?: boolean; divergent?: boolean };
+    expect(data.discovered).toBe(true);
+    expect(data.divergent).toBe(false);
+  });
+
+  it('renders divergent and discovered with visually distinct strokes', () => {
+    const edges = deriveEdges(
+      [DIVERGENT_LINK, DISCOVERED_LINK],
+      { link_style: 'orthogonal' }
+    );
+    expect(edges).toHaveLength(2);
+    expect(edges[0].style).not.toEqual(edges[1].style);
+    // Divergent uses red (#f87171); discovered uses amber (#fbbf24).
+    expect(edges[0].style).toContain('#f87171');
+    expect(edges[1].style).toContain('#fbbf24');
+    // Dasharray patterns are distinct so the two states are visually
+    // discriminable even on greyscale displays.
+    expect(edges[0].style).toContain('stroke-dasharray: 2 2');
+    expect(edges[1].style).toContain('stroke-dasharray: 6 4');
+  });
+
+  it('divergent precedence: divergent + discovered both true → divergent wins', () => {
+    const link: Link = {
+      ...DIVERGENT_LINK,
+      id: 'lnk_both',
+      discovered: true,
+      divergent: true,
+    };
+    const edges = deriveEdges([link], { link_style: 'orthogonal' });
+    expect(edges[0].style).toContain('#f87171');
+    expect(edges[0].style).not.toContain('#fbbf24');
+  });
+
+  it('plain links (no divergent / no discovered) keep the default stroke', () => {
+    const edges = deriveEdges(ALPINE_DEMO_LINKS, { link_style: 'orthogonal' });
+    for (const edge of edges) {
+      expect(edge.style).toContain('stroke: #9ca3af');
+      expect(edge.style).not.toContain('stroke-dasharray');
+    }
+  });
+
+  it('threads last_checked through edge.data so the LinkEdge tooltip can read it', () => {
+    const edges = deriveEdges([DIVERGENT_LINK], { link_style: 'orthogonal' });
+    const data = edges[0].data as { last_checked?: string | null };
+    expect(data.last_checked).toBe('2026-04-28T12:34:56+00:00');
+  });
+});
+
 describe('canvasEdges.pickNetworkSide', () => {
   it('returns right when no positions are provided', () => {
     expect(pickNetworkSide(1)).toBe('network:1:right');


### PR DESCRIPTION
Closes #107
Part of #80

## Summary
- Backend `_discovery_loop` now also walks `links[]` after the kernel-side bridge scan and publishes a `link_divergent` WS event for declared links whose veth-host / TAP host-side names are absent from every bridge member of the lab. Lease-respect via `transition_lease.is_leased(...)` (US-204b) — leased links (in-flight hot-plug) are NOT flagged. Payload: `{link_id, lab_id, reason, last_checked}` (ISO-8601, UTC).
- Frontend `canvasEdges.ts` adds an additive branch for `divergent: true` (`stroke: #f87171; stroke-dasharray: 2 2; opacity: 0.7;`). `LinkEdge.svelte` renders a ⚠ glyph at the edge midpoint with a `<title>` tooltip "Declared in lab.json but not present in kernel. Last checked {timestamp}.".
- `labWs.ts` subscribes to `link_divergent`, stores state keyed by `link_id`, and `TopologyCanvas.svelte` re-publishes flow edges on store change so the affected edge repaints in real time. `lab_topology` snapshots clear the divergent store consistent with existing reset semantics.

## Visual contract
- **Divergent edge** (US-404): red `#f87171` stroke, 2-2 dasharray, 0.7 opacity, with a ⚠ glyph at the midpoint. Hovering the glyph shows the `last_checked` ISO-8601 timestamp tooltip.
- **Discovered edge** (US-403, additive): amber `#fbbf24` stroke, 6-4 dasharray. (Included to provide the live regression fixture the plan calls for.)
- Plain edges keep the default `#9ca3af` stroke. When both flags somehow coincide, `divergent` wins (a link cannot simultaneously be missing AND extra in the kernel).

## US-403 overlap notes
- This PR also touches `frontend/src/lib/services/canvasEdges.ts` and adds the discovered branch additively (US-403 needs the same file). Whichever PR lands second will be a trivial rebase on the styling switch.
- `frontend/tests/canvasEdges.test.ts` is shared per the plan — extended here to cover both `discovered`-only and `divergent`-only fixtures, asserting visually distinct rendering.

## Verification
```
$ cd backend && python -m pytest tests/test_discovery_loop.py -v
... 10 passed in 0.30s

$ cd backend && python -m pytest --deselect tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error -q
... 636 passed, 1 skipped, 1 deselected, 12 warnings in 21.78s

$ cd frontend && npm run check
... 0 errors, 0 warnings, 0 files_with_problems

$ cd frontend && npx vitest run
... Test Files  19 passed (19)
... Tests  141 passed (141)
```

HF4 pre-existing PR-#127 failure noted.

## Test plan
- [x] Backend: `link_divergent` emitted when declared veth missing from kernel
- [x] Backend: not emitted when veth IS present
- [x] Backend: not emitted when TAP IS present (QEMU path)
- [x] Backend: not emitted when `transition_lease.is_leased` returns true keyed by `link_id`
- [x] Backend: not emitted when leased keyed by iface name (forward-compatible)
- [x] Frontend: divergent fixture renders red dashed style with `last_checked` in `edge.data`
- [x] Frontend: discovered fixture renders amber dashed style (US-403 regression seed)
- [x] Frontend: divergent + discovered produce visually distinct strokes
- [x] Frontend: divergent precedence over discovered when both true
- [x] Frontend: plain links unaffected by overlay branches
- [x] Frontend: `svelte-check` clean
- [x] Frontend: full vitest suite green (141/141)