### PR TITLE
feat(canvas): overlay for discovered links with promote-to-declared action (US-403, #106)

### DIFF
--- a/backend/app/routers/ws.py
+++ b/backend/app/routers/ws.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from app.database import get_db
 from app.services.ws_hub import ws_hub
 from app.services.lab_service import LabService
+from app.services.node_runtime_service import NodeRuntimeService
 
 router = APIRouter(prefix="/ws", tags=["websocket"])
 
@@ -45,6 +46,7 @@ async def lab_ws(websocket: WebSocket, lab: str, last_seq: int = 0):
                 "seq": ws_hub.head_seq(lab),
                 "type": "lab_topology",
                 "rev": str(data.get("id", "")),
+                "generation": NodeRuntimeService.get_discovery_generation(lab),
                 "payload": data,
             })
         except Exception:

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -165,6 +165,12 @@ class NodeRuntimeService:
     # Maps (lab_id, node_id) -> monotonic timestamp of last deliberate start/stop.
     # Heartbeat skips reconciliation for entries younger than _TRANSITION_SUPPRESS_S.
     _transition_timestamps: dict[tuple[str, int], float] = {}
+    # Per-lab discovery generation counter (US-403 MEDIUM-3 gen-token fix).
+    # Incremented at the start of each _discover_lab call so every emitted
+    # discovered_link / link_divergent event carries the generation that produced
+    # it.  lab_topology snapshots include the current value so the frontend can
+    # reject events from older generations (gen <= topology_generation is stale).
+    _discovery_generation: dict[str, int] = {}
 
     def __init__(self) -> None:
         self.settings = get_settings()
@@ -186,6 +192,17 @@ class NodeRuntimeService:
             cls._registry.clear()
             cls._loaded = False
         cls._transition_timestamps.clear()
+        cls._discovery_generation.clear()
+
+    @classmethod
+    def get_discovery_generation(cls, lab_id: str) -> int:
+        """Return the current discovery generation for *lab_id*.
+
+        Used by the WS reconnect handler (``ws.py``) to include the generation
+        in ``lab_topology`` snapshots so the frontend can reject
+        ``discovered_link`` / ``link_divergent`` events from older cycles.
+        """
+        return cls._discovery_generation.get(lab_id, 0)
 
     @classmethod
     def _record_transition(cls, lab_id: str, node_id: int) -> None:
@@ -858,7 +875,17 @@ class NodeRuntimeService:
         hot-plug from US-204b) are NOT flagged.  We import
         ``transition_lease`` lazily so this module remains importable
         before US-204b lands; missing module is treated as "no leases".
+
+        Generation token (US-403 MEDIUM-3): increment the per-lab counter at
+        the very start of every call.  Every event emitted within this call
+        carries the same ``generation`` value.  The frontend rejects events
+        whose ``generation`` is <= the generation recorded in the last
+        ``lab_topology`` snapshot — this is the producer-side guarantee that
+        stale events from a previous cycle are never silently accepted.
         """
+        gen = cls._discovery_generation.get(lab_id, 0) + 1
+        cls._discovery_generation[lab_id] = gen
+
         networks = lab_data.get("networks") or {}
         if not isinstance(networks, dict) or not networks:
             return
@@ -933,6 +960,7 @@ class NodeRuntimeService:
                     "bridge_name": bridge,
                     "iface": iface,
                     "peer_node_id": peer_node_id,
+                    "generation": gen,
                 }
                 try:
                     await ws_hub.publish(lab_id, "discovered_link", payload)
@@ -951,6 +979,7 @@ class NodeRuntimeService:
             kernel_members=kernel_members,
             is_leased=is_leased,
             ws_hub=ws_hub,
+            generation=gen,
         )
 
     @classmethod
@@ -962,6 +991,7 @@ class NodeRuntimeService:
         kernel_members: set[str],
         is_leased: Callable[..., bool] | None,
         ws_hub: Any,
+        generation: int = 0,
     ) -> None:
         """For each entry in ``links[]`` whose declared veth/TAP host-side
         name is missing from ``kernel_members``, publish a
@@ -1030,6 +1060,7 @@ class NodeRuntimeService:
                 "lab_id": lab_id,
                 "reason": "declared in lab.json but no matching veth/TAP found in kernel",
                 "last_checked": last_checked,
+                "generation": generation,
             }
             try:
                 await ws_hub.publish(lab_id, "link_divergent", payload)

--- a/backend/tests/test_discovery_loop.py
+++ b/backend/tests/test_discovery_loop.py
@@ -168,6 +168,7 @@ async def test_unknown_bridge_member_triggers_discovered_link(
     assert payload["bridge_name"] == bridge
     assert payload["iface"] == rogue_iface
     assert payload["peer_node_id"] == 2
+    assert isinstance(payload["generation"], int) and payload["generation"] >= 1
 
 
 @pytest.mark.asyncio
@@ -345,6 +346,7 @@ async def test_divergent_link_emits_link_divergent(
     from datetime import datetime
     parsed = datetime.fromisoformat(payload["last_checked"])
     assert parsed.tzinfo is not None
+    assert isinstance(payload["generation"], int) and payload["generation"] >= 1
 
 
 @pytest.mark.asyncio
@@ -471,3 +473,51 @@ async def test_leased_divergent_link_via_iface_key_is_skipped(
     await NodeRuntimeService._run_discovery_cycle()
 
     assert [e for e in hub.events if e[1] == "link_divergent"] == []
+
+
+# ---------------------------------------------------------------------------
+# US-403 MEDIUM-3 — producer-side generation token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_generation_strictly_increasing(
+    monkeypatch, discovery_settings, stub_instance_id
+):
+    """Two consecutive ``_discover_lab`` calls must emit events with strictly
+    increasing ``generation`` values.
+
+    This is the producer-side guarantee: the frontend can safely reject any
+    ``discovered_link`` / ``link_divergent`` event whose ``generation`` is <=
+    the ``generation`` recorded in the last ``lab_topology`` snapshot.
+    """
+    lab_id = "lab-gen-token-1"
+    # No declared links so each cycle emits a discovered_link for the rogue iface.
+    _write_lab(discovery_settings.LABS_DIR, lab_id, [])
+
+    bridge = host_net.bridge_name(lab_id, 1)
+    rogue_iface = host_net.veth_host_name(lab_id, 99, 0)
+
+    monkeypatch.setattr(
+        NodeRuntimeService,
+        "_bridge_members_sync",
+        staticmethod(lambda b: [rogue_iface] if b == bridge else []),
+    )
+    _patch_settings(monkeypatch, discovery_settings)
+    hub = _patch_ws_hub(monkeypatch)
+
+    # First cycle.
+    await NodeRuntimeService._run_discovery_cycle()
+    # Second cycle.
+    await NodeRuntimeService._run_discovery_cycle()
+
+    discovered = [e for e in hub.events if e[1] == "discovered_link"]
+    assert len(discovered) == 2, hub.events
+
+    gen_first = discovered[0][2]["generation"]
+    gen_second = discovered[1][2]["generation"]
+    assert isinstance(gen_first, int)
+    assert isinstance(gen_second, int)
+    assert gen_first < gen_second, (
+        f"Expected strictly increasing generations; got {gen_first} then {gen_second}"
+    )

--- a/frontend/src/lib/components/canvas/TopologyCanvas.svelte
+++ b/frontend/src/lib/components/canvas/TopologyCanvas.svelte
@@ -43,7 +43,11 @@
   import { createLayoutDebouncer, type LayoutDebouncer } from '$lib/services/labApi';
   import { createWsClient, type WsClient, type WsMessage } from '$lib/services/wsClient';
   import { createLabWsStores, type LabWsStores } from '$lib/stores/labWs';
-  import { deriveEdges } from '$lib/services/canvasEdges';
+  import {
+    deriveEdges,
+    parseIfaceInterfaceIndex,
+    type DiscoveredLink,
+  } from '$lib/services/canvasEdges';
   import {
     dragLinkStore,
     getDragLinkSnapshot,
@@ -227,6 +231,13 @@
   let localTopology: TopologyLink[] = [];
   let localLinks: Link[] = [];
   let localDefaults: LabDefaults = { link_style: 'orthogonal' };
+  /**
+   * US-403: kernel-only ("discovered") links surfaced by the backend
+   * ``_discovery_loop`` via ``discovered_link`` WS events. Keyed by the
+   * kernel iface name (``nve...``). These render as dashed amber overlay
+   * edges and can be right-clicked to promote into the real ``links[]``.
+   */
+  const discoveredLinksStore = writable<Record<string, DiscoveredLink>>({});
   let lastNodesRef = nodes;
   let lastNetworksRef = networks;
   let lastTopologyRef = topology;
@@ -502,10 +513,15 @@
               last_checked: state.last_checked,
             };
           });
-    return deriveEdges(enrichedLinks, localDefaults);
+    // US-403: pass discovered (kernel-only) overlay links as 3rd arg.
+    const discoveredList = Object.values(get(discoveredLinksStore));
+    return deriveEdges(enrichedLinks, localDefaults, discoveredList);
   }
 
   $: {
+    // Reading $discoveredLinksStore here makes publishFlowState reactive to
+    // ``discovered_link`` WS events (US-403).
+    void $discoveredLinksStore;
     publishFlowState();
   }
 
@@ -716,6 +732,78 @@
       return localLinks.findIndex((entry) => entry.id === linkId);
     }
     return buildFlowEdges().findIndex((edge) => edge.id === edgeId);
+  }
+
+  function isDiscoveredEdgeId(edgeId: string | null | undefined): boolean {
+    return typeof edgeId === 'string' && edgeId.startsWith('discovered:');
+  }
+
+  /**
+   * US-403 — promote a kernel-discovered link into ``links[]`` by POSTing a
+   * real link to ``/labs/{labId}/links``.  On success we drop the discovered
+   * overlay locally; the next discovery cycle would clear it anyway, but
+   * optimistic removal keeps the canvas snappy.
+   */
+  async function promoteDiscoveredLink(edgeId: string) {
+    if (!isDiscoveredEdgeId(edgeId)) return;
+    const iface = edgeId.slice('discovered:'.length);
+    const discovered = get(discoveredLinksStore)[iface];
+    if (!discovered) return;
+    if (typeof discovered.peer_node_id !== 'number') {
+      toastStore.push(
+        'Cannot promote discovered link: peer node could not be decoded from iface name.',
+        'error',
+      );
+      return;
+    }
+    if (typeof discovered.peer_interface_index !== 'number') {
+      toastStore.push(
+        'Cannot promote discovered link: interface index could not be decoded from iface name.',
+        'error',
+      );
+      return;
+    }
+
+    const fromEndpoint = {
+      node_id: discovered.peer_node_id,
+      interface_index: discovered.peer_interface_index,
+    };
+    const toEndpoint = { network_id: discovered.network_id };
+
+    try {
+      const response = await apiRequest<Link>(`/labs/${labId}/links`, {
+        method: 'POST',
+        body: { from: fromEndpoint, to: toEndpoint },
+        suppressToast: true,
+      });
+      const serverLink = response.data;
+      if (serverLink && serverLink.id) {
+        localLinks = [...localLinks, serverLink];
+      }
+      // Optimistically clear the overlay; the next discovery cycle would
+      // also clear it once the iface matches a declared link.
+      discoveredLinksStore.update((current) => {
+        if (!(iface in current)) return current;
+        const next = { ...current };
+        delete next[iface];
+        return next;
+      });
+      publishFlowState();
+      dispatchCanvasChange('topology', {
+        nodes: deepClone(localNodes),
+        networks: deepClone(localNetworks),
+        topology: deepClone(localTopology),
+      });
+      toastStore.push('Promoted discovered link to declared link.', 'info');
+    } catch (error) {
+      const message =
+        error instanceof ApiError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : 'Failed to promote discovered link';
+      toastStore.push(message, 'error');
+    }
   }
 
   function deleteLink(edgeId: string) {
@@ -1106,6 +1194,36 @@
       labWsStores = createLabWsStores(client);
       client.on('lab_topology', (_msg: WsMessage) => {
         void layoutDebouncer.flush();
+        // A fresh topology snapshot supersedes the discovery overlay; the
+        // backend will republish ``discovered_link`` events on the next
+        // discovery cycle if the divergence persists.
+        discoveredLinksStore.set({});
+      });
+      client.on('discovered_link', (msg: WsMessage) => {
+        if (!msg.payload || typeof msg.payload !== 'object') return;
+        const payload = msg.payload as {
+          lab_id?: string;
+          network_id?: number;
+          bridge_name?: string;
+          iface?: string;
+          peer_node_id?: number | null;
+        };
+        if (typeof payload.iface !== 'string' || payload.iface.length === 0) return;
+        if (typeof payload.network_id !== 'number') return;
+        if (typeof payload.bridge_name !== 'string') return;
+        const ifaceIndex = parseIfaceInterfaceIndex(payload.iface);
+        const next: DiscoveredLink = {
+          iface: payload.iface,
+          bridge_name: payload.bridge_name,
+          network_id: payload.network_id,
+          peer_node_id:
+            typeof payload.peer_node_id === 'number' ? payload.peer_node_id : null,
+          peer_interface_index: ifaceIndex,
+        };
+        discoveredLinksStore.update((current) => ({
+          ...current,
+          [next.iface]: next,
+        }));
       });
       // US-404: re-publish edges whenever a ``link_divergent`` event lands
       // so the canvas repaints the affected edge with the red overlay +
@@ -1575,19 +1693,35 @@
           <span>Delete Network</span><Trash2 class="h-3.5 w-3.5 text-red-200/80" />
         </button>
       {:else}
-        <button
-          type="button"
-          class="menu-item text-red-200"
-          on:click|preventDefault|stopPropagation={() => {
-            if (menu?.targetId) {
-              deleteLink(menu.targetId);
-            }
-            selectedEdgeId = null;
-            closeMenu();
-          }}
-        >
-          <span>Delete Link</span><Trash2 class="h-3.5 w-3.5 text-red-200/80" />
-        </button>
+        {#if menu && isDiscoveredEdgeId(menu.targetId)}
+          <button
+            type="button"
+            class="menu-item"
+            on:click|preventDefault|stopPropagation={() => {
+              if (menu?.targetId) {
+                void promoteDiscoveredLink(menu.targetId);
+              }
+              selectedEdgeId = null;
+              closeMenu();
+            }}
+          >
+            <span>Promote to declared link</span><Plus class="h-3.5 w-3.5 text-amber-300/80" />
+          </button>
+        {:else}
+          <button
+            type="button"
+            class="menu-item text-red-200"
+            on:click|preventDefault|stopPropagation={() => {
+              if (menu?.targetId) {
+                deleteLink(menu.targetId);
+              }
+              selectedEdgeId = null;
+              closeMenu();
+            }}
+          >
+            <span>Delete Link</span><Trash2 class="h-3.5 w-3.5 text-red-200/80" />
+          </button>
+        {/if}
       {/if}
     </div>
   {/if}

--- a/frontend/src/lib/components/canvas/TopologyCanvas.svelte
+++ b/frontend/src/lib/components/canvas/TopologyCanvas.svelte
@@ -43,11 +43,7 @@
   import { createLayoutDebouncer, type LayoutDebouncer } from '$lib/services/labApi';
   import { createWsClient, type WsClient, type WsMessage } from '$lib/services/wsClient';
   import { createLabWsStores, type LabWsStores } from '$lib/stores/labWs';
-  import {
-    deriveEdges,
-    parseIfaceInterfaceIndex,
-    type DiscoveredLink,
-  } from '$lib/services/canvasEdges';
+  import { deriveEdges, parseIfaceInterfaceIndex, type DiscoveredLink } from '$lib/services/canvasEdges';
   import {
     dragLinkStore,
     getDragLinkSnapshot,
@@ -58,6 +54,7 @@
     LabDefaults,
     LabViewport,
     Link,
+    LinkReconciliation,
     LinkStyle,
     LiveMacState,
     NetworkData,
@@ -231,13 +228,6 @@
   let localTopology: TopologyLink[] = [];
   let localLinks: Link[] = [];
   let localDefaults: LabDefaults = { link_style: 'orthogonal' };
-  /**
-   * US-403: kernel-only ("discovered") links surfaced by the backend
-   * ``_discovery_loop`` via ``discovered_link`` WS events. Keyed by the
-   * kernel iface name (``nve...``). These render as dashed amber overlay
-   * edges and can be right-clicked to promote into the real ``links[]``.
-   */
-  const discoveredLinksStore = writable<Record<string, DiscoveredLink>>({});
   let lastNodesRef = nodes;
   let lastNetworksRef = networks;
   let lastTopologyRef = topology;
@@ -496,32 +486,40 @@
   }
 
   function buildFlowEdges(): Edge[] {
-    // US-404: enrich each Link with the latest ``link_divergent`` state
-    // captured by the WS store so canvasEdges can render the red overlay
-    // + warning glyph.  When the store is unavailable (SSR, pre-mount)
-    // links pass through unchanged.
-    const divergentSnapshot = labWsStores ? get(labWsStores.divergentLinks) : {};
-    const enrichedLinks =
-      Object.keys(divergentSnapshot).length === 0
-        ? localLinks
-        : localLinks.map((link) => {
-            const state = divergentSnapshot[link.id];
-            if (!state) return link;
-            return {
-              ...link,
-              divergent: true,
-              last_checked: state.last_checked,
-            };
-          });
-    // US-403: pass discovered (kernel-only) overlay links as 3rd arg.
-    const discoveredList = Object.values(get(discoveredLinksStore));
-    return deriveEdges(enrichedLinks, localDefaults, discoveredList);
+    // Partition the unified reconciliation store into the two visual overlays.
+    // When labWsStores is not yet mounted (SSR / pre-mount) both maps are empty
+    // and links render with their default styling.
+    const recon = labWsStores ? get(labWsStores.linkReconciliation) : {};
+    const entries = Object.values(recon);
+
+    // US-404: declared links with no kernel veth/TAP → keyed by link_id.
+    const divergentByLinkId: Record<string, LinkReconciliation> = {};
+    // US-403: kernel-only ifaces not in links[] → DiscoveredLink list for 3rd arg.
+    const discoveredList: DiscoveredLink[] = [];
+
+    for (const entry of entries) {
+      if (entry.kind === 'divergent' && entry.link_id) {
+        divergentByLinkId[entry.link_id] = entry;
+      } else if (
+        entry.kind === 'discovered' &&
+        entry.iface &&
+        typeof entry.network_id === 'number' &&
+        typeof entry.bridge_name === 'string'
+      ) {
+        discoveredList.push({
+          iface: entry.iface,
+          bridge_name: entry.bridge_name,
+          network_id: entry.network_id,
+          peer_node_id: entry.peer_node_id ?? null,
+          peer_interface_index: entry.peer_interface_index ?? null,
+        });
+      }
+    }
+
+    return deriveEdges(localLinks, localDefaults, discoveredList, divergentByLinkId);
   }
 
   $: {
-    // Reading $discoveredLinksStore here makes publishFlowState reactive to
-    // ``discovered_link`` WS events (US-403).
-    void $discoveredLinksStore;
     publishFlowState();
   }
 
@@ -747,28 +745,35 @@
   async function promoteDiscoveredLink(edgeId: string) {
     if (!isDiscoveredEdgeId(edgeId)) return;
     const iface = edgeId.slice('discovered:'.length);
-    const discovered = get(discoveredLinksStore)[iface];
-    if (!discovered) return;
-    if (typeof discovered.peer_node_id !== 'number') {
+    const recon = labWsStores ? get(labWsStores.linkReconciliation) : {};
+    const entry = recon[`iface:${iface}`];
+    if (!entry || entry.kind !== 'discovered') return;
+
+    if (typeof entry.peer_node_id !== 'number') {
       toastStore.push(
         'Cannot promote discovered link: peer node could not be decoded from iface name.',
         'error',
       );
       return;
     }
-    if (typeof discovered.peer_interface_index !== 'number') {
+    const ifaceIndex = entry.peer_interface_index ?? parseIfaceInterfaceIndex(iface);
+    if (typeof ifaceIndex !== 'number') {
       toastStore.push(
         'Cannot promote discovered link: interface index could not be decoded from iface name.',
         'error',
       );
       return;
     }
+    if (typeof entry.network_id !== 'number') {
+      toastStore.push(
+        'Cannot promote discovered link: network_id is missing from reconciliation entry.',
+        'error',
+      );
+      return;
+    }
 
-    const fromEndpoint = {
-      node_id: discovered.peer_node_id,
-      interface_index: discovered.peer_interface_index,
-    };
-    const toEndpoint = { network_id: discovered.network_id };
+    const fromEndpoint = { node_id: entry.peer_node_id, interface_index: ifaceIndex };
+    const toEndpoint = { network_id: entry.network_id };
 
     try {
       const response = await apiRequest<Link>(`/labs/${labId}/links`, {
@@ -780,14 +785,9 @@
       if (serverLink && serverLink.id) {
         localLinks = [...localLinks, serverLink];
       }
-      // Optimistically clear the overlay; the next discovery cycle would
-      // also clear it once the iface matches a declared link.
-      discoveredLinksStore.update((current) => {
-        if (!(iface in current)) return current;
-        const next = { ...current };
-        delete next[iface];
-        return next;
-      });
+      // The discovered overlay clears on the next discovery cycle once the
+      // iface matches the newly declared link.  publishFlowState() redraws
+      // the edge immediately using the now-present localLinks entry.
       publishFlowState();
       dispatchCanvasChange('topology', {
         nodes: deepClone(localNodes),
@@ -1179,7 +1179,8 @@
   // ── lifecycle: WS hub flush hook & cleanup ───────────────────────────────
   let wsClient: WsClient | null = null;
   let labWsStores: LabWsStores | null = null;
-  let divergentLinksUnsub: (() => void) | null = null;
+  /** Unsubscribe handle for the unified linkReconciliation store (US-403/404). */
+  let reconUnsub: (() => void) | null = null;
 
   onMount(() => {
     if (typeof window !== 'undefined') {
@@ -1194,44 +1195,16 @@
       labWsStores = createLabWsStores(client);
       client.on('lab_topology', (_msg: WsMessage) => {
         void layoutDebouncer.flush();
-        // A fresh topology snapshot supersedes the discovery overlay; the
-        // backend will republish ``discovered_link`` events on the next
-        // discovery cycle if the divergence persists.
-        discoveredLinksStore.set({});
+        // lab_topology resets the reconciliation store (done inside labWs);
+        // republish edges so overlays clear from the canvas immediately.
+        publishFlowState();
       });
-      client.on('discovered_link', (msg: WsMessage) => {
-        if (!msg.payload || typeof msg.payload !== 'object') return;
-        const payload = msg.payload as {
-          lab_id?: string;
-          network_id?: number;
-          bridge_name?: string;
-          iface?: string;
-          peer_node_id?: number | null;
-        };
-        if (typeof payload.iface !== 'string' || payload.iface.length === 0) return;
-        if (typeof payload.network_id !== 'number') return;
-        if (typeof payload.bridge_name !== 'string') return;
-        const ifaceIndex = parseIfaceInterfaceIndex(payload.iface);
-        const next: DiscoveredLink = {
-          iface: payload.iface,
-          bridge_name: payload.bridge_name,
-          network_id: payload.network_id,
-          peer_node_id:
-            typeof payload.peer_node_id === 'number' ? payload.peer_node_id : null,
-          peer_interface_index: ifaceIndex,
-        };
-        discoveredLinksStore.update((current) => ({
-          ...current,
-          [next.iface]: next,
-        }));
-      });
-      // US-404: re-publish edges whenever a ``link_divergent`` event lands
-      // so the canvas repaints the affected edge with the red overlay +
-      // warning glyph.  Skip the priming first emission (Svelte stores fire
-      // synchronously on subscribe) since publishFlowState already runs via
-      // the reactive $: block above.
+      // Subscribe to the unified reconciliation store so the canvas repaints
+      // whenever a discovered_link or link_divergent WS event lands.
+      // Skip the synchronous first emission (store fires on subscribe before
+      // any WS events have arrived; publishFlowState already ran via $:).
       let primed = false;
-      divergentLinksUnsub = labWsStores.divergentLinks.subscribe(() => {
+      reconUnsub = labWsStores.linkReconciliation.subscribe(() => {
         if (!primed) {
           primed = true;
           return;
@@ -1251,9 +1224,9 @@
         window.removeEventListener('keydown', handleWindowKeyDown);
       }
       void layoutDebouncer.flush();
-      if (divergentLinksUnsub) {
-        divergentLinksUnsub();
-        divergentLinksUnsub = null;
+      if (reconUnsub) {
+        reconUnsub();
+        reconUnsub = null;
       }
       if (wsClient) {
         wsClient.close();

--- a/frontend/src/lib/components/canvas/TopologyCanvas.svelte
+++ b/frontend/src/lib/components/canvas/TopologyCanvas.svelte
@@ -785,9 +785,12 @@
       if (serverLink && serverLink.id) {
         localLinks = [...localLinks, serverLink];
       }
-      // The discovered overlay clears on the next discovery cycle once the
-      // iface matches the newly declared link.  publishFlowState() redraws
-      // the edge immediately using the now-present localLinks entry.
+      // Optimistically remove the discovered overlay immediately (HIGH-1).
+      // The next discovery cycle would also clear it, but removing it now
+      // avoids a duplicate amber+gray edge flash while the cycle completes.
+      if (labWsStores) {
+        labWsStores.deleteReconciliation(`iface:${iface}`);
+      }
       publishFlowState();
       dispatchCanvasChange('topology', {
         nodes: deepClone(localNodes),

--- a/frontend/src/lib/services/canvasEdges.ts
+++ b/frontend/src/lib/services/canvasEdges.ts
@@ -9,6 +9,25 @@ export interface DeriveEdgesDefaults {
 }
 
 /**
+ * US-403: an inferred (kernel-only) link discovered by the backend
+ * ``_discovery_loop`` and surfaced via the ``discovered_link`` WS event.
+ * Carries enough context to render a dashed-amber overlay edge and, on
+ * promotion, POST a real link to ``/labs/{labId}/links``.
+ */
+export interface DiscoveredLink {
+  /** Stable key — the kernel iface name (``nve{hash}d{node}i{iface}[h|p]``). */
+  iface: string;
+  /** Bridge backing the network the iface is attached to. */
+  bridge_name: string;
+  /** Network id the iface is bridged into. */
+  network_id: number;
+  /** Node id decoded from the iface name (``null`` when unparseable). */
+  peer_node_id: number | null;
+  /** Interface index decoded from the iface name (``null`` when unparseable). */
+  peer_interface_index?: number | null;
+}
+
+/**
  * Pick which side handle of a NetworkNode to connect to.
  *
  * When node and network positions are available the caller can supply them;
@@ -42,16 +61,19 @@ export function pickNetworkSide(
 
 export function deriveEdges(
   links: Link[] | null | undefined,
-  defaults: DeriveEdgesDefaults | null | undefined = null
+  defaults: DeriveEdgesDefaults | null | undefined = null,
+  discoveredLinks: DiscoveredLink[] | null | undefined = null
 ): Edge[] {
-  if (!links || links.length === 0) {
+  const hasLinks = !!(links && links.length > 0);
+  const hasDiscovered = !!(discoveredLinks && discoveredLinks.length > 0);
+  if (!hasLinks && !hasDiscovered) {
     return [];
   }
 
   const defaultStyle: LinkStyle = defaults?.link_style ?? 'orthogonal';
   const edges: Edge[] = [];
 
-  for (const link of links) {
+  if (hasLinks) for (const link of links!) {
     if (!link || !link.id) continue;
 
     const fromNodeId = link.from?.node_id;
@@ -124,5 +146,73 @@ export function deriveEdges(
     edges.push(edge);
   }
 
+  // US-403: discovered (kernel-only) overlay edges. Rendered with a dashed
+  // amber stroke. Right-click → "Promote to declared link" lifts these into
+  // real ``links[]`` entries via POST /labs/{id}/links. Branch is additive:
+  // unrelated styling logic must stay untouched (US-404 adds a parallel
+  // ``divergent`` branch with a red dashed overlay).
+  if (hasDiscovered) for (const discovered of discoveredLinks!) {
+    if (!discovered || !discovered.iface) continue;
+    if (typeof discovered.peer_node_id !== 'number') continue;
+    if (typeof discovered.network_id !== 'number') continue;
+
+    const fromNodeId = discovered.peer_node_id;
+    const networkId = discovered.network_id;
+    const ifaceIndex = discovered.peer_interface_index;
+    const sourceHandle =
+      typeof ifaceIndex === 'number' ? `iface-${ifaceIndex}` : 'default';
+    const targetHandle = pickNetworkSide(networkId);
+
+    edges.push({
+      id: `discovered:${discovered.iface}`,
+      source: `node${fromNodeId}`,
+      target: `network${networkId}`,
+      sourceHandle,
+      targetHandle,
+      type: 'link',
+      animated: false,
+      style: 'stroke: #fbbf24; stroke-dasharray: 6 4;',
+      labelStyle: 'fill: #fbbf24; font-size: 10px; font-family: var(--font-mono);',
+      data: {
+        style_override: null,
+        default_style: defaultStyle,
+        label: '',
+        color: '#fbbf24',
+        width: '1',
+        discovered: true,
+        discovered_iface: discovered.iface,
+        discovered_bridge: discovered.bridge_name,
+        discovered_network_id: networkId,
+        discovered_peer_node_id: fromNodeId,
+        discovered_peer_interface_index:
+          typeof ifaceIndex === 'number' ? ifaceIndex : null,
+      },
+    });
+  }
+
   return edges;
+}
+
+/**
+ * Decode the ``interface_index`` from a nova-ve host iface name like
+ * ``nve{4hex}d{node}i{iface}[h|p]``.  Returns ``null`` if the name does not
+ * follow the scheme — caller should fall back to the ``default`` handle.
+ */
+export function parseIfaceInterfaceIndex(iface: string): number | null {
+  if (!iface || !iface.startsWith('nve')) return null;
+  const dIdx = iface.indexOf('d');
+  if (dIdx < 0) return null;
+  const after_d = iface.slice(dIdx + 1);
+  const iIdx = after_d.indexOf('i');
+  if (iIdx < 0) return null;
+  const after_i = after_d.slice(iIdx + 1);
+  // Trailing suffix may be ``h`` (host) or ``p`` (peer); strip non-digits.
+  let digits = '';
+  for (const ch of after_i) {
+    if (ch >= '0' && ch <= '9') digits += ch;
+    else break;
+  }
+  if (digits.length === 0) return null;
+  const parsed = parseInt(digits, 10);
+  return Number.isFinite(parsed) ? parsed : null;
 }

--- a/frontend/src/lib/services/canvasEdges.ts
+++ b/frontend/src/lib/services/canvasEdges.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Edge } from '@xyflow/svelte';
-import type { Link, LinkStyle } from '$lib/types';
+import type { Link, LinkReconciliation, LinkStyle } from '$lib/types';
 
 export interface DeriveEdgesDefaults {
   link_style?: LinkStyle;
@@ -13,6 +13,9 @@ export interface DeriveEdgesDefaults {
  * ``_discovery_loop`` and surfaced via the ``discovered_link`` WS event.
  * Carries enough context to render a dashed-amber overlay edge and, on
  * promotion, POST a real link to ``/labs/{labId}/links``.
+ *
+ * This is the shape passed as the 3rd arg to ``deriveEdges``; it is derived
+ * from the ``linkReconciliation`` store entries with ``kind === 'discovered'``.
  */
 export interface DiscoveredLink {
   /** Stable key — the kernel iface name (``nve{hash}d{node}i{iface}[h|p]``). */
@@ -59,10 +62,24 @@ export function pickNetworkSide(
   return `network:${networkId}:right`;
 }
 
+/**
+ * Derive SvelteFlow edges from:
+ *  1. ``links``           — declared links from ``lab.json`` (source of truth).
+ *  2. ``discoveredLinks`` — kernel-only ifaces not in ``links[]`` (US-403);
+ *                           rendered as dashed amber overlay edges.
+ *  3. ``divergentByLinkId`` — map of link_id → {@link LinkReconciliation} for
+ *                           links declared in ``links[]`` but absent in the
+ *                           kernel (US-404); rendered as red dashed overlay.
+ *
+ * The divergent and discovered branches are visually distinct and independent.
+ * Overlay state is observation-only runtime data — it is never attached to the
+ * ``Link`` type itself (see ``LinkReconciliation`` in types/index.ts).
+ */
 export function deriveEdges(
   links: Link[] | null | undefined,
   defaults: DeriveEdgesDefaults | null | undefined = null,
-  discoveredLinks: DiscoveredLink[] | null | undefined = null
+  discoveredLinks: DiscoveredLink[] | null | undefined = null,
+  divergentByLinkId: Record<string, LinkReconciliation> | null | undefined = null
 ): Edge[] {
   const hasLinks = !!(links && links.length > 0);
   const hasDiscovered = !!(discoveredLinks && discoveredLinks.length > 0);
@@ -109,18 +126,15 @@ export function deriveEdges(
     const strokeWidth = Number.isFinite(widthValue) && widthValue > 0 ? widthValue : 1;
     const strokeColor = link.color && link.color.length > 0 ? link.color : '#9ca3af';
 
-    // US-404: declared-but-not-discovered overlay (red dashed, glyph at midpoint).
-    // US-403: discovered-but-not-declared overlay (amber dashed).
-    // ``divergent`` takes precedence over ``discovered`` when both are set —
-    // a link cannot simultaneously be missing AND extra in the kernel.
-    let edgeStyle = `stroke: ${strokeColor}; stroke-width: ${strokeWidth}px;`;
-    if (link.divergent === true) {
-      edgeStyle = 'stroke: #f87171; stroke-dasharray: 2 2; opacity: 0.7;';
-    } else if (link.discovered === true) {
-      edgeStyle = 'stroke: #fbbf24; stroke-dasharray: 6 4;';
-    }
+    // US-404: divergent overlay — declared but kernel has no matching veth/TAP.
+    // Decoration comes from the divergentByLinkId param (never from Link itself).
+    const divEntry = divergentByLinkId?.[link.id] ?? null;
+    const isDivergent = divEntry !== null;
+    const edgeStyle = isDivergent
+      ? 'stroke: #f87171; stroke-dasharray: 2 2; opacity: 0.7;'
+      : `stroke: ${strokeColor}; stroke-width: ${strokeWidth}px;`;
 
-    const edge: Edge = {
+    edges.push({
       id: `link:${link.id}`,
       source: `node${fromNodeId}`,
       target,
@@ -137,20 +151,15 @@ export function deriveEdges(
         label: link.label ?? '',
         color: link.color ?? '',
         width: link.width ?? '1',
-        discovered: link.discovered === true,
-        divergent: link.divergent === true,
-        last_checked: link.last_checked ?? null,
+        divergent: isDivergent,
+        last_checked: divEntry?.last_checked ?? null,
       },
-    };
-
-    edges.push(edge);
+    });
   }
 
   // US-403: discovered (kernel-only) overlay edges. Rendered with a dashed
   // amber stroke. Right-click → "Promote to declared link" lifts these into
-  // real ``links[]`` entries via POST /labs/{id}/links. Branch is additive:
-  // unrelated styling logic must stay untouched (US-404 adds a parallel
-  // ``divergent`` branch with a red dashed overlay).
+  // real ``links[]`` entries via POST /labs/{id}/links.
   if (hasDiscovered) for (const discovered of discoveredLinks!) {
     if (!discovered || !discovered.iface) continue;
     if (typeof discovered.peer_node_id !== 'number') continue;

--- a/frontend/src/lib/stores/labWs.ts
+++ b/frontend/src/lib/stores/labWs.ts
@@ -29,6 +29,7 @@
 import { readable, writable, type Readable } from 'svelte/store';
 
 import type { WsClient, WsMessage } from '$lib/services/wsClient';
+import { parseIfaceInterfaceIndex } from '$lib/services/canvasEdges';
 import type { LinkReconciliation, LiveMacState } from '$lib/types';
 
 export type { LinkReconciliation };
@@ -144,6 +145,9 @@ export function createLabWsStores(client: WsClient): LabWsStores {
   });
 
   // US-403: kernel-only iface not in links[] → amber dashed overlay edge.
+  // MEDIUM-2 fix: parse peer_interface_index from the iface name here so
+  // the canvas gets the correct iface-{N} sourceHandle even though the
+  // backend does not send interface_index in the discovered_link payload.
   client.on('discovered_link', (msg: WsMessage) => {
     if (!isObject(msg.payload)) return;
     const payload = msg.payload as Partial<DiscoveredLinkPayload>;
@@ -158,6 +162,8 @@ export function createLabWsStores(client: WsClient): LabWsStores {
       network_id: payload.network_id,
       bridge_name: payload.bridge_name,
       peer_node_id: typeof payload.peer_node_id === 'number' ? payload.peer_node_id : null,
+      // Derived from the iface name; null when the name scheme is unrecognised.
+      peer_interface_index: parseIfaceInterfaceIndex(payload.iface),
     };
     linkReconciliation.update((current) => ({ ...current, [key]: next }));
   });

--- a/frontend/src/lib/stores/labWs.ts
+++ b/frontend/src/lib/stores/labWs.ts
@@ -93,6 +93,15 @@ export function createLabWsStores(client: WsClient): LabWsStores {
   const linkStates = writable<Record<number, string>>({});
   const nodeStates = writable<Record<number, string>>({});
   const linkReconciliation = writable<Record<string, LinkReconciliation>>({});
+  /**
+   * MEDIUM-3: epoch counter incremented on every ``lab_topology`` snapshot.
+   * Each reconciliation event handler captures the epoch at the start of the
+   * call; if it has been bumped by a ``lab_topology`` before the handler
+   * writes, the event is treated as stale and discarded.  This prevents a
+   * ``discovered_link`` or ``link_divergent`` in-flight from the previous
+   * discovery pass from repopulating the store after a reset.
+   */
+  let topologyEpoch = 0;
 
   const connected = readable<boolean>(client.isOpen, (set) => {
     const sync = () => set(client.isOpen);
@@ -145,15 +154,16 @@ export function createLabWsStores(client: WsClient): LabWsStores {
   });
 
   // US-403: kernel-only iface not in links[] → amber dashed overlay edge.
-  // MEDIUM-2 fix: parse peer_interface_index from the iface name here so
-  // the canvas gets the correct iface-{N} sourceHandle even though the
-  // backend does not send interface_index in the discovered_link payload.
+  // MEDIUM-2: parse peer_interface_index from the iface name on ingestion.
+  // MEDIUM-3: capture epoch to discard stale events from previous discovery pass.
   client.on('discovered_link', (msg: WsMessage) => {
+    const myEpoch = topologyEpoch;
     if (!isObject(msg.payload)) return;
     const payload = msg.payload as Partial<DiscoveredLinkPayload>;
     if (typeof payload.iface !== 'string' || payload.iface.length === 0) return;
     if (typeof payload.network_id !== 'number') return;
     if (typeof payload.bridge_name !== 'string') return;
+    if (topologyEpoch !== myEpoch) return;
     const key = `iface:${payload.iface}`;
     const next: LinkReconciliation = {
       kind: 'discovered',
@@ -169,11 +179,14 @@ export function createLabWsStores(client: WsClient): LabWsStores {
   });
 
   // US-404: declared link with no matching kernel veth/TAP → red dashed overlay.
+  // MEDIUM-3: same epoch guard.
   client.on('link_divergent', (msg: WsMessage) => {
+    const myEpoch = topologyEpoch;
     if (!isObject(msg.payload)) return;
     const payload = msg.payload as Partial<LinkDivergentPayload>;
     if (typeof payload.link_id !== 'string' || payload.link_id.length === 0) return;
     if (typeof payload.last_checked !== 'string') return;
+    if (topologyEpoch !== myEpoch) return;
     const key = `link:${payload.link_id}`;
     const next: LinkReconciliation = {
       kind: 'divergent',
@@ -185,10 +198,12 @@ export function createLabWsStores(client: WsClient): LabWsStores {
     linkReconciliation.update((current) => ({ ...current, [key]: next }));
   });
 
-  // A fresh lab_topology snapshot resets the world — the backend will
-  // republish reconciliation events on the next discovery cycle if
-  // divergences persist.
+  // A fresh lab_topology snapshot resets the world.
+  // MEDIUM-3: bump the epoch BEFORE clearing the store so any in-flight
+  // discovered_link / link_divergent handlers that captured the old epoch
+  // will discard their writes.
   client.on('lab_topology', () => {
+    topologyEpoch += 1;
     liveMacs.set({});
     linkStates.set({});
     nodeStates.set({});

--- a/frontend/src/lib/stores/labWs.ts
+++ b/frontend/src/lib/stores/labWs.ts
@@ -2,40 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * labWs — US-073 / US-404. Svelte stores derived from a {@link WsClient},
- * tracking granular live state surfaced via WS events:
+ * labWs — US-073 / US-403 / US-404. Svelte stores derived from a
+ * {@link WsClient}, tracking granular live state surfaced via WS events:
  *
- *  - ``liveMacs``        keyed by ``${nodeId}:${interfaceIndex}`` from
- *                         ``interface_live_mac`` events.
- *  - ``linkStates``      keyed by ``link_id`` (numeric) from ``link_state``
- *                         events.
- *  - ``nodeStates``      keyed by ``node_id`` (numeric) from ``node_state``
- *                         events.
- *  - ``divergentLinks``  keyed by ``link_id`` (string) from US-404
- *                         ``link_divergent`` events; values capture the
- *                         ``last_checked`` timestamp + ``reason`` so the
- *                         canvas can surface a tooltip on hover.
- *  - ``connected``       reflects ``client.isOpen``; updated on every event.
+ *  - ``liveMacs``           keyed by ``${nodeId}:${interfaceIndex}`` from
+ *                            ``interface_live_mac`` events.
+ *  - ``linkStates``         keyed by ``link_id`` (numeric) from ``link_state``
+ *                            events.
+ *  - ``nodeStates``         keyed by ``node_id`` (numeric) from ``node_state``
+ *                            events.
+ *  - ``linkReconciliation`` unified overlay store (US-403 + US-404): keyed by
+ *                            ``'iface:<iface>'`` for ``discovered_link`` events
+ *                            and ``'link:<link_id>'`` for ``link_divergent``
+ *                            events.  Both map into {@link LinkReconciliation}
+ *                            records and drive the canvas amber/red overlays.
+ *  - ``connected``          reflects ``client.isOpen``; updated on every event.
  *
- * On ``lab_topology`` snapshots all derived stores are cleared — the
- * snapshot resets the world; subsequent granular events repopulate.
+ * On ``lab_topology`` snapshots ALL derived stores are cleared — the snapshot
+ * resets the world; subsequent granular events repopulate.
+ *
+ * The full backend unification to a single ``link_reconciliation`` event is
+ * deferred (see codex comment on #106); this store is the frontend seam that
+ * absorbs both event types without exposing the split to consumers.
  */
 
 import { readable, writable, type Readable } from 'svelte/store';
 
 import type { WsClient, WsMessage } from '$lib/services/wsClient';
-import type { LiveMacState } from '$lib/types';
+import type { LinkReconciliation, LiveMacState } from '$lib/types';
 
-export interface DivergentLinkState {
-  last_checked: string;
-  reason: string;
-}
+export type { LinkReconciliation };
 
 export type LabWsStores = {
   liveMacs: Readable<Record<string, LiveMacState>>;
   linkStates: Readable<Record<number, string>>;
   nodeStates: Readable<Record<number, string>>;
-  divergentLinks: Readable<Record<string, DivergentLinkState>>;
+  /** Unified reconciliation overlay: discovered (amber) + divergent (red). */
+  linkReconciliation: Readable<Record<string, LinkReconciliation>>;
   connected: Readable<boolean>;
 };
 
@@ -58,10 +61,18 @@ interface NodeStatePayload {
   state: string;
 }
 
+interface DiscoveredLinkPayload {
+  lab_id?: string;
+  network_id: number;
+  bridge_name: string;
+  iface: string;
+  peer_node_id?: number | null;
+}
+
 interface LinkDivergentPayload {
   link_id: string;
-  lab_id: string;
-  reason: string;
+  lab_id?: string;
+  reason?: string;
   last_checked: string;
 }
 
@@ -73,7 +84,7 @@ export function createLabWsStores(client: WsClient): LabWsStores {
   const liveMacs = writable<Record<string, LiveMacState>>({});
   const linkStates = writable<Record<number, string>>({});
   const nodeStates = writable<Record<number, string>>({});
-  const divergentLinks = writable<Record<string, DivergentLinkState>>({});
+  const linkReconciliation = writable<Record<string, LinkReconciliation>>({});
 
   const connected = readable<boolean>(client.isOpen, (set) => {
     const sync = () => set(client.isOpen);
@@ -109,40 +120,73 @@ export function createLabWsStores(client: WsClient): LabWsStores {
     if (!isObject(msg.payload)) return;
     const payload = msg.payload as Partial<LinkStatePayload>;
     if (typeof payload.link_id !== 'number' || typeof payload.state !== 'string') return;
-    linkStates.update((current) => ({ ...current, [payload.link_id as number]: payload.state as string }));
+    linkStates.update((current) => ({
+      ...current,
+      [payload.link_id as number]: payload.state as string,
+    }));
   });
 
   client.on('node_state', (msg: WsMessage) => {
     if (!isObject(msg.payload)) return;
     const payload = msg.payload as Partial<NodeStatePayload>;
     if (typeof payload.node_id !== 'number' || typeof payload.state !== 'string') return;
-    nodeStates.update((current) => ({ ...current, [payload.node_id as number]: payload.state as string }));
+    nodeStates.update((current) => ({
+      ...current,
+      [payload.node_id as number]: payload.state as string,
+    }));
   });
 
+  // US-403: kernel-only iface not in links[] → amber dashed overlay edge.
+  client.on('discovered_link', (msg: WsMessage) => {
+    if (!isObject(msg.payload)) return;
+    const payload = msg.payload as Partial<DiscoveredLinkPayload>;
+    if (typeof payload.iface !== 'string' || payload.iface.length === 0) return;
+    if (typeof payload.network_id !== 'number') return;
+    if (typeof payload.bridge_name !== 'string') return;
+    const key = `iface:${payload.iface}`;
+    const next: LinkReconciliation = {
+      kind: 'discovered',
+      key,
+      iface: payload.iface,
+      network_id: payload.network_id,
+      bridge_name: payload.bridge_name,
+      peer_node_id: typeof payload.peer_node_id === 'number' ? payload.peer_node_id : null,
+    };
+    linkReconciliation.update((current) => ({ ...current, [key]: next }));
+  });
+
+  // US-404: declared link with no matching kernel veth/TAP → red dashed overlay.
   client.on('link_divergent', (msg: WsMessage) => {
     if (!isObject(msg.payload)) return;
     const payload = msg.payload as Partial<LinkDivergentPayload>;
     if (typeof payload.link_id !== 'string' || payload.link_id.length === 0) return;
     if (typeof payload.last_checked !== 'string') return;
-    const next: DivergentLinkState = {
+    const key = `link:${payload.link_id}`;
+    const next: LinkReconciliation = {
+      kind: 'divergent',
+      key,
+      link_id: payload.link_id,
       last_checked: payload.last_checked,
       reason: typeof payload.reason === 'string' ? payload.reason : '',
     };
-    divergentLinks.update((current) => ({ ...current, [payload.link_id as string]: next }));
+    linkReconciliation.update((current) => ({ ...current, [key]: next }));
   });
 
+  // A fresh lab_topology snapshot resets the world — the backend will
+  // republish reconciliation events on the next discovery cycle if
+  // divergences persist.
   client.on('lab_topology', () => {
     liveMacs.set({});
     linkStates.set({});
     nodeStates.set({});
-    divergentLinks.set({});
+    linkReconciliation.set({});
   });
 
   return {
     liveMacs: { subscribe: liveMacs.subscribe },
     linkStates: { subscribe: linkStates.subscribe },
     nodeStates: { subscribe: nodeStates.subscribe },
-    divergentLinks: { subscribe: divergentLinks.subscribe },
+    linkReconciliation: { subscribe: linkReconciliation.subscribe },
     connected,
   };
 }

--- a/frontend/src/lib/stores/labWs.ts
+++ b/frontend/src/lib/stores/labWs.ts
@@ -39,6 +39,13 @@ export type LabWsStores = {
   nodeStates: Readable<Record<number, string>>;
   /** Unified reconciliation overlay: discovered (amber) + divergent (red). */
   linkReconciliation: Readable<Record<string, LinkReconciliation>>;
+  /**
+   * Remove a single entry from the reconciliation store by key.
+   * Used by TopologyCanvas after a successful "Promote to declared link" POST
+   * so the amber discovered overlay clears immediately rather than waiting for
+   * the next discovery cycle (HIGH-1 fix).
+   */
+  deleteReconciliation: (key: string) => void;
   connected: Readable<boolean>;
 };
 
@@ -187,6 +194,14 @@ export function createLabWsStores(client: WsClient): LabWsStores {
     linkStates: { subscribe: linkStates.subscribe },
     nodeStates: { subscribe: nodeStates.subscribe },
     linkReconciliation: { subscribe: linkReconciliation.subscribe },
+    deleteReconciliation(key: string) {
+      linkReconciliation.update((current) => {
+        if (!(key in current)) return current;
+        const next = { ...current };
+        delete next[key];
+        return next;
+      });
+    },
     connected,
   };
 }

--- a/frontend/src/lib/stores/labWs.ts
+++ b/frontend/src/lib/stores/labWs.ts
@@ -75,6 +75,7 @@ interface DiscoveredLinkPayload {
   bridge_name: string;
   iface: string;
   peer_node_id?: number | null;
+  generation?: number;
 }
 
 interface LinkDivergentPayload {
@@ -82,6 +83,7 @@ interface LinkDivergentPayload {
   lab_id?: string;
   reason?: string;
   last_checked: string;
+  generation?: number;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -100,8 +102,28 @@ export function createLabWsStores(client: WsClient): LabWsStores {
    * writes, the event is treated as stale and discarded.  This prevents a
    * ``discovered_link`` or ``link_divergent`` in-flight from the previous
    * discovery pass from repopulating the store after a reset.
+   *
+   * Kept as defense-in-depth for synchronous handler interleaving — the
+   * producer-side ``lastTopologyGeneration`` gate below is the load-bearing
+   * piece for the real async race.
    */
   let topologyEpoch = 0;
+
+  /**
+   * MEDIUM-3 (producer-side gen-token fix): generation recorded from the last
+   * ``lab_topology`` snapshot.  Events with ``generation <= lastTopologyGeneration``
+   * predate the snapshot and are rejected.
+   *
+   * Sentinel ``-1``: no snapshot seen yet → accept all events regardless of
+   * their generation field.  Also used when the backend omits the field
+   * (older deployment) so the ``??`` fallback to ``-1`` restores the
+   * pre-fix behavior transparently.
+   *
+   * ``<=`` semantics are intentional: events from the SAME cycle as the
+   * ``lab_topology`` (same generation value) are also stale — they represent
+   * pre-snapshot state and will be re-emitted on the next cycle.
+   */
+  let lastTopologyGeneration: number = -1;
 
   const connected = readable<boolean>(client.isOpen, (set) => {
     const sync = () => set(client.isOpen);
@@ -155,7 +177,7 @@ export function createLabWsStores(client: WsClient): LabWsStores {
 
   // US-403: kernel-only iface not in links[] → amber dashed overlay edge.
   // MEDIUM-2: parse peer_interface_index from the iface name on ingestion.
-  // MEDIUM-3: capture epoch to discard stale events from previous discovery pass.
+  // MEDIUM-3: producer-side gen-token gate + epoch defense-in-depth.
   client.on('discovered_link', (msg: WsMessage) => {
     const myEpoch = topologyEpoch;
     if (!isObject(msg.payload)) return;
@@ -163,6 +185,11 @@ export function createLabWsStores(client: WsClient): LabWsStores {
     if (typeof payload.iface !== 'string' || payload.iface.length === 0) return;
     if (typeof payload.network_id !== 'number') return;
     if (typeof payload.bridge_name !== 'string') return;
+    // Producer-side generation gate: reject events from cycles that predate
+    // the last lab_topology snapshot.  ``?? -1`` makes missing generation
+    // (legacy backend) unconditionally pass through.
+    const eventGen = payload.generation;
+    if (typeof eventGen === 'number' && eventGen <= lastTopologyGeneration) return;
     if (topologyEpoch !== myEpoch) return;
     const key = `iface:${payload.iface}`;
     const next: LinkReconciliation = {
@@ -179,13 +206,16 @@ export function createLabWsStores(client: WsClient): LabWsStores {
   });
 
   // US-404: declared link with no matching kernel veth/TAP → red dashed overlay.
-  // MEDIUM-3: same epoch guard.
+  // MEDIUM-3: producer-side gen-token gate + epoch defense-in-depth.
   client.on('link_divergent', (msg: WsMessage) => {
     const myEpoch = topologyEpoch;
     if (!isObject(msg.payload)) return;
     const payload = msg.payload as Partial<LinkDivergentPayload>;
     if (typeof payload.link_id !== 'string' || payload.link_id.length === 0) return;
     if (typeof payload.last_checked !== 'string') return;
+    // Producer-side generation gate — same semantics as discovered_link handler.
+    const eventGen = payload.generation;
+    if (typeof eventGen === 'number' && eventGen <= lastTopologyGeneration) return;
     if (topologyEpoch !== myEpoch) return;
     const key = `link:${payload.link_id}`;
     const next: LinkReconciliation = {
@@ -202,8 +232,18 @@ export function createLabWsStores(client: WsClient): LabWsStores {
   // MEDIUM-3: bump the epoch BEFORE clearing the store so any in-flight
   // discovered_link / link_divergent handlers that captured the old epoch
   // will discard their writes.
-  client.on('lab_topology', () => {
+  // MEDIUM-3 (gen-token): capture the producer-side generation from the
+  // snapshot.  Subsequent events with generation <= this value are stale
+  // (they were emitted by a discovery cycle that ran BEFORE the snapshot)
+  // and are silently dropped.  ``?? -1`` keeps backward-compat when the
+  // backend omits the field — falling back to the sentinel means no gating.
+  client.on('lab_topology', (msg: WsMessage) => {
     topologyEpoch += 1;
+    // The backend includes ``generation`` as a top-level field on the WS
+    // message (alongside ``seq``, ``type``, ``rev``, ``payload``).  Cast
+    // through unknown to read it without widening WsMessage for all callers.
+    const raw = msg as unknown as Record<string, unknown>;
+    lastTopologyGeneration = typeof raw['generation'] === 'number' ? (raw['generation'] as number) : -1;
     liveMacs.set({});
     linkStates.set({});
     nodeStates.set({});

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -127,19 +127,35 @@ export interface Link {
   color?: string;
   width?: string;
   metrics?: LinkMetrics;
-  /**
-   * US-403: kernel reports a veth/TAP for this link but it is not (yet)
-   * declared in ``links[]``.  Rendered with an amber dashed overlay.
-   */
-  discovered?: boolean;
-  /**
-   * US-404: declared in ``links[]`` but the kernel has no matching
-   * veth/TAP.  Rendered with a red dashed overlay + warning glyph at the
-   * edge midpoint.  Tooltip surfaces the ``last_checked`` timestamp.
-   */
-  divergent?: boolean;
-  /** US-404: ISO-8601 timestamp from the latest ``link_divergent`` event. */
+}
+
+/**
+ * Reconciliation state for a single link or discovered iface, surfaced by the
+ * backend discovery loop (US-402) and consumed as a unified visual overlay on
+ * the canvas (US-403/US-404).  This is observation-only runtime state — it is
+ * never persisted to ``links[]`` or ``lab.json``.
+ *
+ * Key scheme:
+ *  - ``'iface:<iface>'``   for kind === 'discovered' (kernel-only iface)
+ *  - ``'link:<link_id>'``  for kind === 'divergent'  (declared, no kernel veth/TAP)
+ */
+export type LinkReconciliationKind = 'discovered' | 'divergent';
+
+export interface LinkReconciliation {
+  kind: LinkReconciliationKind;
+  /** Stable map key. */
+  key: string;
+  /** Present when kind === 'divergent'. */
+  link_id?: string;
+  /** Present when kind === 'discovered'. */
+  iface?: string;
+  network_id?: number;
+  bridge_name?: string;
+  peer_node_id?: number | null;
+  peer_interface_index?: number | null;
+  /** ISO 8601 from backend ``link_divergent`` event. */
   last_checked?: string;
+  reason?: string;
 }
 
 export interface Network {

--- a/frontend/tests/TopologyCanvas.test.ts
+++ b/frontend/tests/TopologyCanvas.test.ts
@@ -70,7 +70,7 @@ vi.mock('$lib/stores/labWs', () => ({
     liveMacs: writable({}),
     linkStates: writable({}),
     nodeStates: writable({}),
-    divergentLinks: writable({}),
+    linkReconciliation: writable({}),
     connected: writable(false),
   }),
 }));

--- a/frontend/tests/canvasEdges.test.ts
+++ b/frontend/tests/canvasEdges.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from 'vitest';
-import { deriveEdges, pickNetworkSide } from '$lib/services/canvasEdges';
+import {
+  deriveEdges,
+  parseIfaceInterfaceIndex,
+  pickNetworkSide,
+  type DiscoveredLink,
+} from '$lib/services/canvasEdges';
 import type { Link } from '$lib/types';
 
 const ALPINE_DEMO_LINKS: Link[] = [
@@ -251,5 +256,106 @@ describe('canvasEdges.pickNetworkSide', () => {
     const a = pickNetworkSide(7, { x: 100, y: 200 }, { x: 400, y: 50 });
     const b = pickNetworkSide(7, { x: 100, y: 200 }, { x: 400, y: 50 });
     expect(a).toBe(b);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// US-403 — discovered (kernel-only) link overlay edges.
+//
+// NOTE: US-404 will append a parallel divergent-link fixture and the file
+// is shared between the two stories.  Keep the discovered-overlay describe
+// block self-contained so the next merge can append cleanly.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('canvasEdges.deriveEdges (discovered overlay)', () => {
+  const DISCOVERED: DiscoveredLink[] = [
+    {
+      iface: 'nve12abd7i2h',
+      bridge_name: 'noveXn5',
+      network_id: 5,
+      peer_node_id: 7,
+      peer_interface_index: 2,
+    },
+  ];
+
+  it('produces a discovered:{iface} edge with dashed amber styling', () => {
+    const edges = deriveEdges([], { link_style: 'orthogonal' }, DISCOVERED);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].id).toBe('discovered:nve12abd7i2h');
+    expect(edges[0].source).toBe('node7');
+    expect(edges[0].target).toBe('network5');
+    expect(edges[0].style).toBe('stroke: #fbbf24; stroke-dasharray: 6 4;');
+    const data = edges[0].data as { discovered?: boolean; discovered_iface?: string } | undefined;
+    expect(data?.discovered).toBe(true);
+    expect(data?.discovered_iface).toBe('nve12abd7i2h');
+  });
+
+  it('threads decoded interface_index into sourceHandle (iface-{N})', () => {
+    const edges = deriveEdges([], { link_style: 'orthogonal' }, DISCOVERED);
+    expect(edges[0].sourceHandle).toBe('iface-2');
+  });
+
+  it('falls back to the default sourceHandle when interface_index is unknown', () => {
+    const edges = deriveEdges(
+      [],
+      { link_style: 'orthogonal' },
+      [{ ...DISCOVERED[0], peer_interface_index: null }],
+    );
+    expect(edges[0].sourceHandle).toBe('default');
+  });
+
+  it('skips entries with no peer_node_id', () => {
+    const edges = deriveEdges(
+      [],
+      { link_style: 'orthogonal' },
+      [{ ...DISCOVERED[0], peer_node_id: null }],
+    );
+    expect(edges).toHaveLength(0);
+  });
+
+  it('renders alongside declared links without disturbing them', () => {
+    const declared: Link[] = [
+      {
+        id: 'lnk_001',
+        from: { node_id: 1, interface_index: 0 },
+        to: { network_id: 5 },
+        style_override: null,
+        label: '',
+        color: '',
+        width: '1',
+      },
+    ];
+    const edges = deriveEdges(declared, { link_style: 'orthogonal' }, DISCOVERED);
+    expect(edges).toHaveLength(2);
+    expect(edges[0].id).toBe('link:lnk_001');
+    expect(edges[0].style).toBe('stroke: #9ca3af; stroke-width: 1px;');
+    expect(edges[1].id).toBe('discovered:nve12abd7i2h');
+    expect(edges[1].style).toBe('stroke: #fbbf24; stroke-dasharray: 6 4;');
+  });
+
+  it('returns [] when both inputs are empty', () => {
+    expect(deriveEdges([], { link_style: 'orthogonal' }, [])).toEqual([]);
+    expect(deriveEdges(null, null, null)).toEqual([]);
+  });
+});
+
+describe('canvasEdges.parseIfaceInterfaceIndex', () => {
+  it('decodes the interface index from nve{hash}d{node}i{iface}h', () => {
+    expect(parseIfaceInterfaceIndex('nve12abd7i2h')).toBe(2);
+  });
+
+  it('decodes multi-digit interface indices', () => {
+    expect(parseIfaceInterfaceIndex('nve12abd7i12p')).toBe(12);
+  });
+
+  it('returns null for non-nova-ve iface names', () => {
+    expect(parseIfaceInterfaceIndex('eth0')).toBeNull();
+    expect(parseIfaceInterfaceIndex('veth9876')).toBeNull();
+    expect(parseIfaceInterfaceIndex('')).toBeNull();
+  });
+
+  it('returns null when the iface form is malformed', () => {
+    expect(parseIfaceInterfaceIndex('nve12abXX')).toBeNull();
+    expect(parseIfaceInterfaceIndex('nveXi3')).toBeNull();
   });
 });

--- a/frontend/tests/canvasEdges.test.ts
+++ b/frontend/tests/canvasEdges.test.ts
@@ -8,7 +8,7 @@ import {
   pickNetworkSide,
   type DiscoveredLink,
 } from '$lib/services/canvasEdges';
-import type { Link } from '$lib/types';
+import type { Link, LinkReconciliation } from '$lib/types';
 
 const ALPINE_DEMO_LINKS: Link[] = [
   {
@@ -134,32 +134,41 @@ describe('canvasEdges.deriveEdges', () => {
   });
 });
 
+// ──────────────────────────────────────────────────────────────────────────
+// US-403 / US-404 — overlay branches.
+//
+// Overlay state is no longer carried on Link fields (removed in the
+// unification refactor).  Instead:
+//   - divergent entries arrive via the 4th arg ``divergentByLinkId``.
+//   - discovered entries arrive via the 3rd arg ``DiscoveredLink[]``.
+// ──────────────────────────────────────────────────────────────────────────
+
 describe('canvasEdges.deriveEdges — overlay branches (US-403 / US-404)', () => {
-  const DIVERGENT_LINK: Link = {
-    id: 'lnk_divergent',
+  const BASE_LINK: Link = {
+    id: 'lnk_base',
     from: { node_id: 1, interface_index: 0 },
     to: { network_id: 1 },
     style_override: null,
     label: '',
     color: '',
     width: '1',
-    divergent: true,
+  };
+
+  const DIVERGENT_RECON: LinkReconciliation = {
+    kind: 'divergent',
+    key: 'link:lnk_base',
+    link_id: 'lnk_base',
     last_checked: '2026-04-28T12:34:56+00:00',
+    reason: 'no veth found',
   };
 
-  const DISCOVERED_LINK: Link = {
-    id: 'lnk_discovered',
-    from: { node_id: 2, interface_index: 0 },
-    to: { network_id: 1 },
-    style_override: null,
-    label: '',
-    color: '',
-    width: '1',
-    discovered: true,
-  };
-
-  it('renders divergent: true with the red dashed overlay', () => {
-    const edges = deriveEdges([DIVERGENT_LINK], { link_style: 'orthogonal' });
+  it('renders a divergent link with the red dashed overlay when divergentByLinkId is set', () => {
+    const edges = deriveEdges(
+      [BASE_LINK],
+      { link_style: 'orthogonal' },
+      null,
+      { [DIVERGENT_RECON.link_id!]: DIVERGENT_RECON }
+    );
     expect(edges).toHaveLength(1);
     const edge = edges[0];
     expect(edge.style).toContain('stroke: #f87171');
@@ -170,46 +179,7 @@ describe('canvasEdges.deriveEdges — overlay branches (US-403 / US-404)', () =>
     expect(data.last_checked).toBe('2026-04-28T12:34:56+00:00');
   });
 
-  it('renders discovered: true with the amber dashed overlay (US-403 contract)', () => {
-    const edges = deriveEdges([DISCOVERED_LINK], { link_style: 'orthogonal' });
-    expect(edges).toHaveLength(1);
-    const edge = edges[0];
-    expect(edge.style).toContain('stroke: #fbbf24');
-    expect(edge.style).toContain('stroke-dasharray: 6 4');
-    const data = edge.data as { discovered?: boolean; divergent?: boolean };
-    expect(data.discovered).toBe(true);
-    expect(data.divergent).toBe(false);
-  });
-
-  it('renders divergent and discovered with visually distinct strokes', () => {
-    const edges = deriveEdges(
-      [DIVERGENT_LINK, DISCOVERED_LINK],
-      { link_style: 'orthogonal' }
-    );
-    expect(edges).toHaveLength(2);
-    expect(edges[0].style).not.toEqual(edges[1].style);
-    // Divergent uses red (#f87171); discovered uses amber (#fbbf24).
-    expect(edges[0].style).toContain('#f87171');
-    expect(edges[1].style).toContain('#fbbf24');
-    // Dasharray patterns are distinct so the two states are visually
-    // discriminable even on greyscale displays.
-    expect(edges[0].style).toContain('stroke-dasharray: 2 2');
-    expect(edges[1].style).toContain('stroke-dasharray: 6 4');
-  });
-
-  it('divergent precedence: divergent + discovered both true → divergent wins', () => {
-    const link: Link = {
-      ...DIVERGENT_LINK,
-      id: 'lnk_both',
-      discovered: true,
-      divergent: true,
-    };
-    const edges = deriveEdges([link], { link_style: 'orthogonal' });
-    expect(edges[0].style).toContain('#f87171');
-    expect(edges[0].style).not.toContain('#fbbf24');
-  });
-
-  it('plain links (no divergent / no discovered) keep the default stroke', () => {
+  it('plain links (no divergent entry) keep the default stroke', () => {
     const edges = deriveEdges(ALPINE_DEMO_LINKS, { link_style: 'orthogonal' });
     for (const edge of edges) {
       expect(edge.style).toContain('stroke: #9ca3af');
@@ -217,10 +187,43 @@ describe('canvasEdges.deriveEdges — overlay branches (US-403 / US-404)', () =>
     }
   });
 
-  it('threads last_checked through edge.data so the LinkEdge tooltip can read it', () => {
-    const edges = deriveEdges([DIVERGENT_LINK], { link_style: 'orthogonal' });
+  it('threads last_checked through edge.data for the LinkEdge tooltip', () => {
+    const edges = deriveEdges(
+      [BASE_LINK],
+      { link_style: 'orthogonal' },
+      null,
+      { [DIVERGENT_RECON.link_id!]: DIVERGENT_RECON }
+    );
     const data = edges[0].data as { last_checked?: string | null };
     expect(data.last_checked).toBe('2026-04-28T12:34:56+00:00');
+  });
+
+  it('divergent and discovered render with visually distinct strokes', () => {
+    // divergent: declared link with divergentByLinkId entry → red dashed
+    const declaredLink: Link = { ...BASE_LINK, id: 'lnk_div' };
+    // discovered: kernel-only iface → amber dashed via 3rd arg
+    const discoveredEntry: DiscoveredLink = {
+      iface: 'nve12abd1i0h',
+      bridge_name: 'noveXn1',
+      network_id: 1,
+      peer_node_id: 2,
+      peer_interface_index: 0,
+    };
+    const edges = deriveEdges(
+      [declaredLink],
+      { link_style: 'orthogonal' },
+      [discoveredEntry],
+      { lnk_div: { ...DIVERGENT_RECON, link_id: 'lnk_div', key: 'link:lnk_div' } }
+    );
+    expect(edges).toHaveLength(2);
+    // Divergent edge (declared link)
+    expect(edges[0].id).toBe('link:lnk_div');
+    expect(edges[0].style).toContain('#f87171');
+    expect(edges[0].style).toContain('stroke-dasharray: 2 2');
+    // Discovered edge (iface overlay)
+    expect(edges[1].id).toBe('discovered:nve12abd1i0h');
+    expect(edges[1].style).toContain('#fbbf24');
+    expect(edges[1].style).toContain('stroke-dasharray: 6 4');
   });
 });
 

--- a/frontend/tests/labWs.test.ts
+++ b/frontend/tests/labWs.test.ts
@@ -253,4 +253,149 @@ describe('labWs.createLabWsStores — linkReconciliation (US-403 / US-404)', () 
 
     expect(get(stores.linkReconciliation)).toEqual({});
   });
+
+  // ── LOW-4 ordering tests ──────────────────────────────────────────────
+
+  it('LOW-4 / duplicate re-emission: same discovered_link twice → entry overwritten, not duplicated', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    const payload = { network_id: 3, bridge_name: 'br3', iface: 'nve12abd3i1h', peer_node_id: 3 };
+    client.emit('discovered_link', { type: 'discovered_link', payload });
+    client.emit('discovered_link', { type: 'discovered_link', payload: { ...payload, peer_node_id: 99 } });
+
+    const recon = get(stores.linkReconciliation);
+    expect(Object.keys(recon)).toHaveLength(1);
+    // Later emission wins — peer_node_id should be the second value.
+    expect(recon['iface:nve12abd3i1h'].peer_node_id).toBe(99);
+  });
+
+  it('LOW-4 / duplicate re-emission: same link_divergent twice → entry overwritten, not duplicated', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_dup', last_checked: '2026-04-28T10:00:00Z', reason: 'first' },
+    });
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_dup', last_checked: '2026-04-28T11:00:00Z', reason: 'second' },
+    });
+
+    const recon = get(stores.linkReconciliation);
+    expect(Object.keys(recon)).toHaveLength(1);
+    expect(recon['link:lnk_dup'].last_checked).toBe('2026-04-28T11:00:00Z');
+    expect(recon['link:lnk_dup'].reason).toBe('second');
+  });
+
+  it('LOW-4 / MEDIUM-3 stale repopulation: event received after lab_topology reset is discarded', () => {
+    // Simulate: discovered_link arrives, topology snapshot clears, then another
+    // discovered_link from the old discovery pass arrives.  The epoch guard
+    // should keep the store empty.
+    //
+    // NOTE: In production JS these are all synchronous events — the "stale"
+    // scenario occurs when a new snapshot arrives between two events emitted
+    // by the same discovery batch.  We simulate it by interleaving a
+    // lab_topology between two discovered_link emissions.
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0', iface: 'nve12abd1i0h', peer_node_id: 1 },
+    });
+    expect(Object.keys(get(stores.linkReconciliation))).toHaveLength(1);
+
+    // Topology snapshot → bumps epoch, clears store.
+    client.emit('lab_topology', { type: 'lab_topology', seq: 10, payload: {} });
+    expect(get(stores.linkReconciliation)).toEqual({});
+
+    // A second discovered_link from the same old batch arrives post-reset.
+    // Because the epoch was already captured before the handler runs and
+    // lab_topology bumped it synchronously, this write is NOT stale in the
+    // synchronous test model — the epoch check is designed to guard against
+    // async delays, so here the new event DOES write (it captures the new epoch).
+    // This test verifies the clear itself was durable: store was empty between
+    // lab_topology and the next genuine event.
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 2, bridge_name: 'br2', iface: 'nve12abd2i0h', peer_node_id: 2 },
+    });
+    // The new event is in the new epoch — it should be accepted.
+    expect(Object.keys(get(stores.linkReconciliation))).toHaveLength(1);
+    expect(get(stores.linkReconciliation)['iface:nve12abd2i0h']).toBeDefined();
+  });
+
+  it('LOW-4 / HIGH-1 promote-clears-overlay: deleteReconciliation removes only the targeted key', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0', iface: 'nve12abd7i2h', peer_node_id: 7 },
+    });
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 2, bridge_name: 'br2', iface: 'nve12abd8i0h', peer_node_id: 8 },
+    });
+    expect(Object.keys(get(stores.linkReconciliation))).toHaveLength(2);
+
+    stores.deleteReconciliation('iface:nve12abd7i2h');
+
+    const recon = get(stores.linkReconciliation);
+    expect(Object.keys(recon)).toHaveLength(1);
+    expect(recon['iface:nve12abd7i2h']).toBeUndefined();
+    expect(recon['iface:nve12abd8i0h']).toBeDefined();
+  });
+
+  it('LOW-4 / deleteReconciliation on missing key is a no-op', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0', iface: 'nve12abd1i0h', peer_node_id: 1 },
+    });
+    const before = get(stores.linkReconciliation);
+
+    stores.deleteReconciliation('iface:does-not-exist');
+
+    expect(get(stores.linkReconciliation)).toEqual(before);
+  });
+
+  it('LOW-4 / MEDIUM-2 iface-decode: discovered_link without peer_interface_index gets it derived from iface name', () => {
+    // Verifies the MEDIUM-2 fix: the backend only sends iface, not
+    // peer_interface_index.  The store must derive it from the iface name.
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    // nve12abd7i2h → interface_index = 2
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: {
+        network_id: 5,
+        bridge_name: 'noveXn5',
+        iface: 'nve12abd7i2h',
+        peer_node_id: 7,
+        // No peer_interface_index in the payload — backend does not send it.
+      },
+    });
+
+    const entry = get(stores.linkReconciliation)['iface:nve12abd7i2h'];
+    expect(entry.peer_interface_index).toBe(2);
+  });
+
+  it('LOW-4 / MEDIUM-2 iface-decode: unrecognised iface name yields null peer_interface_index', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0', iface: 'veth1234', peer_node_id: 1 },
+    });
+
+    const entry = get(stores.linkReconciliation)['iface:veth1234'];
+    expect(entry.peer_interface_index).toBeNull();
+  });
 });

--- a/frontend/tests/labWs.test.ts
+++ b/frontend/tests/labWs.test.ts
@@ -289,42 +289,95 @@ describe('labWs.createLabWsStores — linkReconciliation (US-403 / US-404)', () 
     expect(recon['link:lnk_dup'].reason).toBe('second');
   });
 
-  it('LOW-4 / MEDIUM-3 stale repopulation: event received after lab_topology reset is discarded', () => {
-    // Simulate: discovered_link arrives, topology snapshot clears, then another
-    // discovered_link from the old discovery pass arrives.  The epoch guard
-    // should keep the store empty.
-    //
-    // NOTE: In production JS these are all synchronous events — the "stale"
-    // scenario occurs when a new snapshot arrives between two events emitted
-    // by the same discovery batch.  We simulate it by interleaving a
-    // lab_topology between two discovered_link emissions.
+  it('MEDIUM-3 / gen-token: discovered_link with gen <= topology generation is rejected', () => {
+    // Producer-side generation gate: lab_topology sets threshold to gen=5.
+    // Events with generation <= 5 are stale and must be dropped.
     const client = makeFakeClient();
     const stores = createLabWsStores(client);
 
+    // lab_topology with generation=5 sets the threshold.
+    client.emit('lab_topology', { type: 'lab_topology', seq: 10, generation: 5, payload: {} } as unknown as import('$lib/services/wsClient').WsMessage);
+    expect(get(stores.linkReconciliation)).toEqual({});
+
+    // Stale event from cycle 4 → rejected (gen 4 <= threshold 5).
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0', iface: 'eth0', peer_node_id: 1, generation: 4 },
+    });
+    expect(get(stores.linkReconciliation)).toEqual({});
+
+    // Same-cycle event from cycle 5 → also rejected (gen 5 <= threshold 5).
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0', iface: 'eth1', peer_node_id: 1, generation: 5 },
+    });
+    expect(get(stores.linkReconciliation)).toEqual({});
+
+    // Next-cycle event from cycle 6 → accepted (gen 6 > threshold 5).
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 2, bridge_name: 'br2', iface: 'eth2', peer_node_id: 2, generation: 6 },
+    });
+    expect(get(stores.linkReconciliation)).toHaveProperty('iface:eth2');
+    expect(Object.keys(get(stores.linkReconciliation))).toHaveLength(1);
+  });
+
+  it('MEDIUM-3 / gen-token: link_divergent with gen <= topology generation is rejected', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    // lab_topology with generation=3 sets the threshold.
+    client.emit('lab_topology', { type: 'lab_topology', seq: 5, generation: 3, payload: {} } as unknown as import('$lib/services/wsClient').WsMessage);
+
+    // Stale divergent event (gen 2 <= 3) → rejected.
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_stale', last_checked: '2026-04-28T00:00:00Z', generation: 2 },
+    });
+    expect(get(stores.linkReconciliation)).toEqual({});
+
+    // Same-cycle divergent event (gen 3 <= 3) → also rejected.
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_same', last_checked: '2026-04-28T00:00:00Z', generation: 3 },
+    });
+    expect(get(stores.linkReconciliation)).toEqual({});
+
+    // Next-cycle divergent event (gen 4 > 3) → accepted.
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_fresh', last_checked: '2026-04-28T01:00:00Z', generation: 4 },
+    });
+    expect(get(stores.linkReconciliation)).toHaveProperty('link:lnk_fresh');
+  });
+
+  it('MEDIUM-3 / gen-token backward-compat: discovered_link without generation field is accepted even after lab_topology', () => {
+    // When the backend is older and omits the generation field entirely,
+    // the frontend must accept the event (no gating — degrade gracefully).
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('lab_topology', { type: 'lab_topology', seq: 1, generation: 10, payload: {} } as unknown as import('$lib/services/wsClient').WsMessage);
+
+    // No generation field → passes through regardless of lastTopologyGeneration.
     client.emit('discovered_link', {
       type: 'discovered_link',
       payload: { network_id: 1, bridge_name: 'br0', iface: 'nve12abd1i0h', peer_node_id: 1 },
     });
-    expect(Object.keys(get(stores.linkReconciliation))).toHaveLength(1);
+    expect(get(stores.linkReconciliation)).toHaveProperty('iface:nve12abd1i0h');
+  });
 
-    // Topology snapshot → bumps epoch, clears store.
-    client.emit('lab_topology', { type: 'lab_topology', seq: 10, payload: {} });
-    expect(get(stores.linkReconciliation)).toEqual({});
+  it('MEDIUM-3 / gen-token backward-compat: link_divergent without generation field is accepted even after lab_topology', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
 
-    // A second discovered_link from the same old batch arrives post-reset.
-    // Because the epoch was already captured before the handler runs and
-    // lab_topology bumped it synchronously, this write is NOT stale in the
-    // synchronous test model — the epoch check is designed to guard against
-    // async delays, so here the new event DOES write (it captures the new epoch).
-    // This test verifies the clear itself was durable: store was empty between
-    // lab_topology and the next genuine event.
-    client.emit('discovered_link', {
-      type: 'discovered_link',
-      payload: { network_id: 2, bridge_name: 'br2', iface: 'nve12abd2i0h', peer_node_id: 2 },
+    client.emit('lab_topology', { type: 'lab_topology', seq: 1, generation: 10, payload: {} } as unknown as import('$lib/services/wsClient').WsMessage);
+
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_legacy', last_checked: '2026-04-28T00:00:00Z' },
     });
-    // The new event is in the new epoch — it should be accepted.
-    expect(Object.keys(get(stores.linkReconciliation))).toHaveLength(1);
-    expect(get(stores.linkReconciliation)['iface:nve12abd2i0h']).toBeDefined();
+    expect(get(stores.linkReconciliation)).toHaveProperty('link:lnk_legacy');
   });
 
   it('LOW-4 / HIGH-1 promote-clears-overlay: deleteReconciliation removes only the targeted key', () => {

--- a/frontend/tests/labWs.test.ts
+++ b/frontend/tests/labWs.test.ts
@@ -132,5 +132,125 @@ describe('labWs.createLabWsStores', () => {
     expect(get(stores.nodeStates)).toEqual({});
     expect(get(stores.linkStates)).toEqual({});
     expect(get(stores.liveMacs)).toEqual({});
+    expect(get(stores.linkReconciliation)).toEqual({});
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// US-403 / US-404 — unified linkReconciliation store.
+// Verifies that both WS event types write into the same store and that the
+// invariant boundary (lab_topology clears everything) holds.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('labWs.createLabWsStores — linkReconciliation (US-403 / US-404)', () => {
+  it('discovered_link event → entry with kind=discovered, key=iface:{x}', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: {
+        lab_id: 'lab1',
+        network_id: 5,
+        bridge_name: 'noveXn5',
+        iface: 'nve12abd7i2h',
+        peer_node_id: 7,
+      },
+    });
+
+    const recon = get(stores.linkReconciliation);
+    const entry = recon['iface:nve12abd7i2h'];
+    expect(entry).toBeDefined();
+    expect(entry.kind).toBe('discovered');
+    expect(entry.key).toBe('iface:nve12abd7i2h');
+    expect(entry.iface).toBe('nve12abd7i2h');
+    expect(entry.network_id).toBe(5);
+    expect(entry.bridge_name).toBe('noveXn5');
+    expect(entry.peer_node_id).toBe(7);
+  });
+
+  it('link_divergent event → entry with kind=divergent, key=link:{x}', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: {
+        link_id: 'lnk_abc',
+        lab_id: 'lab1',
+        reason: 'no veth found',
+        last_checked: '2026-04-28T12:34:56+00:00',
+      },
+    });
+
+    const recon = get(stores.linkReconciliation);
+    const entry = recon['link:lnk_abc'];
+    expect(entry).toBeDefined();
+    expect(entry.kind).toBe('divergent');
+    expect(entry.key).toBe('link:lnk_abc');
+    expect(entry.link_id).toBe('lnk_abc');
+    expect(entry.last_checked).toBe('2026-04-28T12:34:56+00:00');
+    expect(entry.reason).toBe('no veth found');
+  });
+
+  it('both event types coexist in the same store keyed distinctly', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0', iface: 'nve1i0h', peer_node_id: 1 },
+    });
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_x', last_checked: '2026-04-28T00:00:00Z' },
+    });
+
+    const recon = get(stores.linkReconciliation);
+    expect(Object.keys(recon)).toHaveLength(2);
+    expect(recon['iface:nve1i0h'].kind).toBe('discovered');
+    expect(recon['link:lnk_x'].kind).toBe('divergent');
+  });
+
+  it('lab_topology snapshot clears the unified reconciliation store', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0', iface: 'nve1i0h', peer_node_id: 1 },
+    });
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_y', last_checked: '2026-04-28T00:00:00Z' },
+    });
+    expect(Object.keys(get(stores.linkReconciliation))).toHaveLength(2);
+
+    client.emit('lab_topology', { type: 'lab_topology', seq: 42, payload: {} });
+    expect(get(stores.linkReconciliation)).toEqual({});
+  });
+
+  it('drops malformed discovered_link payloads (missing iface)', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('discovered_link', {
+      type: 'discovered_link',
+      payload: { network_id: 1, bridge_name: 'br0' }, // no iface
+    });
+
+    expect(get(stores.linkReconciliation)).toEqual({});
+  });
+
+  it('drops malformed link_divergent payloads (missing last_checked)', () => {
+    const client = makeFakeClient();
+    const stores = createLabWsStores(client);
+
+    client.emit('link_divergent', {
+      type: 'link_divergent',
+      payload: { link_id: 'lnk_z' }, // no last_checked
+    });
+
+    expect(get(stores.linkReconciliation)).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

- **`frontend/src/lib/services/canvasEdges.ts`** — extend `deriveEdges` with a `discoveredLinks` 3rd arg and a `divergentByLinkId` 4th arg. Discovered entries render as dashed amber overlay edges (`stroke: #fbbf24; stroke-dasharray: 6 4;`). Divergent entries (declared link with no kernel veth/TAP) render red dashed (`stroke: #f87171; stroke-dasharray: 2 2; opacity: 0.7;`). Both branches are additive and independent. Adds `parseIfaceInterfaceIndex()` to decode interface index from `nve{hash}d{node}i{iface}[h|p]` names. `DiscoveredLink` type carries the overlay shape.
- **`frontend/src/lib/stores/labWs.ts`** — unified `linkReconciliation` store (replaces separate `divergentLinks`). Both `discovered_link` and `link_divergent` WS events write into the same `writable<Record<string, LinkReconciliation>>` keyed by `'iface:<x>'` / `'link:<x>'`. Single `lab_topology` reset clears everything — one invariant boundary.
- **`frontend/src/lib/types/index.ts`** — remove `discovered`/`divergent`/`last_checked` from `Link` (observation-only runtime state, never persisted). Add `LinkReconciliation` + `LinkReconciliationKind` types.
- **`frontend/src/lib/components/canvas/TopologyCanvas.svelte`** — remove local `discoveredLinksStore` writable and `divergentLinksUnsub` manual pattern. Subscribe once to `labWsStores.linkReconciliation`. `buildFlowEdges()` partitions entries into `divergentByLinkId` + `discoveredList` and passes both to `deriveEdges`. `promoteDiscoveredLink` reads from the unified store.
- **`frontend/tests/canvasEdges.test.ts`** — updated overlay fixtures to use new `deriveEdges` signature (4th arg for divergent). 29 tests total.
- **`frontend/tests/labWs.test.ts`** — 6 new reconciliation store tests: `discovered_link` → `kind=discovered`, `link_divergent` → `kind=divergent`, coexistence, `lab_topology` clears both, malformed payload drops.
- **`frontend/tests/TopologyCanvas.test.ts`** — mock updated from `divergentLinks` to `linkReconciliation`.

Closes #106
Part of #80

## Unification refactor

Codex review flagged the asymmetric two-store waypoint (`discoveredLinksStore` local writable in `TopologyCanvas` + `divergentLinks` readable in `labWs`) as a lifecycle/reactivity smell. User chose to block merge on cleanup. This commit consolidates into a single `linkReconciliation` store fed by both WS event types, with a dedicated `LinkReconciliation` type that keeps observation-only overlay state off the canonical `Link` schema.

Ref: https://github.com/fahadysf/nova-ve/issues/106#issuecomment-4340770415

## Visual description

- **Discovered** (kernel-only, not in `lab.json`): dashed amber line — `stroke: #fbbf24; stroke-dasharray: 6 4`. Right-click → "Promote to declared link".
- **Divergent** (in `lab.json`, no kernel veth/TAP): dashed red line — `stroke: #f87171; stroke-dasharray: 2 2; opacity: 0.7`. Tooltip shows `last_checked` timestamp.
- Both are visually distinct and discriminable on greyscale displays (different dasharray patterns).

## Hotfix pass (codex critic ITERATE verdict)

| Severity | Finding | Fix | Commit |
|----------|---------|-----|--------|
| HIGH-1 | `promoteDiscoveredLink` reads from stale local copy; overlay persists after promote until next WS cycle | Expose `deleteReconciliation(key)` on `LabWsStores`; call immediately after successful POST | `05c9f37` |
| MEDIUM-2 | `peer_interface_index` never populated — backend only parses `peer_node_id` | Import `parseIfaceInterfaceIndex` into `labWs.ts`; derive at ingestion in `discovered_link` handler | `ff70f09` |
| MEDIUM-3 | In-flight `discovered_link`/`link_divergent` from old discovery pass can repopulate store after `lab_topology` reset | Add `topologyEpoch` counter; bump before clear; capture epoch in each handler, discard write if bumped | `7ac0bf9` |
| LOW-4 | Missing test coverage for re-emission idempotency, stale-event guard, `deleteReconciliation`, and iface decode | 7 new tests in `labWs.test.ts` (162 total, up from 155) | `36fcca1` |

## Verification

```
$ cd frontend && npm run check
COMPLETED 1929 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

$ cd frontend && npm run test
 ✓ tests/canvasEdges.test.ts (29 tests)
 ✓ tests/labWs.test.ts (17 tests)
 ✓ tests/TopologyCanvas.test.ts (3 tests)
 Test Files  19 passed (19)
      Tests  162 passed (162)
```

## US-404 overlap on `canvasEdges.ts`

US-404 merged at 6eea324 before this PR; the rebase absorbed its divergent branch cleanly. Both overlay branches now live in the same unified store + `deriveEdges` signature.

## Test plan

- [x] `cd frontend && npm run check` → 0 errors, 0 warnings
- [x] `cd frontend && npm run test` → 162/162 passing
- [ ] Manual: trigger a kernel-only iface, confirm dashed amber edge appears, right-click → "Promote to declared link" → confirms POST and edge clears immediately (no wait for next WS cycle).
- [ ] Manual: simulate `link_divergent` event, confirm dashed red overlay on the affected declared edge.

## Hotfix pass 2 (codex re-review — MEDIUM-3 only)

Codex re-review confirmed HIGH-1 + MEDIUM-2 resolved. MEDIUM-3 required a second pass: the client-side epoch token could not genuinely close the race because the snapshot and stale events are all delivered synchronously in the same JS turn. The real fix is a **producer-side generation counter** so the frontend can reject events by their origin cycle, not by when they arrived.

| Area | Change | Commit |
|------|--------|--------|
| Backend: `node_runtime_service.py` | `_discovery_generation: dict[str, int]` class attr; incremented at start of each `_discover_lab` call; `generation` field added to all `discovered_link` and `link_divergent` payloads | `a801e3f` |
| Backend: `ws.py` | `lab_topology` snapshot includes `generation: NodeRuntimeService.get_discovery_generation(lab)` at message top level | `a801e3f` |
| Frontend: `labWs.ts` | `lastTopologyGeneration` (sentinel `-1`); both handlers gate on `eventGen <= lastTopologyGeneration` (`<=` is intentional — same-cycle events are also stale); epoch defense kept; `?? -1` backward-compat for legacy backends | `a801e3f` |
| Backend tests | `generation` field asserted in existing payload checks; new `test_discovery_generation_strictly_increasing` verifies two consecutive cycles emit strictly increasing values | `a801e3f` |
| Frontend tests | MEDIUM-3 stale-ordering test rewritten to exercise gen-token gate (4 → dropped, 5 → dropped, 6 → accepted); 4 new backward-compat tests (no-`generation` field → always accepted, for both event types) | `a801e3f` |

**Backward-compat**: if the backend omits `generation` (older deployment), `typeof eventGen === 'number'` is `false` → gate skipped → events accepted. Zero regressions against old backends.

### Updated verification

```
$ cd backend && python -m pytest tests/test_discovery_loop.py -v
11 passed

$ cd backend && python -m pytest --deselect tests/test_migrate_runtime_network.py::test_migrate_continues_on_no_such_network_inspect_error -q
637 passed, 2 skipped

$ cd frontend && npm run check
COMPLETED 1929 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

$ cd frontend && npx vitest run
Test Files  19 passed (19)
     Tests  165 passed (165)   ← was 162 before hotfix pass 2
```