### PR TITLE
Drop incorrect bridge_add assertion from migrate-runtime-network test

### DIFF
--- a/backend/tests/test_migrate_runtime_network.py
+++ b/backend/tests/test_migrate_runtime_network.py
@@ -560,7 +560,9 @@ def test_migrate_continues_on_no_such_network_inspect_error(
     assert backfilled == 1
     assert nodes_stamped == 0
     assert saved["networks"]["1"]["runtime"]["bridge_name"] == expected
-    assert bridge_add_calls == [expected]
+    # Migration only stamps runtime.bridge_name in lab.json; bridge creation
+    # happens at lab boot via NodeRuntimeService, not in this migration.
+    assert bridge_add_calls == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `test_migrate_continues_on_no_such_network_inspect_error` has been asserting `bridge_add_calls == [<expected_name>]` since PR #127, but the migration script never calls `host_net.bridge_add` — it only stamps `runtime.bridge_name` in lab.json. Bridge creation happens at lab boot via `NodeRuntimeService`, not at migration time.
- Update the assertion to match the actual contract.

## Test plan
- [x] `pytest backend/tests/test_migrate_runtime_network.py -v` — 15/15 pass
- [x] `pytest -q` — 641 passed, 2 skipped (full backend suite now green without the longstanding `--deselect`)