### PR TITLE
Render canvas edges and unblock the lab WebSocket on prod

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -43,7 +43,7 @@ async def login(
     response.set_cookie(
         key=settings.SESSION_COOKIE_NAME,
         value=token,
-        path="/api/",
+        path="/",
         httponly=True,
         secure=settings.COOKIE_SECURE,
         samesite=settings.COOKIE_SAMESITE,
@@ -52,7 +52,7 @@ async def login(
     response.set_cookie(
         key=settings.SESSION_USER_COOKIE,
         value=user.username,
-        path="/api/",
+        path="/",
         httponly=True,
         secure=settings.COOKIE_SECURE,
         samesite=settings.COOKIE_SAMESITE,
@@ -164,8 +164,8 @@ async def _logout(
         if user_model:
             await auth_service.destroy_session(user_model)
 
-    response.delete_cookie(key=settings.SESSION_COOKIE_NAME, path="/api/")
-    response.delete_cookie(key=settings.SESSION_USER_COOKIE, path="/api/")
+    response.delete_cookie(key=settings.SESSION_COOKIE_NAME, path="/")
+    response.delete_cookie(key=settings.SESSION_USER_COOKIE, path="/")
     return {
         "code": 200,
         "status": "success",

--- a/deploy/templates/Caddyfile.tpl
+++ b/deploy/templates/Caddyfile.tpl
@@ -13,6 +13,11 @@
             reverse_proxy 127.0.0.1:8000
         }
 
+        @ws path /ws/*
+        handle @ws {
+            reverse_proxy 127.0.0.1:8000
+        }
+
         @html5 path /html5*
         handle @html5 {
             reverse_proxy 127.0.0.1:8081

--- a/frontend/src/lib/components/canvas/NetworkNode.svelte
+++ b/frontend/src/lib/components/canvas/NetworkNode.svelte
@@ -28,8 +28,20 @@
   data-testid="network-node"
   data-network-id={networkId}
 >
+  <!--
+    Each side needs both a source and a target handle with the same id so
+    SvelteFlow accepts edges in either direction (links use
+    sourceHandle=iface-N → targetHandle=network:N:side, so the network side
+    must expose a target handle, not just a source).
+  -->
   <Handle
     type="source"
+    position={Position.Top}
+    id={`network:${networkId}:top`}
+    class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"
+  />
+  <Handle
+    type="target"
     position={Position.Top}
     id={`network:${networkId}:top`}
     class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"
@@ -41,13 +53,31 @@
     class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"
   />
   <Handle
+    type="target"
+    position={Position.Right}
+    id={`network:${networkId}:right`}
+    class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"
+  />
+  <Handle
     type="source"
     position={Position.Bottom}
     id={`network:${networkId}:bottom`}
     class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"
   />
   <Handle
+    type="target"
+    position={Position.Bottom}
+    id={`network:${networkId}:bottom`}
+    class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"
+  />
+  <Handle
     type="source"
+    position={Position.Left}
+    id={`network:${networkId}:left`}
+    class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"
+  />
+  <Handle
+    type="target"
     position={Position.Left}
     id={`network:${networkId}:left`}
     class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"

--- a/frontend/src/lib/components/canvas/Port.svelte
+++ b/frontend/src/lib/components/canvas/Port.svelte
@@ -281,8 +281,18 @@
   on:mouseleave={handleMouseLeave}
 >
   {#if insideFlow}
+    <!--
+      Pair source + target handles at the same id/position so peer-to-peer
+      links (where this iface is the target end) also resolve.
+    -->
     <Handle
       type="source"
+      position={xyPosition}
+      id={`iface-${interfaceIndex}`}
+      class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"
+    />
+    <Handle
+      type="target"
       position={xyPosition}
       id={`iface-${interfaceIndex}`}
       class="!h-1 !w-1 !border-0 !bg-transparent !opacity-0 !pointer-events-none"

--- a/frontend/src/lib/components/canvas/TopologyCanvas.svelte
+++ b/frontend/src/lib/components/canvas/TopologyCanvas.svelte
@@ -170,6 +170,7 @@
   }
 
   function resolveNetworkPeerLabel(networkId: number): string | null {
+    const peers: string[] = [];
     for (const link of localLinks) {
       const fromMatches = link.from?.network_id === networkId;
       const toMatches = link.to?.network_id === networkId;
@@ -178,20 +179,20 @@
       if (!other) continue;
       if (typeof other.node_id === 'number') {
         const peerNode = localNodes[String(other.node_id)];
-        if (!peerNode) return `node ${other.node_id}`;
+        const nodeLabel = peerNode?.name ?? `node ${other.node_id}`;
         const peerIface =
-          typeof other.interface_index === 'number'
+          peerNode && typeof other.interface_index === 'number'
             ? peerNode.interfaces[other.interface_index]
             : undefined;
-        if (peerIface) return `${peerNode.name} · ${peerIface.name}`;
-        return peerNode.name;
-      }
-      if (typeof other.network_id === 'number') {
+        peers.push(peerIface ? `${nodeLabel} · ${peerIface.name}` : nodeLabel);
+      } else if (typeof other.network_id === 'number') {
         const network = localNetworks[String(other.network_id)];
-        return network?.name ?? `network ${other.network_id}`;
+        peers.push(network?.name ?? `network ${other.network_id}`);
       }
     }
-    return null;
+    if (peers.length === 0) return null;
+    if (peers.length === 1) return peers[0];
+    return `${peers.length} peers: ${peers.join(', ')}`;
   }
 
   function getLiveMacFor(nodeId: number, interfaceIndex: number): LiveMacState | null {
@@ -427,6 +428,7 @@
     lastLinksRef = links;
     lastDefaultsRef = defaults;
     syncLocalState();
+    publishFlowState();
   }
 
   $: if (


### PR DESCRIPTION
## Summary
Three independent bugs that all had to be fixed together to make the lab canvas usable on the test VM:

- **SvelteFlow handle types.** `NetworkNode`'s four sides and `Port`'s iface ports were `type="source"` only. SvelteFlow silently drops any edge whose `targetHandle` has no matching `type="target"` handle, which was every link in any lab (`from.node iface → to.network side`). Each side now has a paired `type="target"` handle with the same id.
- **TopologyCanvas reactivity.** `$: { publishFlowState(); }` reads no variables in its block, so Svelte tracks zero deps and the block runs exactly once at mount — before `loadLab()`'s `Promise.all` resolves. `publishFlowState()` now also runs inside the existing "props changed" reactive block so edges/nodes republish whenever new data arrives.
- **Cookie path + Caddy WS proxy.** Backend session cookies were scoped `path="/api/"`, so browsers never sent them on the `/ws/*` upgrade. Caddy's `Caddyfile.tpl` also wasn't forwarding `/ws/*` to the FastAPI upstream. Cookie path is now `/`; Caddy now reverse-proxies `/ws/*`. Logout `delete_cookie` updated to match.

Also widens `resolveNetworkPeerLabel`: the network port-info popover used to show only the first peer for any of the four sides — every port appeared "connected to alpine-a · eth0". It now lists every connected peer.

## Test plan
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npx vitest run` — 165 passed
- [x] `pytest -q` (backend) — 641 passed, 2 skipped
- [x] Manual: edges render on alpine-docker-demo (4/4) on the test VM after Caddy + frontend redeploy
- [x] Manual: WS connects and serves `hello` after the cookie path change