### PR TITLE
Splice docker --network=none containers' console port via setns proxy

### DIFF
--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -434,6 +434,37 @@ def link_netns(iface: str, pid: int) -> None:
     _invoke_helper("link-netns", iface, str(int(pid)))
 
 
+def console_proxy_start(node_pid: int, listen_port: int, target_port: int) -> int:
+    """Spawn the console TCP forwarder for a manual-veth Docker container.
+
+    Returns the daemonized proxy pid so the caller can persist it on the
+    runtime record and tear it down later via :func:`console_proxy_stop`.
+    Required because ``docker run --network=none -p`` does not bring up the
+    Docker userland proxy — there's no container IP to forward to — so the
+    advertised host port is unreachable until we splice in via setns.
+    """
+    proc = _invoke_helper(
+        "console-proxy-start",
+        str(int(node_pid)),
+        str(int(listen_port)),
+        str(int(target_port)),
+    )
+    text = (proc.stdout or "").strip()
+    if not text.isdigit():
+        raise HostNetError(
+            f"console-proxy-start did not return a pid: stdout={text!r} "
+            f"stderr={(proc.stderr or '').strip()!r}",
+            returncode=proc.returncode,
+            stderr=proc.stderr or "",
+        )
+    return int(text)
+
+
+def console_proxy_stop(proxy_pid: int) -> None:
+    """Terminate a previously-spawned console proxy. Idempotent."""
+    _invoke_helper("console-proxy-stop", str(int(proxy_pid)))
+
+
 def link_up(iface: str) -> None:
     """Bring ``iface`` up on the host (``ip link set <iface> up``)."""
     _invoke_helper("link-up", iface)

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1844,6 +1844,27 @@ class NodeRuntimeService:
                 pass
             raise
 
+        # ----- Step 7: console TCP forwarder -------------------------------
+        # docker run --network=none never spawns docker-proxy, so the
+        # advertised host port for the console (-p HOST:CONTAINER above) is
+        # unreachable.  Splice the host port into the container's netns via
+        # the privileged helper.  Best-effort: a missing/failed proxy still
+        # leaves the container usable for non-console operations.
+        console_proxy_pid: int | None = None
+        try:
+            console_proxy_pid = host_net.console_proxy_start(
+                node_pid=pid,
+                listen_port=int(console_port),
+                target_port=int(self._container_console_port(console_mode)),
+            )
+        except Exception as exc:
+            _logger.warning(
+                "console proxy failed to start for lab=%s node=%s: %s",
+                lab_id,
+                node_id,
+                exc,
+            )
+
         work_dir = self._work_dir(lab_id, node_id)
         work_dir.mkdir(parents=True, exist_ok=True)
         return {
@@ -1857,6 +1878,7 @@ class NodeRuntimeService:
             "container_id": result.stdout.strip(),
             "pid": pid,
             "pid_create_time": pid_create_time,
+            "console_proxy_pid": console_proxy_pid,
             "work_dir": str(work_dir),
             "stdout_log": str(work_dir / "stdout.log"),
             "stderr_log": str(work_dir / "stderr.log"),
@@ -3543,6 +3565,16 @@ class NodeRuntimeService:
         container_name = runtime.get("container_name")
         if not container_name:
             return
+
+        # Stop the console TCP forwarder before tearing down the container so
+        # in-flight client connections see a clean refused-after-stop instead
+        # of hanging until the proxy notices the netns is gone.
+        proxy_pid = runtime.get("console_proxy_pid")
+        if proxy_pid:
+            try:
+                host_net.console_proxy_stop(int(proxy_pid))
+            except Exception:
+                pass
 
         subprocess.run(
             [docker_binary, "--host", self.settings.DOCKER_HOST, "stop", "-t", "5", container_name],

--- a/deploy/nova-ve-console-proxy.py
+++ b/deploy/nova-ve-console-proxy.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""TCP forwarder from host:LISTEN_PORT to a netns-confined target:TARGET_PORT.
+
+Used by the nova-ve runtime to expose a Docker container's console port to the
+host when the container was started with ``--network none`` (Wave-6 manual-veth
+path). Without this proxy the ``docker run -p`` flag does nothing because
+Docker only spawns its userland ``docker-proxy`` for containers with at least
+one Docker-managed network.
+
+Listens on ``127.0.0.1:LISTEN_PORT`` in the default netns. For each accepted
+connection it forks a worker, joins the container's netns via setns(2), opens
+a TCP connection to ``127.0.0.1:TARGET_PORT`` inside that namespace, and
+splices bytes both ways with select(2). The worker exits when either side
+closes; the parent keeps accepting.
+
+Invocation (root):
+    nova-ve-console-proxy.py <node_pid> <listen_port> <target_port>
+
+The script blocks. The privileged helper detaches it via ``setsid`` + ``Popen``
+and returns the spawned PID.
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import select
+import signal
+import socket
+import sys
+from typing import NoReturn
+
+CLONE_NEWNET = 0x40000000
+
+
+def _setns_to_pid(pid: int) -> None:
+    libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+    fd = os.open(f"/proc/{pid}/ns/net", os.O_RDONLY)
+    try:
+        rc = libc.setns(fd, CLONE_NEWNET)
+    finally:
+        os.close(fd)
+    if rc != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"setns(/proc/{pid}/ns/net, NEWNET) failed: {os.strerror(err)}")
+
+
+def _splice(a: socket.socket, b: socket.socket) -> None:
+    """Bidirectionally forward bytes between two sockets until either closes."""
+    socks = [a, b]
+    try:
+        while True:
+            readable, _, errored = select.select(socks, [], socks, None)
+            if errored:
+                return
+            for src in readable:
+                try:
+                    chunk = src.recv(65536)
+                except OSError:
+                    return
+                if not chunk:
+                    return
+                dst = b if src is a else a
+                try:
+                    dst.sendall(chunk)
+                except OSError:
+                    return
+    finally:
+        for s in socks:
+            try:
+                s.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                s.close()
+            except OSError:
+                pass
+
+
+def _serve_one(client: socket.socket, target_pid: int, target_port: int) -> NoReturn:
+    """Worker: enter ``target_pid``'s netns, dial 127.0.0.1:target_port, splice."""
+    try:
+        _setns_to_pid(target_pid)
+        upstream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        upstream.connect(("127.0.0.1", target_port))
+    except OSError:
+        try:
+            client.close()
+        except OSError:
+            pass
+        os._exit(1)
+    _splice(client, upstream)
+    os._exit(0)
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print("usage: nova-ve-console-proxy.py <pid> <listen_port> <target_port>", file=sys.stderr)
+        return 2
+
+    try:
+        target_pid = int(sys.argv[1])
+        listen_port = int(sys.argv[2])
+        target_port = int(sys.argv[3])
+    except ValueError:
+        print("non-integer argument", file=sys.stderr)
+        return 2
+
+    if target_pid <= 1 or not (1024 <= listen_port <= 65535) or not (1 <= target_port <= 65535):
+        print("argument out of range", file=sys.stderr)
+        return 2
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", listen_port))
+    listener.listen(64)
+
+    # Reap zombie workers.
+    signal.signal(signal.SIGCHLD, signal.SIG_IGN)
+
+    while True:
+        try:
+            client, _addr = listener.accept()
+        except OSError:
+            continue
+        # Refuse to forward if the target netns has gone away (container died).
+        if not os.path.exists(f"/proc/{target_pid}/ns/net"):
+            try:
+                client.close()
+            except OSError:
+                pass
+            return 0
+        worker = os.fork()
+        if worker == 0:
+            try:
+                listener.close()
+            except OSError:
+                pass
+            _serve_one(client, target_pid, target_port)
+        else:
+            try:
+                client.close()
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/nova-ve-net.py
+++ b/deploy/nova-ve-net.py
@@ -82,6 +82,14 @@ RE_NETNS_IFACE = re.compile(r"^eth[0-9]{1,2}$")
 # Pid: 1-7 digits.  Additional runtime checks reject pid<10 and pid==1.
 RE_PID = re.compile(r"^[0-9]{1,7}$")
 
+# TCP port (numeric, 1-65535).
+RE_PORT = re.compile(r"^[0-9]{1,5}$")
+
+# Path to the bundled console TCP forwarder.  Test override via env var.
+CONSOLE_PROXY_BIN = os.environ.get(
+    "NOVA_VE_CONSOLE_PROXY_BIN", "/opt/nova-ve/bin/nova-ve-console-proxy.py"
+)
+
 
 # Sentinel returned by validate_pid for pids in the kernel/init reserved
 # range or non-matching the registry.
@@ -398,6 +406,134 @@ def cmd_read_iface_mac(args: argparse.Namespace) -> int:
     return _nsenter_cat_address(pid, iface)
 
 
+def _validate_port(value: str, *, label: str) -> int:
+    """Reject anything that isn't a 1-5 digit base-10 TCP port."""
+    if not RE_PORT.fullmatch(value):
+        raise _ValidationError(f"{label} must match {RE_PORT.pattern}")
+    port = int(value)
+    if not (1 <= port <= 65535):
+        raise _ValidationError(f"{label} out of range: {port}")
+    return port
+
+
+def cmd_console_proxy_start(args: argparse.Namespace) -> int:
+    """Spawn the console TCP forwarder for a manual-veth Docker container.
+
+    Authorizes the target pid against the runtime registry, then double-forks
+    the proxy script with ``setsid`` so it survives the helper exiting.
+    Prints the daemonized PID to stdout (caller persists it for later kill).
+    """
+    target_pid = authorize_pid(args.pid)
+    listen_port = _validate_port(args.listen_port, label="listen_port")
+    target_port = _validate_port(args.target_port, label="target_port")
+    if listen_port < 1024:
+        raise _ValidationError(
+            "listen_port must be a non-privileged port (>=1024)"
+        )
+
+    if not os.access(CONSOLE_PROXY_BIN, os.X_OK):
+        print(
+            f"console proxy binary missing or not executable: {CONSOLE_PROXY_BIN}",
+            file=sys.stderr,
+        )
+        return 1
+
+    pipe_r, pipe_w = os.pipe()
+
+    # Detach via double-fork + setsid so the proxy survives the helper exit
+    # and is reparented to PID 1 (no zombie / no stdio held open).
+    pid = os.fork()
+    if pid == 0:
+        try:
+            os.close(pipe_r)
+            os.setsid()
+            second = os.fork()
+            if second == 0:
+                # Grandchild: replace with the proxy.
+                os.close(pipe_w)
+                devnull = os.open(os.devnull, os.O_RDWR)
+                os.dup2(devnull, 0)
+                os.dup2(devnull, 1)
+                os.dup2(devnull, 2)
+                if devnull > 2:
+                    os.close(devnull)
+                os.execv(
+                    CONSOLE_PROXY_BIN,
+                    [
+                        CONSOLE_PROXY_BIN,
+                        str(target_pid),
+                        str(listen_port),
+                        str(target_port),
+                    ],
+                )
+            else:
+                os.write(pipe_w, f"{second}\n".encode("ascii"))
+                os._exit(0)
+        except Exception as exc:
+            try:
+                os.write(pipe_w, f"err:{exc}\n".encode("ascii"))
+            except OSError:
+                pass
+            os._exit(1)
+    # Parent: read the grandchild PID, reap the first child, then return.
+    os.close(pipe_w)
+    with os.fdopen(pipe_r, "r") as r:
+        line = r.readline().strip()
+    os.waitpid(pid, 0)
+    if line.startswith("err:") or not line.isdigit():
+        print(f"console proxy spawn failed: {line}", file=sys.stderr)
+        return 1
+    print(line)
+    return 0
+
+
+def cmd_console_proxy_stop(args: argparse.Namespace) -> int:
+    """Terminate a previously-spawned console proxy by PID.
+
+    Validates the PID shape, confirms ``/proc/<pid>/comm`` looks like a
+    Python interpreter running the bundled proxy script (so we never SIGTERM
+    an unrelated process if the registry is stale), then sends SIGTERM
+    followed by SIGKILL on a short grace period.
+    """
+    if not RE_PID.fullmatch(args.pid):
+        raise _ValidationError("pid argument failed validation")
+    pid = int(args.pid)
+    if pid <= 1:
+        raise _ValidationError("pid out of range")
+
+    cmdline_path = PROC_ROOT / str(pid) / "cmdline"
+    try:
+        cmdline = cmdline_path.read_bytes().split(b"\x00")
+    except FileNotFoundError:
+        return 0  # already gone — idempotent
+    except PermissionError:
+        cmdline = []
+    if not any(b"nova-ve-console-proxy" in arg for arg in cmdline):
+        # Refuse to kill an unrelated process (PID recycled or stale registry).
+        print(
+            f"pid {pid} does not look like nova-ve-console-proxy; refusing to kill",
+            file=sys.stderr,
+        )
+        return 1
+
+    import time
+    try:
+        os.kill(pid, 15)
+    except ProcessLookupError:
+        return 0
+    for _ in range(20):
+        time.sleep(0.05)
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return 0
+    try:
+        os.kill(pid, 9)
+    except ProcessLookupError:
+        pass
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # argparse wiring
 # ---------------------------------------------------------------------------
@@ -417,6 +553,8 @@ VERB_TABLE: Mapping[str, Callable[[argparse.Namespace], int]] = {
     "addr-add-in-netns": cmd_addr_add_in_netns,
     "addr-up-in-netns": cmd_addr_up_in_netns,
     "read-iface-mac": cmd_read_iface_mac,
+    "console-proxy-start": cmd_console_proxy_start,
+    "console-proxy-stop": cmd_console_proxy_stop,
 }
 
 
@@ -489,6 +627,24 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("pid")
     p.add_argument("iface")
+
+    p = sub.add_parser(
+        "console-proxy-start",
+        help=(
+            "spawn nova-ve-console-proxy.py to forward 127.0.0.1:<listen_port> "
+            "into the netns of <pid> at 127.0.0.1:<target_port>; prints the "
+            "spawned proxy PID"
+        ),
+    )
+    p.add_argument("pid")
+    p.add_argument("listen_port")
+    p.add_argument("target_port")
+
+    p = sub.add_parser(
+        "console-proxy-stop",
+        help="kill a previously-spawned console proxy by pid (idempotent)",
+    )
+    p.add_argument("pid")
 
     return parser
 

--- a/deploy/scripts/provision-ubuntu-2604.sh
+++ b/deploy/scripts/provision-ubuntu-2604.sh
@@ -194,14 +194,19 @@ PY
 install_nova_ve_net_helper() {
   # US-201: install the privileged network helper at /opt/nova-ve/bin and
   # drop the sudoers fragment into /etc/sudoers.d after a visudo dry-run.
+  # Also install nova-ve-console-proxy.py: the helper's
+  # console-proxy-start verb execs it, so the path must be present.
   local helper_src="${REPO_ROOT}/deploy/nova-ve-net.py"
+  local proxy_src="${REPO_ROOT}/deploy/nova-ve-console-proxy.py"
   local sudoers_src="${REPO_ROOT}/deploy/nova-ve-sudoers"
   local helper_dst="/opt/nova-ve/bin/nova-ve-net.py"
+  local proxy_dst="/opt/nova-ve/bin/nova-ve-console-proxy.py"
   local sudoers_dst="/etc/sudoers.d/nova-ve"
 
   if [[ "${DRY_RUN}" -eq 1 ]]; then
     echo "+ install -d -o root -g root -m 0755 /opt/nova-ve/bin"
     echo "+ install -m 0755 -o root -g root ${helper_src} ${helper_dst}"
+    echo "+ install -m 0755 -o root -g root ${proxy_src} ${proxy_dst}"
     echo "+ visudo -cf ${sudoers_src}"
     echo "+ install -m 0440 -o root -g root ${sudoers_src} ${sudoers_dst}"
     return 0
@@ -209,6 +214,7 @@ install_nova_ve_net_helper() {
 
   install -d -o root -g root -m 0755 /opt/nova-ve /opt/nova-ve/bin
   install -m 0755 -o root -g root "${helper_src}" "${helper_dst}"
+  install -m 0755 -o root -g root "${proxy_src}" "${proxy_dst}"
   if ! visudo -cf "${sudoers_src}" >/dev/null; then
     echo "visudo rejected ${sudoers_src}; aborting deploy" >&2
     exit 1


### PR DESCRIPTION
## Summary
Wave-6 Docker nodes start with `--network=none`, so manual veth wiring to the lab's Linux bridge is the only network the container ever sees. The `-p HOST:CONTAINER` flag still tells Docker to record a port binding, but Docker only spawns its userland `docker-proxy` for containers attached to a Docker-managed network — so freshly created nodes had a "published" port that nothing actually listened on, and guacd's telnet to `127.0.0.1:CONSOLE_PORT` was refused. Old labs only worked because their containers were still attached to the legacy default bridge from before the migration.

This PR adds a tiny Python TCP forwarder (`deploy/nova-ve-console-proxy.py`) that listens on `127.0.0.1:LISTEN_PORT` in the host netns and, for each accepted connection, forks a worker that calls `setns(2)` to join the container's netns, dials `127.0.0.1:TARGET_PORT` inside it, and splices bytes both ways with `select(2)`.

Two new privileged-helper verbs (`console-proxy-start` / `console-proxy-stop`) bracket the proxy lifecycle:
- `start` authorizes the container PID against the runtime registry, double-forks the proxy with `setsid` so it survives the helper exiting, and prints the daemon PID.
- `stop` validates the PID's `/proc/<pid>/cmdline` points at the bundled proxy script before SIGTERM/SIGKILL so a recycled PID can never be misfired.

`NodeRuntimeService` now calls `host_net.console_proxy_start` after veth setup and persists the proxy PID on the runtime record; `_stop_docker_runtime` calls `console_proxy_stop` before tearing down the container.

`provision-ubuntu-2604.sh` installs the proxy script alongside `nova-ve-net.py`.

## Test plan
- [x] `pytest -q` (backend) — 641 passed, 2 skipped
- [x] Live test on test VM:
  - `nc -z 127.0.0.1 <console_port>` succeeded for a freshly-started `--network=none` node where it previously refused
  - Telnet round-trip into the container worked (IAC negotiation + echo)
  - `ps -ef | grep nova-ve-console-proxy` shows exactly one running proxy per started node
  - Stop+start cycles a new proxy PID; old one is killed cleanly