### PR TITLE
Bind console proxy to 0.0.0.0 so guacd in compose can reach it

### DIFF
--- a/deploy/nova-ve-console-proxy.py
+++ b/deploy/nova-ve-console-proxy.py
@@ -10,11 +10,13 @@ path). Without this proxy the ``docker run -p`` flag does nothing because
 Docker only spawns its userland ``docker-proxy`` for containers with at least
 one Docker-managed network.
 
-Listens on ``127.0.0.1:LISTEN_PORT`` in the default netns. For each accepted
-connection it forks a worker, joins the container's netns via setns(2), opens
-a TCP connection to ``127.0.0.1:TARGET_PORT`` inside that namespace, and
-splices bytes both ways with select(2). The worker exits when either side
-closes; the parent keeps accepting.
+Listens on ``0.0.0.0:LISTEN_PORT`` in the default netns — same wildcard bind
+the stock ``docker-proxy`` uses so guacd (running in its own compose
+container) can reach the listener via ``host.docker.internal``. For each
+accepted connection it forks a worker, joins the container's netns via
+setns(2), opens a TCP connection to ``127.0.0.1:TARGET_PORT`` inside that
+namespace, and splices bytes both ways with select(2). The worker exits when
+either side closes; the parent keeps accepting.
 
 Invocation (root):
     nova-ve-console-proxy.py <node_pid> <listen_port> <target_port>
@@ -115,7 +117,9 @@ def main() -> int:
 
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    listener.bind(("127.0.0.1", listen_port))
+    # Bind 0.0.0.0 so guacd (in its own compose container) can reach this
+    # listener via host.docker.internal — matches stock docker-proxy.
+    listener.bind(("0.0.0.0", listen_port))
     listener.listen(64)
 
     # Reap zombie workers.


### PR DESCRIPTION
## Summary
guacd runs in the compose-guacd container and connects to lab consoles via `host.docker.internal`, which resolves to the docker bridge gateway (`172.17.0.1`). The proxy from #149 was binding to `127.0.0.1`, so the connection from guacd was refused — every console open after that change showed "You have been disconnected" in the guacamole iframe.

`0.0.0.0` matches what stock `docker-proxy` does (no host IP in `-p HOST:CONTAINER` means wildcard bind), so this restores the same reachability the legacy default-bridge nodes already had.

## Test plan
- [x] Live test on test VM:
  - `pgrep -af nova-ve-console-proxy.py` shows `0.0.0.0:38279` listener after node restart
  - `docker exec compose-guacd-1 nc -zv host.docker.internal 38279` succeeds (was "Connection refused" before)
  - Right-click → Console on docker-test-a in the canvas now opens an interactive `docker-test-a:/#` shell prompt