### PR TITLE
Reconcile lab bridges on open and self-heal missing bridges at link create

### DIFF
--- a/backend/app/routers/links.py
+++ b/backend/app/routers/links.py
@@ -12,12 +12,14 @@ from fastapi.responses import JSONResponse
 
 from app.dependencies import get_current_user
 from app.schemas.user import UserRead
+from app.services import host_net
 from app.services.lab_service import LEGACY_SCHEMA_ERROR
 from app.services.link_service import (
     DuplicateLinkError,
     LinkContentionError,
     link_service,
 )
+from app.services.node_runtime_service import NodeRuntimeError
 
 
 router = APIRouter(prefix="/api/labs", tags=["links"])
@@ -141,6 +143,19 @@ async def create_link(
                 "message": str(exc),
             },
         )
+    except (NodeRuntimeError, host_net.HostNetError) as exc:
+        # Hot-attach refused or kernel-side bridge/veth/TAP work failed.
+        # Surface the real reason instead of a bare 500 so the canvas can
+        # show an actionable toast (e.g. ownership mismatch, bridge
+        # provisioning failure, runtime not in expected state).
+        return JSONResponse(
+            status_code=422,
+            content={
+                "code": 422,
+                "status": "fail",
+                "message": str(exc),
+            },
+        )
 
     response: Dict[str, Any] = {
         "code": 200 if replayed else 201,
@@ -180,6 +195,15 @@ async def delete_link(
                 "message": str(exc),
             },
         )
+    except (NodeRuntimeError, host_net.HostNetError) as exc:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "code": 422,
+                "status": "fail",
+                "message": str(exc),
+            },
+        )
 
     if not existed:
         return {
@@ -207,7 +231,17 @@ async def patch_link(
     if err is not None:
         return err
 
-    updated = await link_service.patch_link(lab_path, link_id, body)
+    try:
+        updated = await link_service.patch_link(lab_path, link_id, body)
+    except (NodeRuntimeError, host_net.HostNetError) as exc:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "code": 422,
+                "status": "fail",
+                "message": str(exc),
+            },
+        )
     if updated is None:
         return JSONResponse(
             status_code=404,

--- a/backend/app/routers/networks.py
+++ b/backend/app/routers/networks.py
@@ -176,3 +176,28 @@ async def patch_network(
         "event": event_type,
         "network": payload,
     }
+
+
+@router.post("/{lab_path:path}/runtime/reconcile")
+async def reconcile_runtime(
+    lab_path: str,
+    current_user: UserRead = Depends(get_current_user),
+):
+    """Idempotently ensure host bridges for every network in the lab.
+
+    Called by the canvas on lab open so labs restored from static JSON
+    or labs whose bridges were lost (host reboot, manual removal) find
+    their host state already provisioned by the time the user starts a
+    node or creates a link.
+    """
+    data, err = _read_lab_or_error(lab_path)
+    if err is not None:
+        return err
+
+    summary = network_service.ensure_lab_bridges(lab_path)
+    return {
+        "code": 200,
+        "status": "success",
+        "message": "Runtime reconciliation completed.",
+        "data": summary,
+    }

--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -465,6 +465,15 @@ def console_proxy_stop(proxy_pid: int) -> None:
     _invoke_helper("console-proxy-stop", str(int(proxy_pid)))
 
 
+def console_proxy_alive(proxy_pid: int) -> bool:
+    """Return True if ``proxy_pid`` still refers to a running console proxy."""
+    try:
+        cmdline = (Path("/proc") / str(int(proxy_pid)) / "cmdline").read_bytes().split(b"\x00")
+        return any(b"nova-ve-console-proxy" in arg for arg in cmdline)
+    except OSError:
+        return False
+
+
 def link_up(iface: str) -> None:
     """Bring ``iface`` up on the host (``ip link set <iface> up``)."""
     _invoke_helper("link-up", iface)

--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -519,10 +519,11 @@ def tap_del(name: str) -> None:
 def link_del(name: str) -> None:
     """Delete a host-side link (TAP or veth host-end) via the helper.
 
-    The helper reuses the ``tap-del`` verb (``ip link del``) which works for
-    veth host-ends as well — deleting the host end auto-removes the peer.
+    Uses the helper's ``link-del`` verb whose validator accepts both TAP
+    and veth host-end names. Deleting the host end of a veth pair
+    auto-removes the peer.
     """
-    _invoke_helper("tap-del", name)
+    _invoke_helper("link-del", name)
 
 
 def try_link_del(name: str) -> None:

--- a/backend/app/services/host_net.py
+++ b/backend/app/services/host_net.py
@@ -497,12 +497,24 @@ def read_iface_mac(pid: int, iface: str) -> str:
     return (proc.stdout or "").strip()
 
 
+def tap_exists(name: str) -> bool:
+    """Return True if a Linux interface named ``name`` currently exists.
+
+    Uses the same unprivileged ``ip link show`` check as ``bridge_exists``.
+    """
+    try:
+        proc = _run([_ip_bin(), "link", "show", name])
+    except FileNotFoundError:
+        return False
+    return proc.returncode == 0
+
+
 def tap_add(name: str) -> None:
     """Create a Linux TAP device with ``name`` via the privileged helper.
 
     Used by the QEMU start path (US-302): one TAP per NIC, attached to the
     network's bridge before QEMU launches with ``-netdev tap,ifname=...``.
-    Raises :class:`HostNetEEXIST` if a link with ``name`` already exists.
+    Raises :class:`HostNetUnknown` if the kernel rejects the creation.
     """
     _invoke_helper("tap-add", name)
 

--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -694,6 +694,7 @@ class LinkService:
         # ``attached`` carries the kind so rollback can pick the matching
         # cleanup path (veth host-end for docker, TAP for qemu).
         attached: List[Tuple[int, int, str]] = []
+        bridges_to_raise: List[str] = []
         try:
             for node_id, interface_index, network_id, bridge, kind in attach_targets:
                 # US-204b: the per-(lab, node, iface) mutex is held by the
@@ -717,6 +718,8 @@ class LinkService:
                         bridge_name=bridge,
                     )
                 attached.append((node_id, interface_index, kind))
+                if bridge not in bridges_to_raise:
+                    bridges_to_raise.append(bridge)
 
                 # US-204b: stamp the link's ``runtime.attach_generation``
                 # under lab_lock — atomic with the lab.json write so the
@@ -731,6 +734,19 @@ class LinkService:
                     network_id=network_id,
                     attach_generation=attach_generation,
                 )
+
+                if kind == "qemu":
+                    # Best-effort: a hot-added QEMU NIC starts at link=on
+                    # by default, but if the boot-time NIC at this index
+                    # was created with ``link=off`` (the unconnected
+                    # branch in the boot path), set_link forces the
+                    # guest-visible carrier to match the lab JSON. QMP
+                    # errors here are non-fatal — the attach itself
+                    # already succeeded and the next reconcile will
+                    # correct any drift.
+                    runtime_service.set_qemu_nic_link(
+                        lab_id, node_id, interface_index, up=True
+                    )
         except (NodeRuntimeError, NodeRuntimeQMPTimeout, host_net.HostNetError):
             # US-303 codex iter1 HIGH-1: NodeRuntimeQMPTimeout is a
             # subclass of NodeRuntimeError so the listing is technically
@@ -802,6 +818,22 @@ class LinkService:
                 except host_net.HostNetError:
                     pass
             raise
+
+        # Force every bridge that just had a port attached to UP. Linux
+        # bridges with admin-down state hold their slave ports in
+        # ``state disabled`` so packets do not forward — even though the
+        # slaves themselves are up. Best-effort: failures here only mean
+        # we will try again on the next link create or reconcile pass.
+        for bridge_name in bridges_to_raise:
+            try:
+                host_net.link_up(bridge_name)
+            except host_net.HostNetError as exc:
+                _logger.warning(
+                    "create_link: link_up(%s) failed (%s); will retry "
+                    "on next attach or reconcile",
+                    bridge_name,
+                    exc,
+                )
 
         return bool(attached)
 
@@ -1081,6 +1113,16 @@ class LinkService:
                                 primary_error,
                             )
                 elif kind == "qemu":
+                    # Pin guest-visible carrier OFF before tearing the
+                    # device down. The hot-detach path will remove the
+                    # device entirely on the happy path, so this is
+                    # mostly belt-and-suspenders for the forced-fallback
+                    # branch (where ``netdev_del`` is skipped and the
+                    # device lingers until guest reboot). Best-effort.
+                    runtime_service.set_qemu_nic_link(
+                        mutex_lab_id, int(node_id), int(iface_idx), up=False
+                    )
+
                     # US-304: hot-detach via QMP. Mutex is held by the
                     # caller (delete_link) so we use the PRIVATE locked
                     # helper directly to avoid re-acquiring on the same

--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -653,16 +653,41 @@ class LinkService:
                 (node_id, interface_index, network_id, bridge, kind)
             )
 
-        # Provision the implicit network's bridge exactly once before any
-        # attach call (Codex critic v4 new defect #3). Idempotent: pre-existing
-        # bridge is treated as a no-op.
-        provisioned_implicit_bridge: Optional[str] = None
+        # Provision missing host bridges before any attach call.
+        # 1. Implicit network's bridge (Codex critic v4 new defect #3) — created
+        #    exactly once per ``create_link`` call.
+        # 2. Self-heal for explicit networks: labs loaded from static JSON or
+        #    labs whose bridges were lost (host reboot, manual cleanup) never
+        #    went through ``create_network`` so their bridges are absent. Mirror
+        #    the implicit-bridge auto-provision so a link create succeeds
+        #    end-to-end. The lab-open ``ensure_lab_bridges`` reconciliation is
+        #    the primary path; this is the belt-and-suspenders for any lab
+        #    where reconciliation hasn't run yet (e.g. direct API call).
+        # Idempotent: pre-existing bridges are no-ops. We track every bridge
+        # *we* provisioned so a downstream attach failure rolls them back.
+        provisioned_bridges: List[str] = []
+        implicit_net_id_value: Optional[int] = None
         if resolved_implicit_bridge is not None:
-            net_id, bridge_name = resolved_implicit_bridge
-            if any(target[2] == net_id for target in attach_targets):
+            implicit_net_id_value, bridge_name = resolved_implicit_bridge
+            if any(target[2] == implicit_net_id_value for target in attach_targets):
                 if not host_net.bridge_exists(bridge_name):
                     host_net.bridge_add(bridge_name)
-                    provisioned_implicit_bridge = bridge_name
+                    provisioned_bridges.append(bridge_name)
+        seen_explicit_bridges: set = set()
+        for _node_id, _iface, network_id, bridge, _kind in attach_targets:
+            if network_id == implicit_net_id_value:
+                continue  # already handled above
+            if bridge in seen_explicit_bridges:
+                continue
+            seen_explicit_bridges.add(bridge)
+            if not host_net.bridge_exists(bridge):
+                host_net.bridge_add(bridge)
+                provisioned_bridges.append(bridge)
+                # Stamp ownership so future reconciliations recognise it as ours.
+                try:
+                    host_net.bridge_fingerprint_write(bridge, lab_id, network_id)
+                except host_net.HostNetError:
+                    pass
 
         # Attach each target. On the FIRST failure, sweep the bridges + every
         # already-attached interface so we leave no host-side leftover.
@@ -771,9 +796,9 @@ class LinkService:
                     ]
                     runtime["tap_names"] = tap_names
                     runtime_service._persist_runtime(runtime)
-            if provisioned_implicit_bridge is not None:
+            for bridge_name in provisioned_bridges:
                 try:
-                    host_net.bridge_del(provisioned_implicit_bridge)
+                    host_net.bridge_del(bridge_name)
                 except host_net.HostNetError:
                     pass
             raise

--- a/backend/app/services/network_service.py
+++ b/backend/app/services/network_service.py
@@ -327,7 +327,9 @@ class NetworkService:
             if dirty:
                 LabService.write_lab_json_static(normalized, data)
 
-            nic_link_state = _reconcile_qemu_nic_link_state(lab_id, data)
+        # QMP set_link calls are idempotent and read-only w.r.t. lab.json —
+        # run outside the lock to avoid holding it for O(nodes × NICs × 2s).
+        nic_link_state = _reconcile_qemu_nic_link_state(lab_id, data)
 
         return {
             "ensured": ensured,

--- a/backend/app/services/network_service.py
+++ b/backend/app/services/network_service.py
@@ -95,6 +95,95 @@ def _bridge_ownership_message(bridge: str, lab_id: str, network_id: int) -> str:
     )
 
 
+def _network_ids_with_links(lab_data: dict) -> set:
+    """Return the set of ``network_id`` values referenced by any link."""
+    ids: set = set()
+    for link in lab_data.get("links", []) or []:
+        for endpoint in (link.get("from"), link.get("to")):
+            if not isinstance(endpoint, dict):
+                continue
+            if "network_id" in endpoint:
+                try:
+                    ids.add(int(endpoint["network_id"]))
+                except (TypeError, ValueError):
+                    continue
+    return ids
+
+
+def _connected_iface_indices_by_node(lab_data: dict) -> Dict[int, set]:
+    """Return ``{node_id: set(interface_index)}`` for indices that appear in any link."""
+    out: Dict[int, set] = {}
+    for link in lab_data.get("links", []) or []:
+        for endpoint in (link.get("from"), link.get("to")):
+            if not isinstance(endpoint, dict):
+                continue
+            if "node_id" not in endpoint:
+                continue
+            try:
+                node_id = int(endpoint["node_id"])
+                iface = int(endpoint.get("interface_index", 0))
+            except (TypeError, ValueError):
+                continue
+            out.setdefault(node_id, set()).add(iface)
+    return out
+
+
+def _reconcile_qemu_nic_link_state(
+    lab_id: str, lab_data: dict
+) -> List[Dict[str, Any]]:
+    """Walk running QEMU nodes and force per-NIC carrier state via QMP set_link.
+
+    Returns one record per NIC index touched, shape ``{"node_id", "interface_index",
+    "up", "ok", "reason"?}``. Best-effort: any per-node failure is captured in the
+    return value and does not raise.
+    """
+    # Local import — node_runtime_service imports network_service at runtime
+    # (e.g. via ``LabService``), so a top-level import would cycle.
+    from app.services.node_runtime_service import NodeRuntimeService
+
+    out: List[Dict[str, Any]] = []
+    nodes = lab_data.get("nodes") or {}
+    if not nodes:
+        return out
+
+    connected = _connected_iface_indices_by_node(lab_data)
+    runtime_service = NodeRuntimeService()
+
+    for raw_id, node in nodes.items():
+        if not isinstance(node, dict):
+            continue
+        if str(node.get("type") or "").lower() != "qemu":
+            continue
+        try:
+            node_id = int(node.get("id", raw_id))
+        except (TypeError, ValueError):
+            continue
+        ethernet = int(node.get("ethernet", 0) or 0)
+        if ethernet <= 0:
+            continue
+        runtime = runtime_service._runtime_record(lab_id, node_id)
+        if runtime is None:
+            continue
+
+        node_connected = connected.get(node_id, set())
+        for index in range(ethernet):
+            up = index in node_connected
+            ok, reason = runtime_service.set_qemu_nic_link(
+                lab_id, node_id, index, up=up
+            )
+            entry: Dict[str, Any] = {
+                "node_id": node_id,
+                "interface_index": index,
+                "up": up,
+                "ok": ok,
+            }
+            if not ok and reason:
+                entry["reason"] = reason
+            out.append(entry)
+
+    return out
+
+
 class NetworkService:
     def list_networks(self, lab_path: str, *, include_hidden: bool = False) -> Dict[str, dict]:
         """Return networks keyed by string id, mirroring legacy router shape.
@@ -134,7 +223,20 @@ class NetworkService:
         bridge removal — labs restored from static JSON never went through
         ``create_network`` so their bridges were never provisioned.
 
-        Returns ``{"ensured": [...], "created": [...], "skipped": [...]}``.
+        Bridges that have at least one link endpoint pointing at them are
+        forced ``UP`` after the existence/fingerprint check so a bridge
+        with active ports never sits in admin-down (slave ports go to
+        ``state disabled`` and forwarding stops, even though the slaves
+        themselves are up).
+
+        For every running QEMU node, the matching netdev's QMP link state
+        is set to ``on`` for connected NIC indices and ``off`` for
+        unconnected ones. This is independent of TAP-vs-hubport backing,
+        so it works on already-running VMs whose unconnected NICs were
+        booted before the ``link=off`` device-line fix landed.
+
+        Returns ``{"ensured": [...], "created": [...], "skipped": [...],
+        "raised": [...], "nic_link_state": [...]}``.
         """
         normalized = _normalize_relative_lab_path(lab_path)
         labs_dir = get_settings().LABS_DIR
@@ -142,11 +244,14 @@ class NetworkService:
         ensured: List[str] = []
         created: List[str] = []
         skipped: List[Dict[str, Any]] = []
+        raised: List[str] = []
+        nic_link_state: List[Dict[str, Any]] = []
 
         with lab_lock(normalized, labs_dir):
             data = LabService.read_lab_json_static(normalized)
             lab_id = str(data.get("id") or normalized)
             networks = data.get("networks") or {}
+            networks_with_links = _network_ids_with_links(data)
             dirty = False
             for key, network in networks.items():
                 if not isinstance(network, dict):
@@ -202,6 +307,18 @@ class NetworkService:
                     })
                     continue
 
+                if network_id in networks_with_links:
+                    try:
+                        host_net.link_up(bridge)
+                        raised.append(bridge)
+                    except host_net.HostNetError as exc:
+                        logger.warning(
+                            "ensure_lab_bridges: link_up(%s) failed (%s); "
+                            "bridge will stay admin-down until next reconcile",
+                            bridge,
+                            exc,
+                        )
+
                 existing_runtime = network.setdefault("runtime", {})
                 if existing_runtime.get("bridge_name") != bridge:
                     existing_runtime["bridge_name"] = bridge
@@ -210,7 +327,15 @@ class NetworkService:
             if dirty:
                 LabService.write_lab_json_static(normalized, data)
 
-        return {"ensured": ensured, "created": created, "skipped": skipped}
+            nic_link_state = _reconcile_qemu_nic_link_state(lab_id, data)
+
+        return {
+            "ensured": ensured,
+            "created": created,
+            "skipped": skipped,
+            "raised": raised,
+            "nic_link_state": nic_link_state,
+        }
 
     async def create_network(self, lab_path: str, request: dict) -> dict:
         normalized = _normalize_relative_lab_path(lab_path)

--- a/backend/app/services/network_service.py
+++ b/backend/app/services/network_service.py
@@ -121,6 +121,97 @@ class NetworkService:
             out[str(net_id)] = _serialize_network(network, _refcount(data, net_id))
         return out
 
+    def ensure_lab_bridges(self, lab_path: str) -> dict:
+        """Idempotently provision the host bridge for every network in the lab.
+
+        Walks ``data["networks"]``, resolves each network's expected bridge
+        name (``runtime.bridge_name`` if stamped, else
+        ``host_net.bridge_name``), and creates the bridge on the host if
+        absent. Stamps the resolved name back onto the network record so
+        future resolves don't rely on the canonical-derive path.
+
+        Called on lab open to recover host state after a reboot or manual
+        bridge removal — labs restored from static JSON never went through
+        ``create_network`` so their bridges were never provisioned.
+
+        Returns ``{"ensured": [...], "created": [...], "skipped": [...]}``.
+        """
+        normalized = _normalize_relative_lab_path(lab_path)
+        labs_dir = get_settings().LABS_DIR
+
+        ensured: List[str] = []
+        created: List[str] = []
+        skipped: List[Dict[str, Any]] = []
+
+        with lab_lock(normalized, labs_dir):
+            data = LabService.read_lab_json_static(normalized)
+            lab_id = str(data.get("id") or normalized)
+            networks = data.get("networks") or {}
+            dirty = False
+            for key, network in networks.items():
+                if not isinstance(network, dict):
+                    skipped.append({"key": str(key), "reason": "non-dict network record"})
+                    continue
+                try:
+                    network_id = int(network.get("id", key))
+                except (TypeError, ValueError):
+                    skipped.append({"key": str(key), "reason": "non-integer id"})
+                    continue
+
+                runtime_record = network.get("runtime") or {}
+                bridge = runtime_record.get("bridge_name")
+                if not isinstance(bridge, str) or not bridge:
+                    bridge = host_net.bridge_name(lab_id, network_id)
+
+                try:
+                    if host_net.bridge_exists(bridge):
+                        status = host_net.bridge_fingerprint_check(
+                            bridge, lab_id, network_id
+                        )
+                        if status == "mismatch":
+                            skipped.append({
+                                "bridge": bridge,
+                                "network_id": network_id,
+                                "reason": _bridge_ownership_message(
+                                    bridge, lab_id, network_id
+                                ),
+                            })
+                            continue
+                        if status == "absent":
+                            try:
+                                host_net.bridge_fingerprint_write(
+                                    bridge, lab_id, network_id
+                                )
+                            except host_net.HostNetError:
+                                pass
+                        ensured.append(bridge)
+                    else:
+                        host_net.bridge_add(bridge)
+                        try:
+                            host_net.bridge_fingerprint_write(
+                                bridge, lab_id, network_id
+                            )
+                        except host_net.HostNetError:
+                            pass
+                        created.append(bridge)
+                except host_net.HostNetError as exc:
+                    skipped.append({
+                        "bridge": bridge,
+                        "network_id": network_id,
+                        "reason": str(exc),
+                    })
+                    continue
+
+                existing_runtime = network.setdefault("runtime", {})
+                if existing_runtime.get("bridge_name") != bridge:
+                    existing_runtime["bridge_name"] = bridge
+                    dirty = True
+
+            if dirty:
+                LabService.write_lab_json_static(normalized, data)
+
+        return {"ensured": ensured, "created": created, "skipped": skipped}
+
     async def create_network(self, lab_path: str, request: dict) -> dict:
         normalized = _normalize_relative_lab_path(lab_path)
         labs_dir = get_settings().LABS_DIR

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -670,8 +670,9 @@ class NodeRuntimeService:
         if not container_pid:
             return runtime
 
-        # Verify the container itself is still alive before attempting respawn.
-        if not Path(f"/proc/{container_pid}/ns/net").exists():
+        # Verify the container is still alive. Check /proc/{pid} (the directory
+        # itself is always world-accessible); /proc/{pid}/ns/net requires root.
+        if not Path(f"/proc/{container_pid}").is_dir():
             return runtime
 
         _logger.info(

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -640,6 +640,9 @@ class NodeRuntimeService:
         if not runtime:
             raise NodeRuntimeError(f"Node is not running: {node_id}")
 
+        if runtime.get("kind") == "docker":
+            runtime = self._ensure_console_proxy(lab_id, node_id, runtime)
+
         return {
             "lab_id": lab_id,
             "node_id": node_id,
@@ -649,6 +652,74 @@ class NodeRuntimeService:
             "port": int(runtime.get("console_port", 0)),
             "url": self._console_url(runtime),
         }
+
+    def _ensure_console_proxy(
+        self, lab_id: str, node_id: int, runtime: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Re-spawn a dead console proxy for a running Docker node.
+
+        Checks liveness via /proc. If the container is still up but the proxy
+        died, stops the stale entry, re-spawns, and persists the new PID.
+        Returns the (possibly updated) runtime dict.
+        """
+        proxy_pid = runtime.get("console_proxy_pid")
+        if proxy_pid and host_net.console_proxy_alive(int(proxy_pid)):
+            return runtime
+
+        container_pid = runtime.get("pid")
+        if not container_pid:
+            return runtime
+
+        # Verify the container itself is still alive before attempting respawn.
+        if not Path(f"/proc/{container_pid}/ns/net").exists():
+            return runtime
+
+        _logger.info(
+            "console proxy dead or missing for lab=%s node=%s (old_pid=%s); respawning",
+            lab_id,
+            node_id,
+            proxy_pid,
+        )
+
+        if proxy_pid:
+            try:
+                host_net.console_proxy_stop(int(proxy_pid))
+            except Exception:
+                pass
+
+        console_mode = runtime.get("console", "telnet")
+        listen_port = int(runtime.get("console_port", 0))
+        if not listen_port:
+            return runtime
+
+        try:
+            new_pid = host_net.console_proxy_start(
+                node_pid=int(container_pid),
+                listen_port=listen_port,
+                target_port=self._container_console_port(console_mode),
+            )
+        except Exception as exc:
+            _logger.warning(
+                "console proxy respawn failed for lab=%s node=%s: %s",
+                lab_id,
+                node_id,
+                exc,
+            )
+            return runtime
+
+        runtime = dict(runtime)
+        runtime["console_proxy_pid"] = new_pid
+        key = self._key(lab_id, node_id)
+        with self._lock:
+            self._registry[key] = runtime
+        self._persist_runtime(runtime)
+        _logger.info(
+            "console proxy respawned for lab=%s node=%s new_pid=%s",
+            lab_id,
+            node_id,
+            new_pid,
+        )
+        return runtime
 
     def stream_logs(self, lab_id: str, node_id: int, tail: int = 200) -> Iterator[str]:
         runtime = self._runtime_record(lab_id, node_id, include_stopped=True)

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1850,6 +1850,8 @@ class NodeRuntimeService:
             self._docker_network_alias(node),
             "--network",
             "none",
+            "--cap-add",
+            "NET_ADMIN",
             "-p",
             f"{console_port}:{self._container_console_port(console_mode)}",
         ]

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1386,6 +1386,7 @@ class NodeRuntimeService:
             raise
 
         # ----- Build per-NIC -netdev / -device argv ------------------------
+        unconnected_nic_indices: list[int] = []
         for index in range(ethernet_count):
             device_args = (
                 f"{nic_model},netdev=net{index},mac={self._mac_for_index(first_mac, index)}"
@@ -1411,16 +1412,18 @@ class NodeRuntimeService:
                     device_args,
                 ]
             else:
-                # No network attached and no uplink request — give the NIC
-                # an isolated ``hubport`` netdev (each in its own private
-                # hub, hubid={index}) so it appears in the guest but never
-                # reaches host networking.
+                # No network attached and no uplink request. The carrier
+                # is forced off via QMP ``set_link`` AFTER spawn — e1000
+                # (and most other NIC models) reject ``link=`` as a
+                # device-line option, so the boot-time argv stays plain
+                # and the post-spawn step pins these to ``up=False``.
                 cmd += [
                     "-netdev",
                     f"hubport,id=net{index},hubid={index}",
                     "-device",
                     device_args,
                 ]
+                unconnected_nic_indices.append(index)
 
         if iso_path:
             cmd += ["-cdrom", str(iso_path), "-boot", "order=dc"]
@@ -1459,6 +1462,23 @@ class NodeRuntimeService:
             raise NodeRuntimeError(error or "QEMU exited immediately after start")
 
         process_info = psutil.Process(process.pid)
+
+        # Pin the carrier OFF on every unconnected NIC index. QMP may
+        # not be bound the very first ms after spawn, so we retry each
+        # call once on transport failure. Best-effort: if QMP still
+        # rejects, the next ``ensure_lab_bridges`` reconcile catches it.
+        if unconnected_nic_indices:
+            qmp_path = str(qmp_socket_path)
+            for unconnected_index in unconnected_nic_indices:
+                args = {"name": f"net{unconnected_index}", "up": False}
+                for attempt in range(2):
+                    try:
+                        self._qmp_command(qmp_path, "set_link", args)
+                        break
+                    except Exception:  # noqa: BLE001 — best-effort
+                        if attempt == 0:
+                            time.sleep(0.1)
+                        # else: give up, reconcile will retry.
 
         # US-201/US-203: register the PID into the runtime registry. On
         # registry failure we kill the QEMU process and sweep the TAPs to
@@ -3187,6 +3207,44 @@ class NodeRuntimeService:
             raise NodeRuntimeQMPTimeout(
                 f"QMP {command} transport error on {socket_path}: {exc}"
             ) from exc
+
+    def set_qemu_nic_link(
+        self, lab_id: str, node_id: int, interface_index: int, *, up: bool
+    ) -> tuple[bool, str | None]:
+        """Best-effort QMP ``set_link`` for ``net{interface_index}``.
+
+        Returns ``(ok, reason)``. ``ok`` is True only when QEMU returned a
+        successful (non-error) response. The QMP ``name`` is the **netdev
+        id** (``net{index}``) which exists on both boot-time and hot-added
+        NICs, so this works for hubport-backed and tap-backed NICs alike.
+
+        The runtime mutex is intentionally NOT acquired — set_link is
+        idempotent and a missed flip during a concurrent attach will be
+        corrected by the caller's own attach/detach path or the next
+        reconcile pass.
+        """
+        runtime = self._runtime_record(lab_id, node_id)
+        if runtime is None:
+            return False, "no runtime record"
+        if str(runtime.get("kind") or "") != "qemu":
+            return False, f"runtime kind={runtime.get('kind')!r}"
+        socket_path = runtime.get("qmp_socket") or ""
+        if not socket_path:
+            work_dir = runtime.get("work_dir")
+            socket_path = str(Path(work_dir) / "qmp.sock") if work_dir else ""
+        if not socket_path:
+            return False, "no qmp socket"
+        try:
+            response = self._qmp_command(
+                socket_path,
+                "set_link",
+                {"name": f"net{int(interface_index)}", "up": bool(up)},
+            )
+        except NodeRuntimeQMPTimeout as exc:
+            return False, f"qmp transport: {exc}"
+        if isinstance(response, dict) and isinstance(response.get("error"), dict):
+            return False, f"qmp error: {response['error']}"
+        return True, None
 
     def _find_free_pcie_slot(
         self,

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1375,8 +1375,9 @@ class NodeRuntimeService:
                 if index in attachment_by_index:
                     tap = host_net.tap_name(lab_id, node_id, index)
                     bridge = attachment_by_index[index]["bridge_name"]
-                    host_net.tap_add(tap)
-                    provisioned_taps.append(tap)
+                    if not host_net.tap_exists(tap):
+                        host_net.tap_add(tap)
+                        provisioned_taps.append(tap)
                     host_net.link_master(tap, bridge)
                     host_net.link_up(tap)
                     tap_names[index] = tap

--- a/backend/tests/test_host_net.py
+++ b/backend/tests/test_host_net.py
@@ -60,8 +60,8 @@ def test_classify_helper_error_matches_contract(
             ("link-set-name-in-netns", "4242", "nvec0de1d2i3p", "eth3"),
         ),
         ("addr_up_in_netns", (4242, "eth3"), ("addr-up-in-netns", "4242", "eth3")),
-        ("link_del", ("nvec0de1d2i3h",), ("tap-del", "nvec0de1d2i3h")),
-        ("try_link_del", ("nvec0de1d2i3h",), ("tap-del", "nvec0de1d2i3h")),
+        ("link_del", ("nvec0de1d2i3h",), ("link-del", "nvec0de1d2i3h")),
+        ("try_link_del", ("nvec0de1d2i3h",), ("link-del", "nvec0de1d2i3h")),
     ],
 )
 def test_public_wrapper_verbs_shape_expected_helper_argv(

--- a/backend/tests/test_link_service.py
+++ b/backend/tests/test_link_service.py
@@ -297,3 +297,296 @@ async def test_us204b_create_link_records_runtime_field_on_link(
     persisted = saved["links"][0]
     runtime_record = persisted.get("runtime") or {}
     assert int(runtime_record.get("attach_generation", 0)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Bridge auto-up + per-NIC link state — link create/delete events
+# ---------------------------------------------------------------------------
+
+
+def _instance_id_fixture(monkeypatch, tmp_path):
+    """Seed a deterministic instance_id so host_net.bridge_name() works."""
+    instance_dir = tmp_path / "instance"
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    (instance_dir / "instance_id").write_text("test-link-state-instance")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+
+
+def _patch_host_net_for_attach(monkeypatch):
+    """Stub host_net helpers so create_link can run without root."""
+    from app.services import host_net
+
+    calls: dict[str, list] = {
+        "bridge_exists": [],
+        "bridge_add": [],
+        "bridge_del": [],
+        "bridge_fingerprint_write": [],
+        "link_up": [],
+        "try_link_del": [],
+    }
+
+    monkeypatch.setattr(
+        host_net, "bridge_exists", lambda n: (calls["bridge_exists"].append(n) or True)
+    )
+    monkeypatch.setattr(
+        host_net, "bridge_add", lambda n: calls["bridge_add"].append(n)
+    )
+    monkeypatch.setattr(
+        host_net, "bridge_del", lambda n: calls["bridge_del"].append(n)
+    )
+    monkeypatch.setattr(
+        host_net,
+        "bridge_fingerprint_write",
+        lambda n, lab_id, net_id: calls["bridge_fingerprint_write"].append(
+            (n, lab_id, net_id)
+        ),
+    )
+    monkeypatch.setattr(host_net, "link_up", lambda n: calls["link_up"].append(n))
+    monkeypatch.setattr(
+        host_net, "try_link_del", lambda n: calls["try_link_del"].append(n)
+    )
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_create_link_brings_bridge_up_after_running_attach(
+    link_settings, monkeypatch, tmp_path,
+):
+    """A successful hot-attach to a running endpoint forces ``link_up``
+    on the destination bridge so a bridge with any port stays UP."""
+    from app.services import host_net, node_runtime_service
+
+    _instance_id_fixture(monkeypatch, tmp_path)
+    helper = _patch_host_net_for_attach(monkeypatch)
+
+    lab_name = _seed_lab(
+        link_settings.LABS_DIR,
+        "lab.json",
+        nodes={"1": _node(1)},
+        networks={"5": _explicit_network(5, "lan")},
+    )
+
+    expected_bridge = host_net.bridge_name("lab", 5)
+    attach_calls: list[tuple] = []
+
+    def fake_runtime_record(_self, _lab_id, _node_id, *, include_stopped=False):
+        return {"kind": "docker", "lab_id": "lab", "node_id": 1}
+
+    def fake_attach_docker(
+        self, _lab_id, node_id, network_id, interface_index, *, bridge_name=None
+    ):
+        attach_calls.append((node_id, network_id, interface_index, bridge_name))
+        return {"interface_index": interface_index, "attach_generation": 1}
+
+    monkeypatch.setattr(
+        node_runtime_service.NodeRuntimeService,
+        "_runtime_record",
+        fake_runtime_record,
+    )
+    monkeypatch.setattr(
+        node_runtime_service.NodeRuntimeService,
+        "_attach_docker_interface_locked",
+        fake_attach_docker,
+    )
+
+    async def _noop_publish(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop_publish)
+
+    service = LinkService()
+    link_payload, _net, _replayed = await service.create_link(
+        lab_name,
+        {"node_id": 1, "interface_index": 0},
+        {"network_id": 5},
+    )
+
+    assert link_payload["id"]
+    assert attach_calls == [(1, 5, 0, expected_bridge)]
+    # The bridge gets brought up after the attach succeeds — only once
+    # even if there are multiple endpoints on the same bridge.
+    assert helper["link_up"] == [expected_bridge]
+
+
+@pytest.mark.asyncio
+async def test_create_link_no_bridge_up_when_no_endpoints_running(
+    link_settings, monkeypatch, tmp_path,
+):
+    """If no endpoint of the new link is on a running node, no
+    hot-attach work runs and link_up is NOT called — there is nothing
+    to wire up yet."""
+    _instance_id_fixture(monkeypatch, tmp_path)
+    helper = _patch_host_net_for_attach(monkeypatch)
+
+    lab_name = _seed_lab(
+        link_settings.LABS_DIR,
+        "lab.json",
+        nodes={"1": _node(1)},
+        networks={"5": _explicit_network(5, "lan")},
+    )
+
+    async def _noop_publish(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop_publish)
+
+    service = LinkService()
+    await service.create_link(
+        lab_name,
+        {"node_id": 1, "interface_index": 0},
+        {"network_id": 5},
+    )
+
+    assert helper["link_up"] == []
+
+
+@pytest.mark.asyncio
+async def test_create_link_calls_set_qemu_nic_link_up_for_running_qemu(
+    link_settings, monkeypatch, tmp_path,
+):
+    """After a successful QEMU hot-attach, ``set_qemu_nic_link`` is
+    called with ``up=True`` so the guest sees carrier on the new NIC."""
+    from app.services import node_runtime_service
+
+    _instance_id_fixture(monkeypatch, tmp_path)
+    _patch_host_net_for_attach(monkeypatch)
+
+    qemu_node = {
+        **_node(1),
+        "type": "qemu",
+        "ethernet": 4,
+    }
+    lab_name = _seed_lab(
+        link_settings.LABS_DIR,
+        "lab.json",
+        nodes={"1": qemu_node},
+        networks={"5": _explicit_network(5, "lan")},
+    )
+
+    set_link_calls: list[tuple] = []
+
+    def fake_runtime_record(_self, _lab_id, _node_id, *, include_stopped=False):
+        return {"kind": "qemu", "lab_id": "lab", "node_id": 1}
+
+    def fake_attach_qemu(
+        self, _lab_id, node_id, network_id, interface_index, *, bridge_name=None
+    ):
+        return {"interface_index": interface_index, "attach_generation": 1}
+
+    def fake_set_qemu_nic_link(
+        self, lab_id, node_id, interface_index, *, up
+    ):
+        set_link_calls.append((node_id, interface_index, up))
+        return True, None
+
+    monkeypatch.setattr(
+        node_runtime_service.NodeRuntimeService,
+        "_runtime_record",
+        fake_runtime_record,
+    )
+    monkeypatch.setattr(
+        node_runtime_service.NodeRuntimeService,
+        "_attach_qemu_interface_locked",
+        fake_attach_qemu,
+    )
+    monkeypatch.setattr(
+        node_runtime_service.NodeRuntimeService,
+        "set_qemu_nic_link",
+        fake_set_qemu_nic_link,
+    )
+
+    async def _noop_publish(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop_publish)
+
+    service = LinkService()
+    await service.create_link(
+        lab_name,
+        {"node_id": 1, "interface_index": 2},
+        {"network_id": 5},
+    )
+
+    assert set_link_calls == [(1, 2, True)]
+
+
+@pytest.mark.asyncio
+async def test_delete_link_calls_set_qemu_nic_link_down_before_detach(
+    link_settings, monkeypatch, tmp_path,
+):
+    """``delete_link`` calls ``set_qemu_nic_link(up=False)`` before
+    handing off to the QMP hot-detach so the guest visibly drops
+    carrier on that interface."""
+    from app.services import node_runtime_service
+
+    _instance_id_fixture(monkeypatch, tmp_path)
+    _patch_host_net_for_attach(monkeypatch)
+
+    qemu_node = {**_node(1), "type": "qemu", "ethernet": 4}
+    lab_name = _seed_lab(
+        link_settings.LABS_DIR,
+        "lab.json",
+        nodes={"1": qemu_node},
+        networks={"5": _explicit_network(5, "lan")},
+        links=[
+            {
+                "id": "lnk_001",
+                "from": {"node_id": 1, "interface_index": 2},
+                "to": {"network_id": 5},
+                "runtime": {"attach_generation": 1},
+            }
+        ],
+    )
+
+    set_link_calls: list[tuple] = []
+    detach_calls: list[tuple] = []
+    detach_order: list[str] = []
+
+    def fake_runtime_record(_self, _lab_id, _node_id, *, include_stopped=False):
+        return {"kind": "qemu", "lab_id": "lab", "node_id": 1}
+
+    def fake_set_qemu_nic_link(self, lab_id, node_id, interface_index, *, up):
+        set_link_calls.append((node_id, interface_index, up))
+        detach_order.append("set_link")
+        return True, None
+
+    def fake_detach_qemu(
+        self, _lab_id, node_id, interface_index, *, lab_path=None,
+        expected_generation=None,
+    ):
+        detach_calls.append((node_id, interface_index, expected_generation))
+        detach_order.append("detach")
+        return {"state": "detached"}
+
+    monkeypatch.setattr(
+        node_runtime_service.NodeRuntimeService,
+        "_runtime_record",
+        fake_runtime_record,
+    )
+    monkeypatch.setattr(
+        node_runtime_service.NodeRuntimeService,
+        "set_qemu_nic_link",
+        fake_set_qemu_nic_link,
+    )
+    monkeypatch.setattr(
+        node_runtime_service.NodeRuntimeService,
+        "_detach_qemu_interface_locked",
+        fake_detach_qemu,
+    )
+
+    async def _noop_publish(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.services.ws_hub.ws_hub.publish", _noop_publish)
+
+    service = LinkService()
+    # ``delete_link`` returns ``(False, ...)`` for "actually deleted" and
+    # ``(True, None)`` only for idempotent no-op on a missing link.
+    already_noop, _implicit = await service.delete_link(lab_name, "lnk_001")
+
+    assert already_noop is False
+    assert set_link_calls == [(1, 2, False)]
+    assert detach_calls == [(1, 2, 1)]
+    # set_link MUST run before detach — otherwise the device is gone
+    # and there is nothing to flip the carrier off on.
+    assert detach_order == ["set_link", "detach"]

--- a/backend/tests/test_network_service.py
+++ b/backend/tests/test_network_service.py
@@ -592,3 +592,134 @@ async def test_allocate_ip_skips_externally_reserved_addresses(
 
     # First free is .4 — .2 and .3 were both reserved.
     assert chosen == "10.99.4.4"
+
+
+# ---------------------------------------------------------------------------
+# ensure_lab_bridges — lab-load reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _seed_lab_with_networks(
+    labs_dir: Path, lab_id: str, networks: dict, *, name: str = "lab.json"
+) -> str:
+    (labs_dir / name).write_text(
+        json.dumps(
+            {
+                "schema": 2,
+                "id": lab_id,
+                "meta": {"name": name},
+                "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+                "nodes": {},
+                "networks": networks,
+                "links": [],
+                "defaults": {"link_style": "orthogonal"},
+            }
+        )
+    )
+    return name
+
+
+def test_ensure_lab_bridges_provisions_missing_bridge(
+    instance_id, settings, helper_mocks, labs_dir
+):
+    """Network in lab.json with no host bridge → bridge_add runs and
+    runtime.bridge_name is stamped on the network record."""
+    lab_id = "ensure-lab-1"
+    expected_bridge = host_net.bridge_name(lab_id, 1)
+    lab_name = _seed_lab_with_networks(
+        labs_dir,
+        lab_id,
+        {"1": {"id": 1, "name": "lan", "type": "linux_bridge"}},
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+
+    assert summary["created"] == [expected_bridge]
+    assert summary["ensured"] == []
+    assert summary["skipped"] == []
+    assert helper_mocks["bridge_add"] == [expected_bridge]
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"]["1"]["runtime"]["bridge_name"] == expected_bridge
+
+
+def test_ensure_lab_bridges_idempotent_when_bridge_already_exists(
+    instance_id, settings, monkeypatch, labs_dir
+):
+    """Existing bridge with matching fingerprint → no bridge_add, classified
+    under 'ensured'. Verifies the lab-open call is safe to fire on every
+    page load without thrashing host state."""
+    lab_id = "ensure-lab-2"
+    bridge = host_net.bridge_name(lab_id, 1)
+    host_net.bridge_fingerprint_write(bridge, lab_id, 1)
+
+    add_calls: list[str] = []
+    monkeypatch.setattr(host_net, "bridge_exists", lambda n: True)
+    monkeypatch.setattr(host_net, "bridge_add", lambda n: add_calls.append(n))
+    monkeypatch.setattr(host_net, "bridge_del", lambda n: None)
+
+    lab_name = _seed_lab_with_networks(
+        labs_dir,
+        lab_id,
+        {"1": {"id": 1, "name": "lan", "runtime": {"bridge_name": bridge}}},
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+
+    assert summary["ensured"] == [bridge]
+    assert summary["created"] == []
+    assert add_calls == []
+
+
+def test_ensure_lab_bridges_skips_on_ownership_mismatch(
+    instance_id, settings, monkeypatch, labs_dir
+):
+    """Existing bridge whose fingerprint maps to a different lab/network →
+    refuse to claim it; report the mismatch in 'skipped'."""
+    lab_id = "ensure-lab-3"
+    bridge = host_net.bridge_name(lab_id, 1)
+    host_net.bridge_fingerprint_write(bridge, "other-lab", 99)
+
+    add_calls: list[str] = []
+    monkeypatch.setattr(host_net, "bridge_exists", lambda n: True)
+    monkeypatch.setattr(host_net, "bridge_add", lambda n: add_calls.append(n))
+
+    lab_name = _seed_lab_with_networks(
+        labs_dir,
+        lab_id,
+        {"1": {"id": 1, "name": "lan"}},
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+
+    assert summary["created"] == []
+    assert summary["ensured"] == []
+    assert len(summary["skipped"]) == 1
+    skipped = summary["skipped"][0]
+    assert skipped["bridge"] == bridge
+    assert "ownership" in skipped["reason"].lower()
+    assert add_calls == []
+
+
+def test_ensure_lab_bridges_walks_multiple_networks(
+    instance_id, settings, helper_mocks, labs_dir
+):
+    """Multiple networks → each gets its bridge provisioned and stamped."""
+    lab_id = "ensure-lab-4"
+    bridge_a = host_net.bridge_name(lab_id, 1)
+    bridge_b = host_net.bridge_name(lab_id, 2)
+    lab_name = _seed_lab_with_networks(
+        labs_dir,
+        lab_id,
+        {
+            "1": {"id": 1, "name": "lan-a"},
+            "2": {"id": 2, "name": "lan-b"},
+        },
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+
+    assert sorted(summary["created"]) == sorted([bridge_a, bridge_b])
+    assert sorted(helper_mocks["bridge_add"]) == sorted([bridge_a, bridge_b])
+    saved = json.loads((labs_dir / lab_name).read_text())
+    assert saved["networks"]["1"]["runtime"]["bridge_name"] == bridge_a
+    assert saved["networks"]["2"]["runtime"]["bridge_name"] == bridge_b

--- a/backend/tests/test_network_service.py
+++ b/backend/tests/test_network_service.py
@@ -723,3 +723,263 @@ def test_ensure_lab_bridges_walks_multiple_networks(
     saved = json.loads((labs_dir / lab_name).read_text())
     assert saved["networks"]["1"]["runtime"]["bridge_name"] == bridge_a
     assert saved["networks"]["2"]["runtime"]["bridge_name"] == bridge_b
+
+
+# ---------------------------------------------------------------------------
+# ensure_lab_bridges — bridge auto-up when ports are connected
+# ---------------------------------------------------------------------------
+
+
+def _seed_lab_with_links(
+    labs_dir: Path,
+    lab_id: str,
+    *,
+    networks: dict,
+    links: list,
+    nodes: dict | None = None,
+    name: str = "lab.json",
+) -> str:
+    (labs_dir / name).write_text(
+        json.dumps(
+            {
+                "schema": 2,
+                "id": lab_id,
+                "meta": {"name": name},
+                "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+                "nodes": nodes or {},
+                "networks": networks,
+                "links": links,
+                "defaults": {"link_style": "orthogonal"},
+            }
+        )
+    )
+    return name
+
+
+def test_ensure_lab_bridges_raises_bridge_with_link(
+    instance_id, settings, helper_mocks, monkeypatch, labs_dir
+):
+    """A bridge whose network has at least one link endpoint is forced UP
+    so its slave ports leave ``state disabled``."""
+    lab_id = "ensure-lab-up-1"
+    bridge = host_net.bridge_name(lab_id, 1)
+    link_up_calls: list[str] = []
+    monkeypatch.setattr(host_net, "link_up", lambda n: link_up_calls.append(n))
+    lab_name = _seed_lab_with_links(
+        labs_dir,
+        lab_id,
+        networks={"1": {"id": 1, "name": "lan"}},
+        links=[
+            {
+                "id": "lnk_001",
+                "from": {"node_id": 7, "interface_index": 0},
+                "to": {"network_id": 1},
+            }
+        ],
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+
+    assert summary["created"] == [bridge]
+    assert summary["raised"] == [bridge]
+    assert link_up_calls == [bridge]
+
+
+def test_ensure_lab_bridges_leaves_unused_bridge_down(
+    instance_id, settings, helper_mocks, monkeypatch, labs_dir
+):
+    """A network with no link → bridge is created but NOT brought up."""
+    lab_id = "ensure-lab-up-2"
+    bridge = host_net.bridge_name(lab_id, 1)
+    link_up_calls: list[str] = []
+    monkeypatch.setattr(host_net, "link_up", lambda n: link_up_calls.append(n))
+    lab_name = _seed_lab_with_links(
+        labs_dir,
+        lab_id,
+        networks={"1": {"id": 1, "name": "lan"}},
+        links=[],
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+
+    assert summary["created"] == [bridge]
+    assert summary["raised"] == []
+    assert link_up_calls == []
+
+
+def test_ensure_lab_bridges_swallows_link_up_failure(
+    instance_id, settings, helper_mocks, monkeypatch, labs_dir
+):
+    """``link_up`` failure is logged, not raised, so reconcile keeps walking."""
+    lab_id = "ensure-lab-up-3"
+    bridge = host_net.bridge_name(lab_id, 1)
+
+    def boom(name: str) -> None:
+        raise host_net.HostNetEINVAL("fake")
+
+    monkeypatch.setattr(host_net, "link_up", boom)
+    lab_name = _seed_lab_with_links(
+        labs_dir,
+        lab_id,
+        networks={"1": {"id": 1, "name": "lan"}},
+        links=[
+            {
+                "id": "lnk_001",
+                "from": {"node_id": 1, "interface_index": 0},
+                "to": {"network_id": 1},
+            }
+        ],
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+
+    assert summary["created"] == [bridge]
+    assert summary["raised"] == []  # link_up failed; bridge not raised
+
+
+# ---------------------------------------------------------------------------
+# ensure_lab_bridges — QEMU NIC link state reconciliation
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_lab_bridges_sets_qemu_nic_link_state_per_lab_links(
+    instance_id, settings, helper_mocks, monkeypatch, labs_dir
+):
+    """Running QEMU node has set_link issued for every NIC index — UP for
+    indices that appear in lab.links, DOWN for the rest."""
+    from app.services import network_service as ns_mod
+
+    lab_id = "ensure-nic-link-1"
+    captured: list[tuple] = []
+
+    class FakeRuntimeService:
+        def _runtime_record(self, _lab_id, _node_id, *, include_stopped=False):
+            return {"kind": "qemu", "qmp_socket": "/tmp/qmp.sock"}
+
+        def set_qemu_nic_link(self, _lab_id, node_id, interface_index, *, up):
+            captured.append((node_id, interface_index, up))
+            return True, None
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.NodeRuntimeService", FakeRuntimeService
+    )
+
+    lab_name = _seed_lab_with_links(
+        labs_dir,
+        lab_id,
+        networks={"1": {"id": 1, "name": "lan"}},
+        nodes={
+            "3": {
+                "id": 3,
+                "name": "vyos-1",
+                "type": "qemu",
+                "ethernet": 4,
+                "interfaces": [
+                    {"name": "Gi1"},
+                    {"name": "Gi2"},
+                    {"name": "Gi3"},
+                    {"name": "Gi4"},
+                ],
+            }
+        },
+        # Only Gi3 (interface_index=2) is connected.
+        links=[
+            {
+                "id": "lnk_003",
+                "from": {"node_id": 3, "interface_index": 2},
+                "to": {"network_id": 1},
+            }
+        ],
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+
+    assert (3, 0, False) in captured
+    assert (3, 1, False) in captured
+    assert (3, 2, True) in captured
+    assert (3, 3, False) in captured
+    assert len(captured) == 4
+    nic_state = {(e["interface_index"], e["up"]) for e in summary["nic_link_state"]}
+    assert nic_state == {(0, False), (1, False), (2, True), (3, False)}
+
+
+def test_ensure_lab_bridges_skips_qemu_nic_link_state_when_node_stopped(
+    instance_id, settings, helper_mocks, monkeypatch, labs_dir
+):
+    """A QEMU node with no runtime record (stopped) → no QMP set_link calls."""
+    from app.services import network_service as ns_mod
+
+    lab_id = "ensure-nic-link-2"
+    captured: list[tuple] = []
+
+    class FakeRuntimeService:
+        def _runtime_record(self, _lab_id, _node_id, *, include_stopped=False):
+            return None
+
+        def set_qemu_nic_link(self, _lab_id, node_id, interface_index, *, up):
+            captured.append((node_id, interface_index, up))
+            return True, None
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.NodeRuntimeService", FakeRuntimeService
+    )
+
+    lab_name = _seed_lab_with_links(
+        labs_dir,
+        lab_id,
+        networks={"1": {"id": 1, "name": "lan"}},
+        nodes={
+            "3": {
+                "id": 3,
+                "name": "vyos-1",
+                "type": "qemu",
+                "ethernet": 4,
+            }
+        },
+        links=[],
+    )
+
+    summary = NetworkService().ensure_lab_bridges(lab_name)
+    assert captured == []
+    assert summary["nic_link_state"] == []
+
+
+def test_ensure_lab_bridges_skips_non_qemu_nodes_for_set_link(
+    instance_id, settings, helper_mocks, monkeypatch, labs_dir
+):
+    """Docker nodes use real veth pairs whose carrier already tracks
+    attach state — set_link must not be called on them."""
+    from app.services import network_service as ns_mod
+
+    lab_id = "ensure-nic-link-3"
+    captured: list[tuple] = []
+
+    class FakeRuntimeService:
+        def _runtime_record(self, _lab_id, _node_id, *, include_stopped=False):
+            return {"kind": "docker"}
+
+        def set_qemu_nic_link(self, _lab_id, node_id, interface_index, *, up):
+            captured.append((node_id, interface_index, up))
+            return True, None
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.NodeRuntimeService", FakeRuntimeService
+    )
+
+    lab_name = _seed_lab_with_links(
+        labs_dir,
+        lab_id,
+        networks={"1": {"id": 1, "name": "lan"}},
+        nodes={
+            "4": {
+                "id": 4,
+                "name": "docker-test-a",
+                "type": "docker",
+                "ethernet": 1,
+            }
+        },
+        links=[],
+    )
+
+    NetworkService().ensure_lab_bridges(lab_name)
+    assert captured == []

--- a/backend/tests/test_node_runtime.py
+++ b/backend/tests/test_node_runtime.py
@@ -2342,3 +2342,185 @@ def test_us302_qemu_stop_sweeps_tap_names(
     helper["try_link_del"].clear()
     service.stop_node(lab_data, 1)
     assert set(helper["try_link_del"]) == expected_taps
+
+
+# ---------------------------------------------------------------------------
+# Boot-time NIC link state: connected NICs default link=on, unconnected NICs
+# get link=off so the guest does not see phantom carrier on hubport-backed
+# devices.
+# ---------------------------------------------------------------------------
+
+
+def _qemu_link_state_lab() -> dict:
+    """4-NIC QEMU node with only ``Gi3`` (interface_index=2) linked."""
+    from app.services import host_net
+
+    lab_id = "lab-link-state"
+    bridge1 = host_net.bridge_name(lab_id, 1)
+    return {
+        "schema": 2,
+        "id": lab_id,
+        "meta": {"name": "link-state"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            "1": {
+                "id": 1,
+                "name": "vyos-1",
+                "type": "qemu",
+                "image": "router-image",
+                "console": "telnet",
+                "cpu": 1,
+                "ram": 1024,
+                "ethernet": 4,
+                "firstmac": "50:00:00:01:00:00",
+                "interfaces": [
+                    {"index": 0, "name": "Gi1"},
+                    {"index": 1, "name": "Gi2"},
+                    {"index": 2, "name": "Gi3"},
+                    {"index": 3, "name": "Gi4"},
+                ],
+            }
+        },
+        "networks": {
+            "1": {
+                "id": 1,
+                "name": "lan",
+                "type": "linux_bridge",
+                "visibility": True,
+                "implicit": False,
+                "config": {},
+                "runtime": {"bridge_name": bridge1},
+            }
+        },
+        "links": [
+            {
+                "id": "lnk_001",
+                "from": {"node_id": 1, "interface_index": 2},
+                "to": {"network_id": 1},
+                "style_override": None,
+                "label": "",
+                "color": "",
+                "width": "1",
+                "metrics": {"delay_ms": 0, "loss_pct": 0, "bandwidth_kbps": 0, "jitter_ms": 0},
+            }
+        ],
+        "defaults": {"link_style": "orthogonal"},
+    }
+
+
+def _device_args_by_index(cmd: list[str]) -> dict[int, str]:
+    """Return ``{index: device_arg}`` for every ``-device <nic_model>,...``
+    that targets ``netdev=net{index}``."""
+    out: dict[int, str] = {}
+    for i, tok in enumerate(cmd):
+        if tok != "-device":
+            continue
+        arg = cmd[i + 1] if i + 1 < len(cmd) else ""
+        if "netdev=net" not in arg:
+            continue
+        for piece in arg.split(","):
+            if piece.startswith("netdev=net"):
+                try:
+                    idx = int(piece[len("netdev=net"):])
+                except ValueError:
+                    continue
+                out[idx] = arg
+                break
+    return out
+
+
+def _patch_qmp_capture(monkeypatch) -> list[tuple]:
+    """Patch ``NodeRuntimeService._qmp_command`` to capture set_link calls."""
+    captured: list[tuple] = []
+
+    def fake_qmp(self, socket_path, command, arguments=None):
+        captured.append((command, arguments))
+        return {"return": {}}
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.NodeRuntimeService._qmp_command",
+        fake_qmp,
+    )
+    return captured
+
+
+def test_qemu_unconnected_nics_get_set_link_off_after_spawn(
+    monkeypatch, patched_settings, _us203_instance_id
+):
+    """Connected NIC keeps the QEMU default (no link=); unconnected NICs
+    have ``set_link {up: False}`` issued via QMP right after spawn.
+    Boot-time argv must NOT carry ``link=off`` because e1000 (and most
+    NIC models) reject it as a device property."""
+    from app.services import host_net
+
+    lab_id = "lab-link-state"
+    bridge = host_net.bridge_name(lab_id, 1)
+    _us302_helper_mock(monkeypatch, present_bridges={bridge})
+    recorded_popen = _setup_us302_qemu_runtime(monkeypatch, patched_settings)
+    set_link_calls = _patch_qmp_capture(monkeypatch)
+
+    NodeRuntimeService().start_node(_qemu_link_state_lab(), 1)
+    cmd = recorded_popen[0]["cmd"]
+    by_index = _device_args_by_index(cmd)
+
+    assert set(by_index.keys()) == {0, 1, 2, 3}
+    # No NIC carries ``link=`` on the device line — that property does
+    # not exist on e1000 and would crash QEMU at boot.
+    for idx, arg in by_index.items():
+        assert "link=" not in arg, f"unexpected link= on idx {idx}: {arg!r}"
+    # Sanity: connected NIC is tap-backed, others are hubport.
+    flat = " ".join(cmd)
+    assert "-netdev tap," in flat
+    assert "-netdev hubport," in flat
+
+    # Post-spawn set_link issued for the three unconnected indices only.
+    set_link_args = [
+        args for cmd_name, args in set_link_calls if cmd_name == "set_link"
+    ]
+    assert {a["name"] for a in set_link_args} == {"net0", "net1", "net3"}
+    assert all(a["up"] is False for a in set_link_args)
+
+
+def test_qemu_all_unconnected_nics_get_set_link_off_after_spawn(
+    monkeypatch, patched_settings, _us203_instance_id
+):
+    """Sample lab (no networks, no links) — both NICs unconnected →
+    set_link issued for net0 and net1 with ``up=False``."""
+    _us302_helper_mock(monkeypatch, present_bridges=set())
+    recorded_popen = _setup_us302_qemu_runtime(monkeypatch, patched_settings)
+    set_link_calls = _patch_qmp_capture(monkeypatch)
+
+    lab_data = {
+        "schema": 2,
+        "id": "lab-empty",
+        "meta": {"name": "empty"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            "1": {
+                "id": 1,
+                "name": "router",
+                "type": "qemu",
+                "image": "router-image",
+                "console": "telnet",
+                "cpu": 1,
+                "ram": 512,
+                "ethernet": 2,
+                "firstmac": "50:00:00:01:00:00",
+            }
+        },
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+
+    NodeRuntimeService().start_node(lab_data, 1)
+    by_index = _device_args_by_index(recorded_popen[0]["cmd"])
+    assert set(by_index.keys()) == {0, 1}
+    for idx, arg in by_index.items():
+        assert "link=" not in arg, f"unexpected link= on idx {idx}: {arg!r}"
+
+    set_link_args = [
+        args for cmd_name, args in set_link_calls if cmd_name == "set_link"
+    ]
+    assert {a["name"] for a in set_link_args} == {"net0", "net1"}
+    assert all(a["up"] is False for a in set_link_args)

--- a/deploy/nova-ve-net.py
+++ b/deploy/nova-ve-net.py
@@ -345,6 +345,11 @@ def cmd_tap_del(args: argparse.Namespace) -> int:
     return _ip("link", "del", name)
 
 
+def cmd_link_del(args: argparse.Namespace) -> int:
+    name = validate_iface_name(args.name)
+    return _ip("link", "del", name)
+
+
 def cmd_veth_pair_add(args: argparse.Namespace) -> int:
     host = validate_veth_name(args.hostend, label="hostend")
     peer = validate_veth_name(args.peerend, label="peerend")
@@ -544,6 +549,7 @@ VERB_TABLE: Mapping[str, Callable[[argparse.Namespace], int]] = {
     "bridge-del": cmd_bridge_del,
     "tap-add": cmd_tap_add,
     "tap-del": cmd_tap_del,
+    "link-del": cmd_link_del,
     "veth-pair-add": cmd_veth_pair_add,
     "link-master": cmd_link_master,
     "link-set-nomaster": cmd_link_set_nomaster,
@@ -578,6 +584,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("name")
 
     p = sub.add_parser("tap-del", help="ip link del <name>")
+    p.add_argument("name")
+
+    p = sub.add_parser(
+        "link-del",
+        help="ip link del <name> — accepts both TAP and veth host-end names",
+    )
     p.add_argument("name")
 
     p = sub.add_parser("veth-pair-add", help="ip link add <h> type veth peer name <p>")

--- a/deploy/nova-ve-net.py
+++ b/deploy/nova-ve-net.py
@@ -121,8 +121,16 @@ def validate_veth_name(value: str, *, label: str = "veth_name") -> str:
 
 
 def validate_iface_name(value: str, *, label: str = "iface_name") -> str:
-    """Accept any nova-ve-owned interface name (TAP or veth)."""
-    if RE_TAP_NAME.match(value) or RE_VETH_NAME.match(value):
+    """Accept any nova-ve-owned interface name (TAP, veth, or bridge).
+
+    Bridges are accepted so generic verbs like ``link-up`` / ``link-del``
+    can target a bridge without needing a bridge-specific verb.
+    """
+    if (
+        RE_TAP_NAME.match(value)
+        or RE_VETH_NAME.match(value)
+        or RE_BRIDGE_NAME.match(value)
+    ):
         return value
     raise _ValidationError(label)
 

--- a/frontend/src/routes/labs/[...id]/+page.svelte
+++ b/frontend/src/routes/labs/[...id]/+page.svelte
@@ -7,7 +7,7 @@
   import { goto } from '$app/navigation';
   import { ChevronDown, ChevronRight, ChevronsLeft, ChevronsRight, Monitor, RefreshCw } from 'lucide-svelte';
   import { authStore } from '$lib/stores/auth';
-  import { apiGetData, ApiError } from '$lib/api';
+  import { apiGetData, apiRequest, ApiError } from '$lib/api';
   import { toastStore } from '$lib/stores/toasts';
   import { SvelteFlowProvider } from '@xyflow/svelte';
   import TopologyCanvas from '$lib/components/canvas/TopologyCanvas.svelte';
@@ -256,6 +256,19 @@
     }
 
     try {
+      // Fire-and-forget host-state reconciliation — provisions any missing
+      // Linux bridges for this lab's networks. Restored labs and labs whose
+      // bridges were lost across a host reboot/manual cleanup find their
+      // host state already prepared by the time the user starts a node or
+      // creates a link.
+      apiRequest(`/labs/${labId}/runtime/reconcile`, {
+        method: 'POST',
+        suppressToast: true
+      }).catch(() => {
+        /* best-effort; surfacing the failure in a toast would be noisy
+           on every lab open and isn't actionable for the user. */
+      });
+
       const [meta, nodeData, networkData, topologyData, linksData] = await Promise.all([
         apiGetData<LabMeta>(`/labs/${labId}`),
         apiGetData<Record<string, NodeData>>(`/labs/${labId}/nodes`),


### PR DESCRIPTION
## Summary

- **Bridge reconciliation on lab open**: self-heals missing host bridges at attach time and reconciles on `loadLab()` via a fire-and-forget `POST /runtime/reconcile`
- **QEMU NIC carrier state**: reconciles per-NIC `set_link` state via QMP on lab open
- **QMP lock starvation fix** (#156): moved `_reconcile_qemu_nic_link_state()` outside `lab_lock` — QMP calls are read-only w.r.t. lab.json and were holding the lock for up to `N×M×2s` on large QEMU labs
- **Stale TAP on node start**: `tap_exists()` check before `tap_add` — orphaned TAPs from a previous run no longer block QEMU node startup
- **Console proxy self-healing**: `_ensure_console_proxy()` on every `console_info()` call for Docker nodes — detects dead proxy, verifies container is still alive via `/proc/{pid}`, respawns and persists new PID
- **`/proc/{pid}/ns/net` permission fix**: `ubuntu` user can't read `ns/net`; switched to `Path(/proc/{pid}).is_dir()` which is world-accessible
- **NET_ADMIN capability**: all Docker containers now launch with `--cap-add NET_ADMIN` so `udhcpc`, `ip addr`, and `ip route` work inside the container

## Test plan

- [x] 657 backend tests passing on test VM (`192.168.100.212`)
- [x] Lab open triggers bridge reconciliation (verified via logs)
- [x] QEMU node start succeeds when stale TAP exists
- [x] Console proxy respawn logged when dead proxy detected on console open
- [x] Docker nodes require stop+restart to pick up `NET_ADMIN`

## Fixes

Closes #156