### PR TITLE
feat: boot order select with human-readable disk/cdrom labels

### DIFF
--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -203,10 +203,13 @@ def _qemu_extras_schema() -> list[dict[str, Any]]:
         {
             "key": "boot_order",
             "label": "Boot order",
-            "type": "text",
+            "type": "select",
+            "options": [
+                {"value": "", "label": "Default (disk first when ISO attached)"},
+                {"value": "cd", "label": "Disk, then CD-ROM"},
+                {"value": "dc", "label": "CD-ROM, then disk"},
+            ],
             "default": "",
-            "placeholder": "cd",
-            "description": "QEMU boot order (c=disk, d=cdrom, n=PXE). Default when ISO attached: cd (disk-first).",
             "stoppedOnly": True,
             "runtime": True,
         },


### PR DESCRIPTION
## Summary
- Replaces the free-text `boot_order` extra field with a `select` dropdown showing explicit human-readable options instead of QEMU letter codes
- Options: **Default (disk first when ISO attached)** / **Disk, then CD-ROM** / **CD-ROM, then disk**
- Stored values remain QEMU-native (`""` / `"cd"` / `"dc"`) — no backend logic change
- Existing nodes with `boot_order: dc` saved will correctly show "CD-ROM, then disk" selected

## Test plan
- [ ] Open NodeConfigModal for a QEMU node → Boot order field shows a dropdown (not a text input)
- [ ] Dropdown options are "Default (disk first when ISO attached)", "Disk, then CD-ROM", "CD-ROM, then disk"
- [ ] Saving with "CD-ROM, then disk" selected → QEMU starts with `-boot order=dc`
- [ ] Saving with "Default" selected → QEMU starts with `-boot order=cd` when ISO attached, no `-boot` flag when no ISO
- [ ] `python -m pytest backend/tests/ -q` → 672 passed