### PR TITLE
Fix QEMU hot-plug: clear allocated_slots at boot and idempotent same-network re-attach

### DIFF
--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1560,9 +1560,11 @@ class NodeRuntimeService:
             i for i in range(ethernet_count)
             if i not in tap_names and not self._interface_uplink(node_interfaces, i)
         ]
-        # US-301: track pre-allocated pcie-root-port slot indices for hot-plug
-        # book-keeping (used by attach_interface / detach_interface).
-        allocated_slots: list[int] = list(range(max_nics)) if machine == "q35" and max_nics > 0 else []
+        # US-301: in-flight slot reservations for hot-plug race-window only
+        # (between slot-pick and device_add visibility in query-pci).
+        # Boot-time occupancy is detected live via query-pci; pre-seeding
+        # this list would mark every slot occupied and block all hot-adds.
+        allocated_slots: list[int] = []
 
         extra_args = _extra_str(extras, "qemu_options")
         try:
@@ -2279,12 +2281,16 @@ class NodeRuntimeService:
         # Reject duplicate interface indices on the same node — the host_end
         # name only encodes (lab, node, iface), so re-attaching the same iface
         # would collide on ``ip link add``.
+        # Same-network re-attach is idempotent; different-network names blocker.
         existing_attachments = runtime.get("interface_attachments") or []
         for existing in existing_attachments:
             if int(existing.get("interface_index", -1)) == int(interface_index):
+                if int(existing.get("network_id", -1)) == int(network_id):
+                    return existing
                 raise NodeRuntimeError(
-                    f"interface_index={interface_index} already attached on "
-                    f"node {node_id}; detach before re-attaching."
+                    f"interface_index={interface_index} already attached to "
+                    f"network {existing.get('network_id')} on node {node_id}; "
+                    "detach that link before re-attaching."
                 )
 
         bridge = bridge_name or host_net.bridge_name(lab_id, int(network_id))
@@ -2643,12 +2649,17 @@ class NodeRuntimeService:
 
         # Reject duplicate interface indices on the same node — the QMP
         # ``id=net{interface_index}`` would collide with an existing one.
+        # Same-network re-attach is idempotent (stale runtime record after a
+        # failed hot-detach); different-network conflict names the blocker.
         existing_attachments = runtime.get("interface_attachments") or []
         for existing in existing_attachments:
             if int(existing.get("interface_index", -1)) == int(interface_index):
+                if int(existing.get("network_id", -1)) == int(network_id):
+                    return existing
                 raise NodeRuntimeError(
-                    f"interface_index={interface_index} already attached on "
-                    f"node {node_id}; detach before re-attaching."
+                    f"interface_index={interface_index} already attached to "
+                    f"network {existing.get('network_id')} on node {node_id}; "
+                    "detach that link before re-attaching."
                 )
 
         bridge = bridge_name or host_net.bridge_name(lab_id, int(network_id))

--- a/backend/tests/test_qemu_pcie_root_ports.py
+++ b/backend/tests/test_qemu_pcie_root_ports.py
@@ -196,7 +196,7 @@ def test_q35_default_preallocates_eight_root_ports(patched_settings, argv_captur
 
     assert runtime["machine"] == "q35"
     assert runtime["max_nics"] == 8
-    assert runtime["allocated_slots"] == list(range(8))
+    assert runtime["allocated_slots"] == []  # starts empty; populated on hot-add only
     assert runtime["hotplug_capable"] is True
 
 

--- a/backend/tests/test_runtime_mutex.py
+++ b/backend/tests/test_runtime_mutex.py
@@ -436,17 +436,17 @@ def test_us204b_parallel_attach_same_iface_serializes(
     )
 
     # Release A. Now B's mutex acquire should unblock — but B will then
-    # discover the duplicate-iface check and surface NodeRuntimeError
-    # without doing any kernel work.
+    # discover the duplicate-iface check and return idempotent success
+    # (same network_id) without doing any further kernel work.
     hold.set()
     t_a.join(timeout=5.0)
     t_b.join(timeout=5.0)
 
-    # A succeeded, B was rejected by the duplicate-iface guard.
+    # A succeeded; B also succeeded idempotently (same-network re-attach).
     a_done = any(entry == "A:done" for entry in enter_order)
-    b_err = any(entry.startswith("B:err:") for entry in enter_order)
+    b_done = any(entry == "B:done" for entry in enter_order)
     assert a_done, f"thread A did not complete: {enter_order!r}"
-    assert b_err, f"thread B did not surface duplicate-iface error: {enter_order!r}"
+    assert b_done, f"thread B did not complete idempotently: {enter_order!r}"
 
     # The duplicate-iface check ran AFTER the mutex acquire, so exactly one
     # 6-step sequence happened.

--- a/backend/tests/test_us303_qemu_hot_add.py
+++ b/backend/tests/test_us303_qemu_hot_add.py
@@ -470,16 +470,16 @@ def test_us303_rejects_when_hotplug_capable_false(
 def test_us303_rejects_duplicate_interface_index(
     lab_settings, monkeypatch, _instance_id
 ):
-    """Re-attaching the same interface_index on an already-attached node
-    raises NodeRuntimeError (the QMP id collision would manifest as a
-    confusing kernel-side error otherwise).
+    """Re-attaching the same interface_index to the SAME network is idempotent
+    (returns the existing attachment, no QMP calls).  Re-attaching to a
+    DIFFERENT network raises NodeRuntimeError naming the current network.
     """
     lab_id = "labdup"
     _seed_lab(
         lab_settings.LABS_DIR,
         f"{lab_id}.json",
         nodes={"1": _qemu_node(1)},
-        networks={"5": _network(5)},
+        networks={"5": _network(5), "6": _network(6)},
     )
 
     svc = NodeRuntimeService()
@@ -496,8 +496,15 @@ def test_us303_rejects_duplicate_interface_index(
     fake_qmp = _FakeQmp()
     svc._qmp_client = fake_qmp
 
-    with pytest.raises(NodeRuntimeError, match="already attached"):
-        svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+    # Same network — idempotent success, no QMP traffic.
+    result = svc.attach_qemu_interface(lab_id, 1, network_id=5, interface_index=2)
+    assert result["interface_index"] == 2
+    assert result["network_id"] == 5
+    assert fake_qmp.calls == []
+
+    # Different network — should raise naming the currently-attached network.
+    with pytest.raises(NodeRuntimeError, match="already attached to network 5"):
+        svc.attach_qemu_interface(lab_id, 1, network_id=6, interface_index=2)
     assert fake_qmp.calls == []
 
 


### PR DESCRIPTION
## Summary

- **#171 — All slots in use**: `allocated_slots` was initialised to `list(range(max_nics))` at boot, so `_find_free_pcie_slot` always saw every PCIe root-port slot as reserved and returned `None`. Every hot-plug attempt on a q35 VM was blocked. Fixed by starting with `[]` — boot-time occupancy is already detected live via `query-pci`.

- **#172 — Stale "already attached" error**: The duplicate-interface check in both `_attach_qemu_interface_locked` and `_attach_docker_interface_locked` now distinguishes two cases:
  - **Same network** → idempotent success (returns the existing attachment, no QMP/kernel work). Heals stale runtime records left behind by a partially-failed hot-detach.
  - **Different network** → `NodeRuntimeError` now names the currently-attached network so the user knows which link to remove first.

## Test plan

- [ ] 672 backend tests pass (3 test files updated to assert new correct behaviour)
- [ ] Start a q35 QEMU node, drag a link to an unconnected interface → hot-plug succeeds (was blocked by #171)
- [ ] With a stale runtime attachment, drag the same link again → succeeds idempotently (was blocked by #172)
- [ ] Drag a link to an interface attached to a different network → error names the blocking network