### PR TITLE
Fix QEMU boot-NIC reconciler races + bridge-reconciliation hardening (#174 #175)

### DIFF
--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -528,28 +528,34 @@ class LinkService:
                         link_payload = _link_with_state(link)
                         break
 
-        # Issue #174: bulletproof reconcile after create. The targeted attach
-        # in `_hot_attach_running_endpoints` is generation-gated and can no-op
-        # silently on stale state; converge runtime + kernel for every running
-        # QEMU node against the JSON we just wrote.
-        try:
-            from app.services.node_runtime_service import (  # noqa: WPS433
-                NodeRuntimeService,
-            )
+            # Issue #174 / #175 (M2): bulletproof reconcile after create.
+            # The targeted attach in `_hot_attach_running_endpoints` is
+            # generation-gated and can no-op silently on stale state;
+            # converge runtime + kernel for every running QEMU node
+            # against the JSON we just wrote. MUST run INSIDE lab_lock
+            # so the post-write re-read sees the same JSON state that
+            # was written under the lock and another writer cannot slip
+            # a divergent state in between. The reconciler exception is
+            # swallowed so a reconcile failure cannot corrupt the
+            # otherwise-successful create_link op.
+            try:
+                from app.services.node_runtime_service import (  # noqa: WPS433
+                    NodeRuntimeService,
+                )
 
-            rt_svc = NodeRuntimeService()
-            data_after = LabService.read_lab_json_static(normalized)
-            lab_id_after = str(data_after.get("id") or normalized)
-            for raw_id, node_after in (data_after.get("nodes") or {}).items():
-                if not isinstance(node_after, dict):
-                    continue
-                if str(node_after.get("type") or "").lower() != "qemu":
-                    continue
-                rt_svc.reconcile_qemu_node_links(lab_id_after, data_after, node_after)
-        except Exception:  # noqa: BLE001 — best-effort safety net
-            _logger.exception(
-                "create_link: post-create reconcile failed (lab=%s)", normalized
-            )
+                rt_svc = NodeRuntimeService()
+                data_after = LabService.read_lab_json_static(normalized)
+                lab_id_after = str(data_after.get("id") or normalized)
+                for raw_id, node_after in (data_after.get("nodes") or {}).items():
+                    if not isinstance(node_after, dict):
+                        continue
+                    if str(node_after.get("type") or "").lower() != "qemu":
+                        continue
+                    rt_svc.reconcile_qemu_node_links(lab_id_after, data_after, node_after)
+            except Exception:  # noqa: BLE001 — best-effort safety net
+                _logger.exception(
+                    "create_link: post-create reconcile failed (lab=%s)", normalized
+                )
 
         for event_type, payload in ws_events:
             await ws_hub.publish(normalized, event_type, payload)
@@ -1253,30 +1259,36 @@ class LinkService:
 
             ws_events.append(("link_deleted", {"link_id": str(link_id)}))
 
-        # Issue #174: bulletproof reconcile after delete. The targeted detach
-        # in Phase 2 might have stale-gen no-op'd or failed silently mid-flight;
-        # walk every running QEMU node in the lab and converge runtime + kernel
-        # to the JSON we just wrote.
-        try:
-            from app.services.node_runtime_service import (  # noqa: WPS433
-                NodeRuntimeService,
-            )
+            # Issue #174 / #175 (M2): bulletproof reconcile after delete.
+            # The targeted detach in Phase 2 might have stale-gen no-op'd
+            # or failed silently mid-flight; walk every running QEMU node
+            # in the lab and converge runtime + kernel to the JSON we
+            # just wrote. MUST run INSIDE lab_lock so the post-write
+            # re-read sees the same JSON state that was written under
+            # the lock and another writer cannot slip a divergent state
+            # in between. The reconciler exception is swallowed so a
+            # reconcile failure cannot corrupt the otherwise-successful
+            # delete_link op.
+            try:
+                from app.services.node_runtime_service import (  # noqa: WPS433
+                    NodeRuntimeService,
+                )
 
-            rt_svc = NodeRuntimeService()
-            data_after = LabService.read_lab_json_static(normalized)
-            lab_id_after = str(data_after.get("id") or normalized)
-            for raw_id, node_after in (data_after.get("nodes") or {}).items():
-                if not isinstance(node_after, dict):
-                    continue
-                if str(node_after.get("type") or "").lower() != "qemu":
-                    continue
-                rt_svc.reconcile_qemu_node_links(lab_id_after, data_after, node_after)
-        except Exception:  # noqa: BLE001 — best-effort safety net
-            _logger.exception(
-                "delete_link: post-delete reconcile failed (lab=%s link=%s)",
-                normalized,
-                link_id,
-            )
+                rt_svc = NodeRuntimeService()
+                data_after = LabService.read_lab_json_static(normalized)
+                lab_id_after = str(data_after.get("id") or normalized)
+                for raw_id, node_after in (data_after.get("nodes") or {}).items():
+                    if not isinstance(node_after, dict):
+                        continue
+                    if str(node_after.get("type") or "").lower() != "qemu":
+                        continue
+                    rt_svc.reconcile_qemu_node_links(lab_id_after, data_after, node_after)
+            except Exception:  # noqa: BLE001 — best-effort safety net
+                _logger.exception(
+                    "delete_link: post-delete reconcile failed (lab=%s link=%s)",
+                    normalized,
+                    link_id,
+                )
 
         for event_type, payload in ws_events:
             await ws_hub.publish(normalized, event_type, payload)

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -1597,10 +1597,10 @@ class NodeRuntimeService:
                     try:
                         host_net.link_set_nomaster(tap)
                     except host_net.HostNetError:
-                        # Best-effort: if the TAP has no master, the helper
-                        # may exit non-zero. Either way the desired end
-                        # state ("not on a bridge") is reached or harmless.
-                        pass
+                        _logger.debug(
+                            "boot loop: link_set_nomaster(%s) returned non-zero — likely already had no master (idempotent)",
+                            tap,
+                        )
         except Exception:
             for tap in provisioned_taps:
                 host_net.try_link_del(tap)
@@ -3310,10 +3310,16 @@ class NodeRuntimeService:
                     "detach boot-nic: set_link(%s, up=False) failed (best-effort)",
                     netdev_id,
                 )
-            try:
-                host_net.link_set_nomaster(tap)
-            except Exception:  # noqa: BLE001
-                _logger.exception("detach boot-nic: link_set_nomaster(%s) failed", tap)
+            # Issue #175 (M3): link_set_nomaster failure is a HARD detach
+            # failure. If we swallow it, the TAP stays on the bridge, packets
+            # still flow, and the system thinks the detach succeeded (the
+            # attachment record below would get dropped + generation bumped
+            # + lab.json link removed → no way to retry). Match the prior
+            # 'Codex hotfix HIGH-2' contract for hot-plug detach: raise so
+            # link_service.delete_link surfaces the failure to the caller and
+            # leaves interface_attachments / current_attach_generation /
+            # lab.json UNCHANGED for retry.
+            host_net.link_set_nomaster(tap)
             device_gone = True
         else:
             # ----- Step 1: device_del with race-A retry ------------------
@@ -3832,7 +3838,14 @@ class NodeRuntimeService:
                             socket_path, "set_link", {"name": f"net{idx}", "up": True}
                         )
                     except Exception:  # noqa: BLE001 — best-effort
-                        pass
+                        _logger.debug(
+                            "reconciler: set_link(net%d, up=True) failed for node=%s (best-effort)",
+                            idx, node_id,
+                        )
+                        warnings.append({
+                            "interface_index": idx,
+                            "reason": "set_link up=True failed (best-effort)",
+                        })
             except host_net.HostNetError as exc:
                 warnings.append({"interface_index": idx, "reason": str(exc)})
                 continue
@@ -3862,6 +3875,17 @@ class NodeRuntimeService:
                 if not replaced:
                     attachments_now.append(new_record)
                 runtime["interface_attachments"] = attachments_now
+                # Issue #175 (M1): force-sync runtime's current_attach_generation to
+                # the link's attach_generation from lab.json. NOT a bump — bumping
+                # in Phase 1 can produce runtime_gen > lab.json_gen, causing the
+                # next user-driven delete_link to silently no-op via the stale-gen
+                # guard (link's expected_generation < runtime's current). Force-sync
+                # means: after reconcile, runtime gen == lab.json gen, so a future
+                # delete_link's expected check matches exactly.
+                iface_runtime = runtime.setdefault("interface_runtime", {})
+                key = str(int(idx))
+                record = iface_runtime.setdefault(key, {})
+                record["current_attach_generation"] = int(want["attach_generation"])
                 tap_names = list(runtime.get("tap_names") or [])
                 if tap not in tap_names:
                     tap_names.append(tap)
@@ -3869,6 +3893,9 @@ class NodeRuntimeService:
             applied.append({"interface_index": idx, "bridge": bridge, "tap": tap})
 
         # ---- Phase 2: tear down attachments not in lab.json ------------
+        # Issue #175 (M1): Phase 2 does NOT bump generation for removed
+        # entries. The next user-driven create_link will bump both lab.json
+        # and runtime sides naturally when the link is re-established.
         for entry in attachments:
             try:
                 idx = int(entry.get("interface_index", -1))

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -625,8 +625,18 @@ class NodeRuntimeService:
         self._record_transition(lab_id, node_id)
         kind = runtime.get("kind")
         if kind == "qemu":
-            self._stop_qemu_runtime(runtime)
-        elif kind == "docker":
+            # Issue #175 (C1): serialize stop against concurrent
+            # reconcile / attach / detach / start on the same (lab, node)
+            # so the runtime mutation in ``_stop_qemu_runtime`` +
+            # ``_delete_runtime`` cannot interleave with another
+            # ``_persist_runtime`` writer. RLock — safe to nest.
+            from app.services.runtime_mutex import runtime_mutex
+
+            with runtime_mutex.acquire_node_sync(lab_id, node_id):
+                self._stop_qemu_runtime(runtime)
+                self._delete_runtime(lab_id, node_id)
+            return
+        if kind == "docker":
             self._stop_docker_runtime(runtime)
 
         self._delete_runtime(lab_id, node_id)
@@ -1341,9 +1351,13 @@ class NodeRuntimeService:
             self._loaded = True
 
     def _persist_runtime(self, runtime: dict[str, Any]) -> None:
-        self._state_path(runtime["lab_id"], runtime["node_id"]).write_text(
-            json.dumps(runtime, indent=2)
-        )
+        # Issue #175 (Q2): atomic write via tmpfile + os.replace so a
+        # concurrent reader cannot observe a torn JSON. ``os.replace``
+        # is atomic on POSIX (rename(2) within the same filesystem).
+        state_path = self._state_path(runtime["lab_id"], runtime["node_id"])
+        tmp_path = state_path.with_suffix(state_path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps(runtime, indent=2))
+        os.replace(tmp_path, state_path)
 
     def _delete_runtime(self, lab_id: str, node_id: int) -> None:
         key = self._key(lab_id, node_id)
@@ -1464,7 +1478,17 @@ class NodeRuntimeService:
                 # is permanent and "connect" becomes a host-only op (link_master
                 # + link_up + QMP set_link up=true). Hubport placeholders
                 # orphaned the e1000 peer on netdev_del + netdev_add (see #174).
-                tap = tap_names[index]
+                # Issue #175 (M4): defensive lookup. _interface_uplink should
+                # return identical results between the provisioning loop and
+                # here, but a stale node mutation between calls would cause
+                # KeyError mid-spawn — surface it as a typed runtime error.
+                tap = tap_names.get(index)
+                if tap is None:
+                    raise NodeRuntimeError(
+                        f"QEMU command build: no TAP provisioned for non-uplink "
+                        f"iface {index}; uplink classification likely changed "
+                        f"between provisioning and command build."
+                    )
                 cmd += [
                     "-netdev", f"tap,id=net{index},ifname={tap},script=no,downscript=no",
                     "-device", device_args,
@@ -1481,6 +1505,28 @@ class NodeRuntimeService:
     def _start_qemu_node(
         self, lab_data: dict[str, Any], node: dict[str, Any]
     ) -> dict[str, Any]:
+        # Issue #175 (C1): hold the node-scoped mutex for the entire
+        # boot path so an in-flight reconcile / attach / detach on the
+        # same (lab, node) cannot race with the freshly-started runtime
+        # record write. The node-scoped lock is RLock — safe to nest if
+        # any inner helper re-acquires.
+        lab_id = self._lab_id(lab_data)
+        node_id = int(node["id"])
+        from app.services.runtime_mutex import runtime_mutex
+
+        with runtime_mutex.acquire_node_sync(lab_id, node_id):
+            return self._start_qemu_node_locked(lab_data, node, lab_id, node_id)
+
+    def _start_qemu_node_locked(
+        self,
+        lab_data: dict[str, Any],
+        node: dict[str, Any],
+        lab_id: str,
+        node_id: int,
+    ) -> dict[str, Any]:
+        """Body of :meth:`_start_qemu_node`. Caller holds the per-(lab,
+        node) node-scoped mutex (issue #175 C1).
+        """
         extras = _node_extras(node)
         architecture = _extra_str(extras, "architecture") or "x86_64"
         qemu_binary = self._resolve_qemu_binary(architecture)
@@ -1488,9 +1534,6 @@ class NodeRuntimeService:
             raise NodeRuntimeError(
                 f"QEMU binary not found for arch {architecture}: {self.settings.QEMU_BINARY}"
             )
-
-        lab_id = self._lab_id(lab_data)
-        node_id = int(node["id"])
         machine, max_nics, hotplug_capable = self._resolve_qemu_machine(node)
 
         # US-302: per-NIC TAP attachments. Pre-flight every declared
@@ -2635,6 +2678,11 @@ class NodeRuntimeService:
         Returns the attachment record (with ``attach_generation``) for the
         link router / link_service to stamp on ``Link.runtime``.
         """
+        # Lock ordering invariant (issue #175): when both per-iface mutex
+        # and node-mutex are needed, per-iface is acquired FIRST by the
+        # external caller, then node-mutex is acquired here. Any new code
+        # path acquiring node-mutex BEFORE per-iface would deadlock —
+        # never do that.
         from app.services.runtime_mutex import runtime_mutex
 
         # Defensive contract: catches accidental bypass of the public API.
@@ -2646,6 +2694,38 @@ class NodeRuntimeService:
             f"runtime_mutex.acquire(...) yourself."
         )
 
+        # Issue #175 (C1): acquire the node-scoped mutex AFTER the
+        # per-iface mutex (held by caller). Wraps the entire host-side +
+        # runtime mutation body so concurrent reconcile/start/stop on
+        # this (lab, node) cannot interleave _persist_runtime writes.
+        # RLock — safe nesting with the inner ``acquire_node_sync`` used
+        # for slot allocation in the hot-plug branch.
+        with runtime_mutex.acquire_node_sync(lab_id, node_id):
+            return self._attach_qemu_interface_inner(
+                lab_id,
+                node_id,
+                network_id,
+                interface_index,
+                bridge_name=bridge_name,
+                nic_model=nic_model,
+                planned_mac=planned_mac,
+            )
+
+    def _attach_qemu_interface_inner(
+        self,
+        lab_id: str,
+        node_id: int,
+        network_id: int,
+        interface_index: int,
+        *,
+        bridge_name: str | None = None,
+        nic_model: str | None = None,
+        planned_mac: str | None = None,
+    ) -> dict[str, Any]:
+        """Body of :meth:`_attach_qemu_interface_locked`. Caller holds
+        BOTH the per-iface mutex (from the outer public entrypoint) and
+        the per-(lab, node) node-scoped mutex (issue #175 C1).
+        """
         runtime = self._runtime_record(lab_id, node_id)
         if runtime is None:
             raise NodeRuntimeError(
@@ -3100,6 +3180,9 @@ class NodeRuntimeService:
         ``links[]`` will be the source of truth and the kernel-side
         object is no longer reachable.
         """
+        # Lock ordering invariant (issue #175): per-iface mutex acquired
+        # FIRST by external caller; node-mutex acquired here SECOND. Same
+        # contract as :meth:`_attach_qemu_interface_locked`.
         from app.services.runtime_mutex import runtime_mutex
 
         # Defensive contract: catches accidental bypass of the public API.
@@ -3111,6 +3194,30 @@ class NodeRuntimeService:
             f"runtime_mutex.acquire(...) yourself."
         )
 
+        # Issue #175 (C1): acquire node-scoped mutex AFTER per-iface
+        # mutex. Wraps the entire host-side + runtime mutation body.
+        with runtime_mutex.acquire_node_sync(lab_id, node_id):
+            return self._detach_qemu_interface_inner(
+                lab_id,
+                node_id,
+                interface_index,
+                lab_path=lab_path,
+                expected_generation=expected_generation,
+            )
+
+    def _detach_qemu_interface_inner(
+        self,
+        lab_id: str,
+        node_id: int,
+        interface_index: int,
+        *,
+        lab_path: str | None = None,
+        expected_generation: int | None = None,
+    ) -> dict[str, Any]:
+        """Body of :meth:`_detach_qemu_interface_locked`. Caller holds
+        BOTH the per-iface mutex and the per-(lab, node) node-scoped
+        mutex (issue #175 C1).
+        """
         runtime = self._runtime_record(lab_id, node_id, include_stopped=True)
         if runtime is None:
             # No runtime record means the node already stopped or never
@@ -3616,6 +3723,28 @@ class NodeRuntimeService:
         except (TypeError, ValueError):
             return {"node_id": None, "applied": [], "removed": [], "warnings": [], "skipped_hotplug": []}
 
+        # Issue #175 (C1): serialize the entire reconcile pass against
+        # concurrent attach/detach/start/stop on the same (lab, node) so
+        # interleaved _persist_runtime writes cannot drop fields. The
+        # node-scoped lock is RLock — safe to nest if a reconcile path
+        # ever needs to delegate into another method that re-acquires.
+        from app.services.runtime_mutex import runtime_mutex
+
+        with runtime_mutex.acquire_node_sync(lab_id, node_id):
+            return self._reconcile_qemu_node_links_locked(
+                lab_id, lab_data, node, node_id
+            )
+
+    def _reconcile_qemu_node_links_locked(
+        self,
+        lab_id: str,
+        lab_data: dict,
+        node: dict,
+        node_id: int,
+    ) -> dict:
+        """Body of :meth:`reconcile_qemu_node_links`. Caller holds the
+        per-(lab, node) node-scoped mutex (issue #175 C1).
+        """
         runtime = self._runtime_record(lab_id, node_id)
         if runtime is None or runtime.get("kind") != "qemu":
             return {"node_id": node_id, "applied": [], "removed": [], "warnings": [], "skipped_hotplug": []}
@@ -3632,7 +3761,15 @@ class NodeRuntimeService:
             ):
                 if not isinstance(endpoint, dict) or not isinstance(peer, dict):
                     continue
-                if endpoint.get("node_id") != node_id:
+                # Issue #175 (C2): lab.json may carry node_id as str (manual
+                # edit / migration / 3rd-party tooling). A bare `!=` against
+                # an int silently skips the endpoint and Phase 2 then tears
+                # down ALL boot-NIC attachments. Match the int(...) pattern
+                # used by every other link-parsing loop in this file.
+                try:
+                    if int(endpoint.get("node_id", -1)) != node_id:
+                        continue
+                except (TypeError, ValueError):
                     continue
                 if "interface_index" not in endpoint:
                     continue
@@ -3678,9 +3815,6 @@ class NodeRuntimeService:
         # ---- Phase 1: ensure expected attachments are present ----------
         with self._lock:
             attachments = list(runtime.get("interface_attachments") or [])
-        existing_by_idx = {
-            int(a.get("interface_index", -1)): a for a in attachments
-        }
 
         for idx, want in expected.items():
             tap = want["tap_name"]
@@ -3744,9 +3878,10 @@ class NodeRuntimeService:
                 continue
             if not bool(entry.get("boot_nic", False)) or idx >= boot_ethernet:
                 # Hot-add ifaces have their own US-304 path. We don't drive
-                # device_del from here. Just observe drift.
-                if idx not in expected:
-                    skipped_hotplug.append({"interface_index": idx})
+                # device_del from here. Just observe drift. (We already
+                # `continue`d above when idx is in expected, so this entry
+                # is by definition not in expected.)
+                skipped_hotplug.append({"interface_index": idx})
                 continue
 
             tap = entry.get("tap_name") or host_net.tap_name(lab_id, node_id, idx)

--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -625,11 +625,8 @@ class NodeRuntimeService:
         self._record_transition(lab_id, node_id)
         kind = runtime.get("kind")
         if kind == "qemu":
-            # Issue #175 (C1): serialize stop against concurrent
-            # reconcile / attach / detach / start on the same (lab, node)
-            # so the runtime mutation in ``_stop_qemu_runtime`` +
-            # ``_delete_runtime`` cannot interleave with another
-            # ``_persist_runtime`` writer. RLock — safe to nest.
+            # Issue #175 (C1): hold node mutex so stop + delete cannot
+            # interleave a concurrent reconcile/attach/start persist write.
             from app.services.runtime_mutex import runtime_mutex
 
             with runtime_mutex.acquire_node_sync(lab_id, node_id):
@@ -1505,11 +1502,8 @@ class NodeRuntimeService:
     def _start_qemu_node(
         self, lab_data: dict[str, Any], node: dict[str, Any]
     ) -> dict[str, Any]:
-        # Issue #175 (C1): hold the node-scoped mutex for the entire
-        # boot path so an in-flight reconcile / attach / detach on the
-        # same (lab, node) cannot race with the freshly-started runtime
-        # record write. The node-scoped lock is RLock — safe to nest if
-        # any inner helper re-acquires.
+        # Issue #175 (C1): hold node mutex for the entire boot path so
+        # a concurrent reconcile/attach/detach cannot race the runtime write.
         lab_id = self._lab_id(lab_data)
         node_id = int(node["id"])
         from app.services.runtime_mutex import runtime_mutex
@@ -2694,12 +2688,8 @@ class NodeRuntimeService:
             f"runtime_mutex.acquire(...) yourself."
         )
 
-        # Issue #175 (C1): acquire the node-scoped mutex AFTER the
-        # per-iface mutex (held by caller). Wraps the entire host-side +
-        # runtime mutation body so concurrent reconcile/start/stop on
-        # this (lab, node) cannot interleave _persist_runtime writes.
-        # RLock — safe nesting with the inner ``acquire_node_sync`` used
-        # for slot allocation in the hot-plug branch.
+        # Issue #175 (C1): acquire node mutex AFTER per-iface mutex (lock
+        # ordering invariant above) to prevent interleaved persist writes.
         with runtime_mutex.acquire_node_sync(lab_id, node_id):
             return self._attach_qemu_interface_inner(
                 lab_id,
@@ -3730,10 +3720,7 @@ class NodeRuntimeService:
             return {"node_id": None, "applied": [], "removed": [], "warnings": [], "skipped_hotplug": []}
 
         # Issue #175 (C1): serialize the entire reconcile pass against
-        # concurrent attach/detach/start/stop on the same (lab, node) so
-        # interleaved _persist_runtime writes cannot drop fields. The
-        # node-scoped lock is RLock — safe to nest if a reconcile path
-        # ever needs to delegate into another method that re-acquires.
+        # concurrent attach/detach/start/stop to prevent interleaved persist writes.
         from app.services.runtime_mutex import runtime_mutex
 
         with runtime_mutex.acquire_node_sync(lab_id, node_id):

--- a/backend/app/services/runtime_mutex.py
+++ b/backend/app/services/runtime_mutex.py
@@ -116,9 +116,6 @@ class RuntimeMutexRegistry:
         # Guards ``_locks`` / ``_node_locks`` themselves.
         self._registry_lock = threading.Lock()
         self._locks: Dict[_MutexKey, threading.Lock] = {}
-        # Issue #175: node-scoped lock is RLock for re-entrant acquires from
-        # nested paths (e.g. outer attach + inner slot-allocation in
-        # ``_attach_qemu_interface_locked``).
         self._node_locks: Dict[_NodeKey, threading.RLock] = {}
 
     def _key(self, lab_id: str, node_id: int, interface_index: int) -> _MutexKey:
@@ -145,9 +142,6 @@ class RuntimeMutexRegistry:
         with self._registry_lock:
             lock = self._node_locks.get(key)
             if lock is None:
-                # Issue #175: re-entrant so the outer acquire taken by
-                # attach/detach/reconcile/start can be nested by the inner
-                # slot-allocation acquire in ``_attach_qemu_interface_locked``.
                 lock = threading.RLock()
                 self._node_locks[key] = lock
             return lock

--- a/backend/app/services/runtime_mutex.py
+++ b/backend/app/services/runtime_mutex.py
@@ -41,6 +41,15 @@ Locking discipline (split public / private — Codex v5 finding #1):
 The registry is intentionally process-local — there is exactly one
 backend process and the mutex protects in-process kernel sequencing only.
 A restart drops every mutex (no leaked state to clean up).
+
+Issue #175: the per-(lab, node) "node-scoped" lock is :class:`threading.RLock`
+(re-entrant) so the existing inner ``acquire_node_sync`` used by
+``_attach_qemu_interface_locked`` for PCIe slot allocation can nest safely
+inside an outer ``acquire_node_sync`` taken by the same thread for the
+full attach / detach / start / reconcile body. The per-(lab, node, iface)
+mutex (``_locks``) stays a plain :class:`threading.Lock` because per-iface
+re-entrance is not needed and keeping it non-reentrant lets the
+``is_held`` defensive contract catch accidental double-acquire bugs.
 """
 
 from __future__ import annotations
@@ -107,7 +116,10 @@ class RuntimeMutexRegistry:
         # Guards ``_locks`` / ``_node_locks`` themselves.
         self._registry_lock = threading.Lock()
         self._locks: Dict[_MutexKey, threading.Lock] = {}
-        self._node_locks: Dict[_NodeKey, threading.Lock] = {}
+        # Issue #175: node-scoped lock is RLock for re-entrant acquires from
+        # nested paths (e.g. outer attach + inner slot-allocation in
+        # ``_attach_qemu_interface_locked``).
+        self._node_locks: Dict[_NodeKey, threading.RLock] = {}
 
     def _key(self, lab_id: str, node_id: int, interface_index: int) -> _MutexKey:
         return (str(lab_id), int(node_id), int(interface_index))
@@ -128,12 +140,15 @@ class RuntimeMutexRegistry:
 
     def _get_or_create_node_lock(
         self, lab_id: str, node_id: int
-    ) -> threading.Lock:
+    ) -> "threading.RLock":
         key = self._node_key(lab_id, node_id)
         with self._registry_lock:
             lock = self._node_locks.get(key)
             if lock is None:
-                lock = threading.Lock()
+                # Issue #175: re-entrant so the outer acquire taken by
+                # attach/detach/reconcile/start can be nested by the inner
+                # slot-allocation acquire in ``_attach_qemu_interface_locked``.
+                lock = threading.RLock()
                 self._node_locks[key] = lock
             return lock
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,24 +2,19 @@ import pytest
 
 
 def _stub_host_net_for_qemu_start(monkeypatch):
-    """Issue #174: every non-uplink boot iface provisions a host TAP at
-    start. This helper stubs the host_net surface used by the QEMU start
-    path so unit tests run without a privileged helper or real
-    ``instance_id`` file.
+    """Issue #174 / #175 (S3): stub the host_net surface used by the QEMU
+    start path so tests run without a privileged helper or real
+    ``instance_id`` file. Canonicalised here so test_node_runtime.py,
+    test_node_extras.py, and test_qemu_pcie_root_ports.py share one
+    definition.
 
     Call this *only* from tests that don't already supply their own
     ``host_net`` patches (e.g. via ``_us302_helper_mock`` or
     ``_us203_helper_mock``); those tests record real call sequences and
     overwriting them here would mask their assertions.
 
-    Issue #175 (S3): canonicalised here so test_node_runtime.py,
-    test_node_extras.py, and test_qemu_pcie_root_ports.py share one
-    definition. Stubs the seven ``host_net`` calls exercised by the QEMU
-    start path: ``tap_name`` / ``tap_exists`` / ``tap_add`` /
-    ``link_master`` / ``link_up`` / ``try_link_del`` / ``bridge_exists``.
-    Tests that need to observe ``link_set_nomaster`` (e.g. the orphan-TAP
-    cleanup test) layer their own monkeypatch on top after calling this
-    helper — leaving it unstubbed here keeps the call observable.
+    ``link_set_nomaster`` is intentionally left unstubbed so tests that
+    need to observe the orphan-TAP cleanup branch can layer their own patch.
     """
     monkeypatch.setattr(
         "app.services.node_runtime_service.host_net.tap_name",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,51 @@
 import pytest
 
 
+def _stub_host_net_for_qemu_start(monkeypatch):
+    """Issue #174: every non-uplink boot iface provisions a host TAP at
+    start. This helper stubs the host_net surface used by the QEMU start
+    path so unit tests run without a privileged helper or real
+    ``instance_id`` file.
+
+    Call this *only* from tests that don't already supply their own
+    ``host_net`` patches (e.g. via ``_us302_helper_mock`` or
+    ``_us203_helper_mock``); those tests record real call sequences and
+    overwriting them here would mask their assertions.
+
+    Issue #175 (S3): canonicalised here so test_node_runtime.py,
+    test_node_extras.py, and test_qemu_pcie_root_ports.py share one
+    definition. Stubs the seven ``host_net`` calls exercised by the QEMU
+    start path: ``tap_name`` / ``tap_exists`` / ``tap_add`` /
+    ``link_master`` / ``link_up`` / ``try_link_del`` / ``bridge_exists``.
+    Tests that need to observe ``link_set_nomaster`` (e.g. the orphan-TAP
+    cleanup test) layer their own monkeypatch on top after calling this
+    helper — leaving it unstubbed here keeps the call observable.
+    """
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_name",
+        lambda lab_id, node_id, iface: f"nve-test-d{node_id}i{iface}",
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_exists", lambda name: False
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_add", lambda name: None
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.link_master",
+        lambda iface, bridge: None,
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.link_up", lambda iface: None
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.try_link_del", lambda name: None
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.bridge_exists", lambda name: True
+    )
+
+
 @pytest.fixture(autouse=True)
 def _redirect_pids_registry(tmp_path_factory, monkeypatch):
     """Redirect ``runtime_pids`` to a tmp path so registration during node

--- a/backend/tests/test_node_extras.py
+++ b/backend/tests/test_node_extras.py
@@ -13,6 +13,7 @@ from app.schemas.node import NodeBatchCreate, NodeCreate, NodeUpdate
 from app.services.lab_service import LabService
 from app.services.node_runtime_service import NodeRuntimeService
 from app.services.template_service import TemplateService
+from tests.conftest import _stub_host_net_for_qemu_start
 
 
 @pytest.fixture(autouse=True)
@@ -272,29 +273,8 @@ def _stub_qemu_subprocess(monkeypatch, recorded):
 
     # Issue #174: every non-uplink boot iface now provisions a host TAP at
     # start. Stub host_net so this unit test runs without a privileged helper.
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_name",
-        lambda lab_id, node_id, iface: f"nve-test-d{node_id}i{iface}",
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_exists", lambda name: False
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_add", lambda name: None
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.link_master",
-        lambda iface, bridge: None,
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.link_up", lambda iface: None
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.try_link_del", lambda name: None
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.bridge_exists", lambda name: True
-    )
+    # Issue #175 (S3): canonicalised in tests/conftest.py.
+    _stub_host_net_for_qemu_start(monkeypatch)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_node_runtime.py
+++ b/backend/tests/test_node_runtime.py
@@ -17,6 +17,7 @@ from app.services.node_runtime_service import (
     _merge_qemu_args,
     _parse_qemu_tokens,
 )
+from tests.conftest import _stub_host_net_for_qemu_start
 
 
 @pytest.fixture(autouse=True)
@@ -169,42 +170,6 @@ def _mock_runtime_binaries(monkeypatch):
     monkeypatch.setattr(
         "app.services.node_runtime_service.NodeRuntimeService._resolve_binary",
         staticmethod(lambda binary: binary),
-    )
-
-
-def _stub_host_net_for_qemu_start(monkeypatch):
-    """Issue #174: every non-uplink boot iface provisions a host TAP at
-    start. This helper stubs the host_net surface used by the QEMU start
-    path so unit tests run without a privileged helper or real
-    ``instance_id`` file.
-
-    Call this *only* from tests that don't already supply their own
-    ``host_net`` patches (e.g. via ``_us302_helper_mock`` or
-    ``_us203_helper_mock``); those tests record real call sequences and
-    overwriting them here would mask their assertions.
-    """
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_name",
-        lambda lab_id, node_id, iface: f"nve-test-d{node_id}i{iface}",
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_exists", lambda name: False
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_add", lambda name: None
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.link_master",
-        lambda iface, bridge: None,
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.link_up", lambda iface: None
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.try_link_del", lambda name: None
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.bridge_exists", lambda name: True
     )
 
 

--- a/backend/tests/test_qemu_pcie_root_ports.py
+++ b/backend/tests/test_qemu_pcie_root_ports.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.services.node_runtime_service import NodeRuntimeService
+from tests.conftest import _stub_host_net_for_qemu_start
 
 
 @pytest.fixture(autouse=True)
@@ -108,36 +109,8 @@ def argv_capture(monkeypatch):
     # Issue #174: every non-uplink boot iface now provisions a TAP at start.
     # Stub host_net so unit tests that don't have a real instance_id or
     # privileged helper still exercise the argv path.
-    def fake_tap_name(lab_id, node_id, iface):
-        return f"nve-test-d{node_id}i{iface}"
-
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_name", fake_tap_name
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_exists",
-        lambda name: False,
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.tap_add",
-        lambda name: None,
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.link_master",
-        lambda iface, bridge: None,
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.link_up",
-        lambda iface: None,
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.try_link_del",
-        lambda name: None,
-    )
-    monkeypatch.setattr(
-        "app.services.node_runtime_service.host_net.bridge_exists",
-        lambda name: True,
-    )
+    # Issue #175 (S3): canonicalised in tests/conftest.py.
+    _stub_host_net_for_qemu_start(monkeypatch)
     return captured
 
 

--- a/backend/tests/test_reconcile_qemu_node_links.py
+++ b/backend/tests/test_reconcile_qemu_node_links.py
@@ -1,0 +1,728 @@
+"""Issue #175 (S3): regression coverage for ``reconcile_qemu_node_links``
+plus the boot-NIC detach failure contract and the start-time orphan-TAP
+cleanup branch.
+
+The reconciler tests construct a synthetic in-process runtime record
+(no real QEMU process) and stub :mod:`host_net` so the test runs without
+the privileged helper. They exercise the PUBLIC outer methods
+(``reconcile_qemu_node_links``, ``detach_qemu_interface``) so the
+node-scoped + per-iface mutex acquisition is included in coverage.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import host_net
+from app.services.node_runtime_service import NodeRuntimeService
+from tests.conftest import _stub_host_net_for_qemu_start
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_registry():
+    NodeRuntimeService.reset_registry()
+    yield
+    NodeRuntimeService.reset_registry()
+
+
+@pytest.fixture()
+def runtime_settings(tmp_path):
+    labs_dir = tmp_path / "labs"
+    images_dir = tmp_path / "images"
+    tmp_dir = tmp_path / "tmp"
+    labs_dir.mkdir()
+    images_dir.mkdir()
+    tmp_dir.mkdir()
+    return SimpleNamespace(
+        LABS_DIR=labs_dir,
+        IMAGES_DIR=images_dir,
+        TMP_DIR=tmp_dir,
+        QEMU_BINARY="qemu-system-x86_64",
+        QEMU_IMG_BINARY="qemu-img",
+        DOCKER_HOST="unix:///var/run/docker.sock",
+        GUACAMOLE_DATABASE_URL="",
+        GUACAMOLE_DATA_SOURCE="postgresql",
+        GUACAMOLE_INTERNAL_URL="http://127.0.0.1:8081/html5/",
+        GUACAMOLE_JSON_SECRET_KEY="4c0b569e4c96df157eee1b65dd0e4d41",
+        GUACAMOLE_PUBLIC_PATH="/html5/",
+        GUACAMOLE_TARGET_HOST="host.docker.internal",
+        GUACAMOLE_JSON_EXPIRE_SECONDS=300,
+        GUACAMOLE_TERMINAL_FONT_NAME="Roboto Mono",
+        GUACAMOLE_TERMINAL_FONT_SIZE=10,
+    )
+
+
+@pytest.fixture()
+def patched_settings(monkeypatch, runtime_settings):
+    monkeypatch.setattr(
+        "app.services.lab_service.get_settings", lambda: runtime_settings
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.get_settings", lambda: runtime_settings
+    )
+    return runtime_settings
+
+
+def _seed_running_qemu_runtime(
+    service: NodeRuntimeService,
+    *,
+    lab_id: str,
+    node_id: int,
+    boot_ethernet: int = 2,
+    interface_attachments: list[dict] | None = None,
+    interface_runtime: dict[str, dict] | None = None,
+    qmp_socket: str = "/tmp/test-qmp.sock",
+) -> dict:
+    """Insert a 'running' QEMU runtime record into the in-process registry.
+
+    Mirrors the shape produced by :meth:`_start_qemu_node` but skips the
+    real spawn — sufficient for reconciler / detach unit tests because
+    the target methods read only the registry + lab.json input.
+    """
+    runtime = {
+        "lab_id": lab_id,
+        "node_id": int(node_id),
+        "kind": "qemu",
+        "name": f"node-{node_id}",
+        "console": "telnet",
+        "console_port": 12345,
+        "pid": 4321,
+        "pid_create_time": 1.0,
+        "work_dir": f"/tmp/lab-{lab_id}-node-{node_id}",
+        "stdout_log": f"/tmp/lab-{lab_id}-node-{node_id}/stdout.log",
+        "stderr_log": f"/tmp/lab-{lab_id}-node-{node_id}/stderr.log",
+        "qmp_socket": qmp_socket,
+        "command": [],
+        "started_at": 1.0,
+        "boot_ethernet": int(boot_ethernet),
+        "interface_attachments": list(interface_attachments or []),
+        "interface_runtime": dict(interface_runtime or {}),
+        "tap_names": [],
+        "allocated_slots": [],
+    }
+    service._registry[service._key(lab_id, int(node_id))] = runtime
+    # Make ``_runtime_record`` treat the synthetic record as alive so the
+    # public reconcile/detach paths don't reap it.
+    service._is_runtime_alive = lambda _r: True  # type: ignore[assignment]
+    return runtime
+
+
+def _make_lab_data(
+    *, lab_id: str, node_id, network_id: int, attach_generation: int = 1
+) -> dict:
+    """Minimal lab.json shape with a single (node, iface 0) -> network link."""
+    return {
+        "schema": 2,
+        "id": lab_id,
+        "meta": {"name": "reconcile-tests"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            str(node_id): {
+                "id": int(node_id) if not isinstance(node_id, str) else int(node_id),
+                "name": "vm-1",
+                "type": "qemu",
+                "ethernet": 2,
+                "interfaces": [
+                    {"index": 0, "name": "eth0", "planned_mac": None},
+                    {"index": 1, "name": "eth1", "planned_mac": None},
+                ],
+            }
+        },
+        "networks": {
+            str(network_id): {
+                "id": network_id,
+                "name": "lab-link",
+                "type": "linux_bridge",
+                "visibility": True,
+                "implicit": False,
+                "config": {},
+            }
+        },
+        "links": [
+            {
+                "id": "lnk-1",
+                "from": {"node_id": node_id, "interface_index": 0},
+                "to": {"network_id": network_id},
+                "style_override": None,
+                "label": "",
+                "color": "",
+                "width": "1",
+                "metrics": {
+                    "delay_ms": 0,
+                    "loss_pct": 0,
+                    "bandwidth_kbps": 0,
+                    "jitter_ms": 0,
+                },
+                "runtime": {"attach_generation": int(attach_generation)},
+            }
+        ],
+        "defaults": {"link_style": "orthogonal"},
+    }
+
+
+def _stub_reconciler_host_net(monkeypatch, *, tap_exists: bool = True):
+    """Stub the ``host_net`` surface used by the reconciler.
+
+    The reconciler reads ``bridge_name`` / ``tap_name`` (deterministic
+    name derivation) and writes via ``link_master`` / ``link_up`` /
+    ``link_set_nomaster``. We capture writes so tests can assert call
+    sequences.
+    """
+    calls: dict[str, list] = {
+        "tap_exists": [],
+        "tap_add": [],
+        "link_master": [],
+        "link_up": [],
+        "link_set_nomaster": [],
+    }
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.bridge_name",
+        lambda lab_id, network_id: f"nve-test-bridge-{network_id}",
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_name",
+        lambda lab_id, node_id, iface: f"nve-test-d{node_id}i{iface}",
+    )
+
+    def fake_tap_exists(name: str) -> bool:
+        calls["tap_exists"].append(name)
+        return tap_exists
+
+    def fake_tap_add(name: str) -> None:
+        calls["tap_add"].append(name)
+
+    def fake_link_master(iface: str, bridge: str) -> None:
+        calls["link_master"].append((iface, bridge))
+
+    def fake_link_up(iface: str) -> None:
+        calls["link_up"].append(iface)
+
+    def fake_link_set_nomaster(iface: str) -> None:
+        calls["link_set_nomaster"].append(iface)
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_exists", fake_tap_exists
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_add", fake_tap_add
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.link_master", fake_link_master
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.link_up", fake_link_up
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.link_set_nomaster",
+        fake_link_set_nomaster,
+    )
+    return calls
+
+
+def _capture_qmp(service: NodeRuntimeService) -> list[dict]:
+    """Replace ``_qmp_command`` with a recorder so reconciler / detach
+    tests can assert ``set_link`` invocations without needing a live
+    QMP socket. Returns the captured-calls list.
+    """
+    captured: list[dict] = []
+
+    def fake_qmp_command(socket_path, command, arguments=None):
+        captured.append(
+            {"socket": socket_path, "command": command, "arguments": arguments}
+        )
+        return {"return": {}}
+
+    service._qmp_command = fake_qmp_command  # type: ignore[assignment]
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_reconciler_phase1_attaches_missing_iface(monkeypatch, patched_settings):
+    """Phase 1: a runtime record with no attachments + a lab.json link
+    drives ``link_master`` + ``link_up`` + QMP ``set_link up=true`` and
+    appends a fresh ``interface_attachments`` entry.
+    """
+    lab_id = "lab-recon-A"
+    node_id = 1
+    service = NodeRuntimeService()
+    runtime = _seed_running_qemu_runtime(
+        service, lab_id=lab_id, node_id=node_id, interface_attachments=[]
+    )
+    lab_data = _make_lab_data(
+        lab_id=lab_id, node_id=node_id, network_id=1, attach_generation=1
+    )
+
+    host_calls = _stub_reconciler_host_net(monkeypatch, tap_exists=True)
+    qmp_calls = _capture_qmp(service)
+
+    result = service.reconcile_qemu_node_links(
+        lab_id, lab_data, lab_data["nodes"]["1"]
+    )
+
+    expected_tap = f"nve-test-d{node_id}i0"
+    expected_bridge = "nve-test-bridge-1"
+
+    assert result["node_id"] == node_id
+    assert len(result["applied"]) == 1
+    assert result["applied"][0]["interface_index"] == 0
+    assert result["applied"][0]["tap"] == expected_tap
+    assert result["applied"][0]["bridge"] == expected_bridge
+    assert result["removed"] == []
+
+    # Runtime now has the attachment record with boot_nic=True.
+    attachments = runtime["interface_attachments"]
+    assert len(attachments) == 1
+    assert attachments[0]["interface_index"] == 0
+    assert attachments[0]["network_id"] == 1
+    assert attachments[0]["boot_nic"] is True
+    assert attachments[0]["tap_name"] == expected_tap
+    assert attachments[0]["bridge_name"] == expected_bridge
+
+    # host_net was driven on the (tap, bridge) pair.
+    assert (expected_tap, expected_bridge) in host_calls["link_master"]
+    assert expected_tap in host_calls["link_up"]
+    # tap_add MUST NOT be called when tap_exists=True (idempotency).
+    assert host_calls["tap_add"] == []
+
+    # QMP ``set_link`` issued for net0 with up=True.
+    set_link_calls = [c for c in qmp_calls if c["command"] == "set_link"]
+    assert any(
+        c["arguments"] == {"name": "net0", "up": True} for c in set_link_calls
+    ), f"expected set_link(net0, up=True) in {set_link_calls}"
+
+
+def test_reconciler_phase2_tears_down_stale_attachment(
+    monkeypatch, patched_settings
+):
+    """Phase 2: a stale boot-NIC attachment with no matching link in
+    ``lab.json`` is torn down via ``link_set_nomaster`` + QMP ``set_link
+    up=false``, and the entry is dropped from ``interface_attachments``.
+    """
+    lab_id = "lab-recon-B"
+    node_id = 2
+    stale_tap = f"nve-test-d{node_id}i0"
+    service = NodeRuntimeService()
+    runtime = _seed_running_qemu_runtime(
+        service,
+        lab_id=lab_id,
+        node_id=node_id,
+        interface_attachments=[
+            {
+                "interface_index": 0,
+                "network_id": 1,
+                "bridge_name": "nve-test-bridge-1",
+                "tap_name": stale_tap,
+                "slot": None,
+                "boot_nic": True,
+                "nic_model": "e1000",
+                "attach_generation": 1,
+                "planned_mac": "",
+            }
+        ],
+    )
+    # lab.json has NO links — the attachment is stale (link was deleted
+    # while the node was running and the stale-gen guard skipped detach).
+    lab_data = {
+        "schema": 2,
+        "id": lab_id,
+        "meta": {"name": "phase2"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            "2": {
+                "id": node_id,
+                "name": "vm-2",
+                "type": "qemu",
+                "ethernet": 2,
+                "interfaces": [],
+            }
+        },
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+
+    host_calls = _stub_reconciler_host_net(monkeypatch, tap_exists=True)
+    qmp_calls = _capture_qmp(service)
+
+    result = service.reconcile_qemu_node_links(
+        lab_id, lab_data, lab_data["nodes"]["2"]
+    )
+
+    assert result["applied"] == []
+    assert len(result["removed"]) == 1
+    assert result["removed"][0]["interface_index"] == 0
+    assert result["removed"][0]["tap"] == stale_tap
+
+    # Attachment is gone from runtime.
+    assert runtime["interface_attachments"] == []
+
+    # link_set_nomaster called with the stale TAP.
+    assert stale_tap in host_calls["link_set_nomaster"]
+
+    # QMP set_link with up=False issued for net0.
+    set_link_calls = [c for c in qmp_calls if c["command"] == "set_link"]
+    assert any(
+        c["arguments"] == {"name": "net0", "up": False} for c in set_link_calls
+    ), f"expected set_link(net0, up=False) in {set_link_calls}"
+
+
+def test_reconciler_handles_string_node_id_in_labjson(
+    monkeypatch, patched_settings
+):
+    """Issue #175 (C2): lab.json may carry ``from.node_id`` as a string
+    (manual edit / migration / 3rd-party tooling). The reconciler MUST
+    accept the string and treat the link as expected; otherwise Phase 2
+    tears down all matching boot-NIC attachments.
+    """
+    lab_id = "lab-recon-C"
+    node_id = 3
+    expected_tap = f"nve-test-d{node_id}i0"
+    service = NodeRuntimeService()
+    # Pre-existing attachment record (e.g. from a previous reconcile pass).
+    runtime = _seed_running_qemu_runtime(
+        service,
+        lab_id=lab_id,
+        node_id=node_id,
+        interface_attachments=[
+            {
+                "interface_index": 0,
+                "network_id": 1,
+                "bridge_name": "nve-test-bridge-1",
+                "tap_name": expected_tap,
+                "slot": None,
+                "boot_nic": True,
+                "nic_model": "e1000",
+                "attach_generation": 1,
+                "planned_mac": "",
+            }
+        ],
+    )
+    # lab.json with from.node_id as STRING "3".
+    lab_data = _make_lab_data(
+        lab_id=lab_id,
+        node_id="3",
+        network_id=1,
+        attach_generation=1,
+    )
+
+    _stub_reconciler_host_net(monkeypatch, tap_exists=True)
+    _capture_qmp(service)
+
+    result = service.reconcile_qemu_node_links(
+        lab_id, lab_data, {"id": node_id, "type": "qemu"}
+    )
+
+    # Before issue #175 (C2) the int(...) cast was missing: ``applied``
+    # would be empty AND ``removed`` would tear down the boot-NIC. With
+    # the fix, the link is recognised and the attachment is refreshed.
+    assert len(result["applied"]) == 1, (
+        f"reconciler must accept str node_id in lab.json; got {result}"
+    )
+    assert result["applied"][0]["interface_index"] == 0
+    assert result["removed"] == [], (
+        f"removed must be empty (link is expected, not stale); got {result}"
+    )
+    # Attachment record retained / refreshed (not torn down).
+    assert len(runtime["interface_attachments"]) == 1
+    assert runtime["interface_attachments"][0]["interface_index"] == 0
+
+
+def test_reconciler_phase1_force_syncs_generation(monkeypatch, patched_settings):
+    """Issue #175 (M1): Phase 1 must FORCE-SYNC
+    ``current_attach_generation`` to the lab.json link's
+    ``attach_generation`` — NOT bump it. Bumping past the lab.json value
+    breaks the next user-driven ``delete_link`` stale-gen guard.
+    """
+    lab_id = "lab-recon-D"
+    node_id = 4
+    service = NodeRuntimeService()
+    # Stale runtime gen=3, no prior attachment record. lab.json gen=7.
+    runtime = _seed_running_qemu_runtime(
+        service,
+        lab_id=lab_id,
+        node_id=node_id,
+        interface_attachments=[],
+        interface_runtime={"0": {"current_attach_generation": 3}},
+    )
+    lab_data = _make_lab_data(
+        lab_id=lab_id, node_id=node_id, network_id=1, attach_generation=7
+    )
+
+    _stub_reconciler_host_net(monkeypatch, tap_exists=True)
+    _capture_qmp(service)
+
+    result = service.reconcile_qemu_node_links(
+        lab_id, lab_data, lab_data["nodes"]["4"]
+    )
+
+    assert len(result["applied"]) == 1
+
+    # Force-sync semantics: runtime gen == lab.json gen, exactly.
+    assert (
+        runtime["interface_runtime"]["0"]["current_attach_generation"] == 7
+    ), (
+        "expected force-sync to 7 (lab.json gen); got "
+        f"{runtime['interface_runtime']['0']['current_attach_generation']}"
+    )
+
+    # The newly-written attachment carries the same gen.
+    attachments = runtime["interface_attachments"]
+    assert len(attachments) == 1
+    assert attachments[0]["attach_generation"] == 7
+
+
+def test_detach_boot_nic_raises_on_link_set_nomaster_failure(
+    monkeypatch, patched_settings
+):
+    """Issue #175 (M3): boot-NIC detach must RAISE on
+    ``link_set_nomaster`` failure. Swallowing leaves the TAP on the
+    bridge (packets still flow) while the system thinks detach
+    succeeded — generation bumped, attachment dropped, lab.json link
+    removed by ``delete_link``, no way to retry.
+
+    On raise, ``interface_attachments`` and
+    ``current_attach_generation`` MUST be unchanged.
+    """
+    lab_id = "lab-recon-E"
+    node_id = 5
+    boot_tap = f"nve-test-d{node_id}i0"
+    service = NodeRuntimeService()
+    runtime = _seed_running_qemu_runtime(
+        service,
+        lab_id=lab_id,
+        node_id=node_id,
+        interface_attachments=[
+            {
+                "interface_index": 0,
+                "network_id": 1,
+                "bridge_name": "nve-test-bridge-1",
+                "tap_name": boot_tap,
+                "slot": None,
+                "boot_nic": True,
+                "nic_model": "e1000",
+                "attach_generation": 4,
+                "planned_mac": "",
+            }
+        ],
+        interface_runtime={"0": {"current_attach_generation": 4}},
+    )
+
+    # Stub QMP set_link (best-effort path — must succeed so we reach the
+    # link_set_nomaster call below).
+    _capture_qmp(service)
+
+    # Stub ``host_net.tap_name`` to match the seeded TAP name (the detach
+    # path falls back to ``host_net.tap_name(...)`` if ``target.tap_name``
+    # is missing, but we set it on the attachment so this is purely
+    # defensive — keep it for parity with the start-path stubs).
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_name",
+        lambda lab_id, node_id, iface: f"nve-test-d{node_id}i{iface}",
+    )
+
+    # The failure injection: ``link_set_nomaster`` raises HostNetError.
+    nomaster_calls: list[str] = []
+
+    def failing_link_set_nomaster(iface: str) -> None:
+        nomaster_calls.append(iface)
+        raise host_net.HostNetError("simulated bridge detach failure")
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.link_set_nomaster",
+        failing_link_set_nomaster,
+    )
+
+    # Detach must propagate the HostNetError.
+    with pytest.raises(host_net.HostNetError, match="simulated"):
+        service.detach_qemu_interface(lab_id, node_id, 0)
+
+    # link_set_nomaster was attempted on the boot TAP exactly once.
+    assert nomaster_calls == [boot_tap]
+
+    # Runtime is UNCHANGED: attachment retained, generation NOT bumped.
+    assert len(runtime["interface_attachments"]) == 1
+    assert runtime["interface_attachments"][0]["interface_index"] == 0
+    assert (
+        runtime["interface_runtime"]["0"]["current_attach_generation"] == 4
+    ), (
+        "current_attach_generation must NOT be bumped when detach raises; "
+        f"got {runtime['interface_runtime']['0']['current_attach_generation']}"
+    )
+
+
+def test_start_qemu_orphan_tap_cleanup(
+    monkeypatch, patched_settings, tmp_path
+):
+    """Commit 7f8f8bf: a pre-existing TAP with a stale bridge master from
+    a prior crashed start MUST be detached via ``link_set_nomaster`` in
+    the boot loop's ``else`` branch. The branch fires when:
+
+      1. ``host_net.tap_exists`` is True (TAP pre-existed; ``tap_add`` is
+         skipped).
+      2. The interface index is NOT in ``attachment_by_index`` (no link
+         declared in lab.json for this iface), so the loop falls into the
+         orphan-cleanup ``else`` branch.
+
+    Symptom of the bug: a re-start after a crash left orphan boot TAPs
+    on whatever bridge they were last attached to, so packets continued
+    to flow on a now-disconnected lab link.
+    """
+    lab_id = "lab-recon-F"
+    node_id = 6
+    expected_orphan_tap = f"nve-test-d{node_id}i0"
+
+    service = NodeRuntimeService()
+
+    # ---- Lab data: NO link for iface 0 (so it's an orphan candidate). --
+    # The node has ethernet=1 (just one boot iface so the test is tightly
+    # scoped to the orphan branch).
+    lab_data = {
+        "schema": 2,
+        "id": lab_id,
+        "meta": {"name": "orphan-test"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            str(node_id): {
+                "id": node_id,
+                "name": "vm-orphan",
+                "type": "qemu",
+                "image": "router-image",
+                "console": "telnet",
+                "cpu": 1,
+                "ram": 256,
+                "ethernet": 1,
+                "firstmac": "50:00:00:01:00:00",
+                "interfaces": [
+                    {
+                        "index": 0,
+                        "name": "eth0",
+                        "planned_mac": None,
+                        "port_position": None,
+                    }
+                ],
+            }
+        },
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+    (patched_settings.LABS_DIR / "orphan.json").write_text(json.dumps(lab_data))
+    image_dir = patched_settings.IMAGES_DIR / "qemu" / "router-image"
+    image_dir.mkdir(parents=True, exist_ok=True)
+    (image_dir / "hda.qcow2").write_text("base-image")
+
+    # ---- Track host_net calls. Start from the canonical stub, then
+    # override ``tap_exists`` to return True (orphan scenario) and
+    # ``link_set_nomaster`` so we can assert it was invoked. ---------
+    _stub_host_net_for_qemu_start(monkeypatch)
+
+    # Counters.
+    tap_add_calls: list[str] = []
+    link_set_nomaster_calls: list[str] = []
+
+    def fake_tap_exists(name: str) -> bool:
+        return True  # orphan — pre-existing TAP from a crashed prior start
+
+    def fake_tap_add(name: str) -> None:
+        tap_add_calls.append(name)
+
+    def fake_link_set_nomaster(iface: str) -> None:
+        # Production code wraps this in ``except host_net.HostNetError:
+        # pass`` for the orphan-cleanup branch. We DO NOT raise here so
+        # the call is observed; the swallow path is the OPPOSITE branch.
+        link_set_nomaster_calls.append(iface)
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_exists", fake_tap_exists
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.tap_add", fake_tap_add
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.host_net.link_set_nomaster",
+        fake_link_set_nomaster,
+    )
+
+    # ---- Stub QEMU subprocess + binaries + clock so spawn is inert. ---
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.NodeRuntimeService._resolve_binary",
+        staticmethod(lambda binary: binary),
+    )
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 4242):
+            self.pid = pid
+
+        def poll(self):
+            return None
+
+    def fake_run(cmd, capture_output=False, text=False, **_kwargs):
+        # qemu-img create writes the overlay file; mimic that.
+        if cmd and Path(cmd[0]).name == "qemu-img":
+            Path(cmd[-1]).write_text("overlay-image")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_popen(
+        cmd, cwd=None, stdin=None, stdout=None, stderr=None, start_new_session=None
+    ):
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.subprocess.run", fake_run
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.time.sleep", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(
+        "app.services.node_runtime_service.psutil.Process",
+        lambda pid: SimpleNamespace(
+            create_time=lambda: 222.0,
+            cpu_percent=lambda interval=0.0: 0,
+            memory_info=lambda: SimpleNamespace(rss=0),
+            wait=lambda timeout=5: None,
+            is_running=lambda: True,
+            status=lambda: "sleeping",
+        ),
+    )
+
+    # Seed an instance_id so ``host_net.bridge_name`` / ``tap_name``
+    # don't blow up.
+    instance_dir = tmp_path / "nova-ve-instance"
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    (instance_dir / "instance_id").write_text("test-instance-S3")
+    monkeypatch.setenv("NOVA_VE_INSTANCE_DIR", str(instance_dir))
+
+    # ---- Run the boot path. ---------------------------------------------
+    runtime = service._start_qemu_node(lab_data, lab_data["nodes"][str(node_id)])
+
+    # The orphan branch fired: link_set_nomaster called for iface 0's TAP.
+    assert expected_orphan_tap in link_set_nomaster_calls, (
+        f"expected link_set_nomaster({expected_orphan_tap!r}) in "
+        f"{link_set_nomaster_calls}"
+    )
+
+    # tap_add MUST NOT be called for an iface whose TAP already exists.
+    assert expected_orphan_tap not in tap_add_calls, (
+        f"tap_add must be skipped when tap_exists=True; got {tap_add_calls}"
+    )
+
+    # Sanity: the runtime record was created (the start path completed
+    # past the boot loop).
+    assert runtime["lab_id"] == lab_id
+    assert runtime["node_id"] == node_id

--- a/backend/tests/test_reconcile_qemu_node_links.py
+++ b/backend/tests/test_reconcile_qemu_node_links.py
@@ -524,10 +524,7 @@ def test_detach_boot_nic_raises_on_link_set_nomaster_failure(
     # link_set_nomaster call below).
     _capture_qmp(service)
 
-    # Stub ``host_net.tap_name`` to match the seeded TAP name (the detach
-    # path falls back to ``host_net.tap_name(...)`` if ``target.tap_name``
-    # is missing, but we set it on the attachment so this is purely
-    # defensive — keep it for parity with the start-path stubs).
+    # Stub ``host_net.tap_name`` so the detach fallback resolves consistently.
     monkeypatch.setattr(
         "app.services.node_runtime_service.host_net.tap_name",
         lambda lab_id, node_id, iface: f"nve-test-d{node_id}i{iface}",


### PR DESCRIPTION
## Summary

- Replaces `-netdev hubport` boot-time placeholders with always-allocated TAPs so the e1000 ↔ TAP peer is permanent for the QEMU lifetime (#174 — fixes guest carrier-down despite host-side TAP-on-bridge).
- Adds an idempotent reconciler (`reconcile_qemu_node_links`) that converges runtime + kernel state to lab.json `links[]`, hooked into `ensure_lab_bridges` and `link_service.create_link` / `delete_link`.
- Hardens the reconciler against all 17 issues raised in critic review #175: node-level mutex serialization, atomic runtime-state writes, generation force-sync, hard-fail on `link_set_nomaster`, and 6 new regression tests.

## Commits

| SHA | Title |
|---|---|
| `5296342` | Reconcile lab bridges on open and self-heal missing host bridges at attach time |
| `156c3c6` | Force bridges UP when ports attach and reconcile QEMU NIC carrier state |
| `43691c9` | Replace hubport boot placeholders with always-allocated TAPs + add reconciler (#174) |
| `7f8f8bf` | Idempotent boot path: detach unconnected boot TAPs from any stale master (#174) |
| `6c5ab0a` | Serialize reconciler/attach/detach via node mutex + atomic runtime persist (#175 — C1 + M2 + Q2) |
| `8a88f74` | Force-sync gen + raise on boot-NIC detach failure + observability (#175 — M1 + M3 + N4 + N5) |
| `a68066e` | Tests: reconciler regression coverage + conftest extraction (#175 — N1 + 6 regression tests) |
| `469dcea` | Clean code slop in #175 fixes |

Plus 4 small safe fixes (C2 type bug, M4 defensive lookup, N2/N3 dead code) shipped earlier in the branch.

## Lock-ordering invariant (#175 C1)

When both per-iface and node mutexes are needed, **per-iface acquired by external caller FIRST, then node-mutex acquired by the locked-variant SECOND**. `_node_locks` is `threading.RLock` so the existing inner `acquire_node_sync` (slot allocation) re-enters safely. Verified across 9 call sites in critic re-review.

## Critic verdict

`oh-my-claudecode:critic` re-reviewed all three substantive #175 commits and returned **ACCEPT** with all 17 findings closed. Full critic report on [#175 comment thread](https://github.com/fahadysf/nova-ve/issues/175).

## Test plan

- [x] `cd backend && python -m pytest -q` — **678 passed, 2 skipped, 0 failed** (was 672 baseline + 6 new regression tests).
- [x] Live verification on test VM `192.168.100.212` of the #174 fix (boot/attach/detach/re-attach cycles, no TAP orphaning, MAC learning on bridge FDB).
- [ ] Re-deploy to test VM and verify the #175 hardening doesn't regress anything (will follow merge).
- [ ] Smoke test concurrent link create/delete to confirm no reconciler races (will follow merge — manual scripted check).

Closes #174. Closes #175.