### PR TITLE
PUT /topology now drives runtime reconcile (#174 follow-up)

### DIFF
--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import uuid
 from urllib.parse import quote
 
@@ -22,6 +23,8 @@ from app.services.lab_service import LEGACY_SCHEMA_ERROR, LabService, _lab_file_
 from app.services.node_runtime_service import NodeRuntimeError, NodeRuntimeService
 from app.services.template_service import TemplateError, TemplateService, _icon_filename_for, render_interface_name
 from app.services.ws_hub import ws_hub
+
+_logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/labs", tags=["labs"])
 
@@ -414,15 +417,6 @@ async def update_topology(
 ):
     try:
         scoped_path = _scoped_lab_path(current_user, lab_path, treat_as_absolute=True)
-        data = _read_lab_data(scoped_path)
-    except LegacyLabSchemaError as exc:
-        return _legacy_schema_response(exc)
-    except FileNotFoundError:
-        return {
-            "code": 404,
-            "status": "fail",
-            "message": "Lab does not exist (60038).",
-        }
     except PermissionError as e:
         return {
             "code": 403,
@@ -430,24 +424,72 @@ async def update_topology(
             "message": str(e),
         }
 
-    if isinstance(payload, list):
-        data["topology"] = payload
-    else:
-        data["topology"] = payload.get("topology", data.get("topology", []))
-        for node_id, node_patch in payload.get("nodes", {}).items():
-            node = data.get("nodes", {}).get(str(node_id))
-            if node and isinstance(node_patch, dict):
-                for field, value in node_patch.items():
-                    if value is not None:
-                        node[field] = value
-        for network_id, network_patch in payload.get("networks", {}).items():
-            network = data.get("networks", {}).get(str(network_id))
-            if network and isinstance(network_patch, dict):
-                for field, value in network_patch.items():
-                    if value is not None:
-                        network[field] = value
+    settings = get_settings()
+    normalized = _normalize_relative_lab_path(scoped_path)
 
-    LabService.write_lab_json_static(scoped_path, data)
+    # Issue #174 follow-up: serialize topology writes against link_service /
+    # network_service via lab_lock. Without this, two concurrent writers can
+    # interleave and lose mutations. Plus, the post-write reconcile below has
+    # to see the same JSON state we just wrote — read inside the lock.
+    with lab_lock(normalized, settings.LABS_DIR):
+        try:
+            data = _read_lab_data(scoped_path)
+        except LegacyLabSchemaError as exc:
+            return _legacy_schema_response(exc)
+        except FileNotFoundError:
+            return {
+                "code": 404,
+                "status": "fail",
+                "message": "Lab does not exist (60038).",
+            }
+
+        if isinstance(payload, list):
+            data["topology"] = payload
+        else:
+            data["topology"] = payload.get("topology", data.get("topology", []))
+            for node_id, node_patch in payload.get("nodes", {}).items():
+                node = data.get("nodes", {}).get(str(node_id))
+                if node and isinstance(node_patch, dict):
+                    for field, value in node_patch.items():
+                        if value is not None:
+                            node[field] = value
+            for network_id, network_patch in payload.get("networks", {}).items():
+                network = data.get("networks", {}).get(str(network_id))
+                if network and isinstance(network_patch, dict):
+                    for field, value in network_patch.items():
+                        if value is not None:
+                            network[field] = value
+
+        LabService.write_lab_json_static(scoped_path, data)
+
+        # Issue #174 follow-up: bridge the legacy PUT /topology bypass that
+        # previously skipped runtime reconciliation. The UI deletes a link by
+        # PUT /topology with the shorter array (NOT DELETE /links/{id}), and
+        # write_lab_json_static regenerates links[] from topology[] — so links
+        # disappear from lab.json without link_service.delete_link ever
+        # firing. Result: kernel TAPs stayed on the bridge and QMP set_link
+        # stayed UP, leaving guest carrier up forever even though the link
+        # was "deleted" in lab.json. Mirror the reconcile-after-write block
+        # from link_service.create_link / delete_link so any path that
+        # mutates lab.json drives runtime + kernel state to match.
+        try:
+            data_after = LabService.read_lab_json_static(scoped_path)
+            lab_id_after = str(data_after.get("id") or scoped_path)
+            rt_svc = NodeRuntimeService()
+            for raw_id, node_after in (data_after.get("nodes") or {}).items():
+                if not isinstance(node_after, dict):
+                    continue
+                if str(node_after.get("type") or "").lower() != "qemu":
+                    continue
+                rt_svc.reconcile_qemu_node_links(
+                    lab_id_after, data_after, node_after
+                )
+        except Exception:  # noqa: BLE001 — best-effort, observability only
+            _logger.exception(
+                "PUT /topology: post-write reconcile failed (lab=%s)",
+                scoped_path,
+            )
+
     return {
         "code": 200,
         "status": "success",

--- a/backend/app/services/lab_lock.py
+++ b/backend/app/services/lab_lock.py
@@ -20,6 +20,10 @@ def lab_lock(lab_id: str, labs_dir: Path, timeout_s: float = 5.0):
     labs_dir = Path(labs_dir)
     labs_dir.mkdir(parents=True, exist_ok=True)
     lock_path = labs_dir / f"{lab_id}.lock"
+    # Issue #174 follow-up: when lab_id contains path separators (nested
+    # labs like "nested/lab.json"), the lock file's parent directory may
+    # not exist. Create it so open(...) doesn't fail with FileNotFoundError.
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
     deadline = time.monotonic() + timeout_s
     with open(lock_path, 'a+') as fd:  # 'a+' avoids truncation
         while True:


### PR DESCRIPTION
## Summary

The legacy \`PUT /topology\` endpoint silently bypassed the entire #174/#175 reconciler chain. When the UI deleted a link via \`PUT /topology\` (the only path it uses for delete), \`lab.json\` got updated but the kernel TAP stayed on the bridge and QMP \`set_link\` stayed UP — guest carrier never went down.

## Root cause

\`backend/app/routers/labs.py:409\` (\`update_topology\`) wrote the new topology to \`lab.json\` via \`LabService.write_lab_json_static\`, which regenerates \`links[]\` from \`topology[]\` (\`lab_service.py:449-450\`), silently discarding the removed link. The PUT path:
- did NOT call \`link_service.delete_link\` (so \`_detach_qemu_interface_inner\` never ran),
- did NOT call \`reconcile_qemu_node_links\`,
- did NOT acquire \`lab_lock\` (concurrent writers could interleave).

This is the unfixed half of the original #174 brief: *"why runtime state doesn't get reconciled when UI operations delete links on running hosts"*. The reconciler we shipped covered the new \`POST /links\` + \`DELETE /links/{id}\` paths but the legacy \`PUT /topology\` path remained an unguarded bypass.

## Fix

- \`update_topology\` now wraps the read → mutate → write → reconcile sequence in \`lab_lock\` so it serializes against \`link_service\` / \`network_service\`.
- After \`write_lab_json_static\`, iterate every QEMU node and call \`NodeRuntimeService.reconcile_qemu_node_links\` inside a try/except (best-effort, logs on failure). Phase 2 detects "iface has attachment record but no matching link in lab.json" and fires \`set_link up=False\` + \`link_set_nomaster\`.
- \`lab_lock\` now \`mkdir\`s the lock file's parent dir so nested-path labs (\`"nested/lab.json"\`) work — exposed by the new \`lab_lock\` acquire in \`update_topology\` under the existing \`test_critic_fixes\` coverage.

## Test plan

- [x] Reproducer on live VM (192.168.100.212) — UI delete + carrier stayed UP confirmed pre-fix
- [x] \`backend && python -m pytest -q\` → 678 passed, 2 skipped, 0 failed
- [ ] Re-deploy and verify on live VM: UI delete-link → carrier drops in guest

Closes #174 (again).