### PR TITLE
deleteLink uses DELETE /links/{id}; preserve links[] (#174)

### DIFF
--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -844,6 +844,21 @@ async def delete_node(
         for link in data.get("topology", [])
         if link.get("source") != f"node{node_id}" and link.get("destination") != f"node{node_id}"
     ]
+    # Issue #174 follow-up: write_lab_json_static no longer regenerates
+    # links[] from topology[] for v2 labs (it preserves links[] as
+    # authoritative). Drop links[] entries referencing the deleted node
+    # explicitly so the topology[] filter above doesn't leave stale links.
+    data["links"] = [
+        link
+        for link in data.get("links", []) or []
+        if not (
+            isinstance(link, dict)
+            and (
+                (isinstance(link.get("from"), dict) and link["from"].get("node_id") == node_id)
+                or (isinstance(link.get("to"), dict) and link["to"].get("node_id") == node_id)
+            )
+        )
+    ]
     LabService.write_lab_json_static(scoped_path, data)
 
     return {
@@ -1399,6 +1414,20 @@ async def delete_network(
         if link.get("network_id") != network_id
         and link.get("source") != f"network{network_id}"
         and link.get("destination") != f"network{network_id}"
+    ]
+    # Issue #174 follow-up: also drop v2 links[] entries referencing the
+    # deleted network — write_lab_json_static no longer regenerates
+    # links[] from topology[] for v2 labs.
+    data["links"] = [
+        link
+        for link in data.get("links", []) or []
+        if not (
+            isinstance(link, dict)
+            and (
+                (isinstance(link.get("from"), dict) and link["from"].get("network_id") == network_id)
+                or (isinstance(link.get("to"), dict) and link["to"].get("network_id") == network_id)
+            )
+        )
     ]
     LabService.write_lab_json_static(scoped_path, data)
 

--- a/backend/app/services/lab_service.py
+++ b/backend/app/services/lab_service.py
@@ -446,7 +446,14 @@ class LabService:
         filepath = _lab_file_path(filename)
         filepath.parent.mkdir(parents=True, exist_ok=True)
 
-        if "topology" in data:
+        # Issue #174 follow-up: only synthesize links[] from topology[]
+        # for v1-shaped writes (no v2 links[] yet). Previously this ran
+        # unconditionally, so a PUT /topology with topology=[] would
+        # regenerate links[]=[] and silently wipe every link from the
+        # lab — even though the caller never asked to touch links[].
+        # For v2 labs, links[] is authoritative; topology[] is a derived
+        # legacy view (`read_lab_json_static` re-derives it on every read).
+        if "topology" in data and not data.get("links"):
             data["links"] = _legacy_topology_to_links(data)
 
         cleaned = _strip_legacy_fields(data)

--- a/frontend/src/lib/components/canvas/TopologyCanvas.svelte
+++ b/frontend/src/lib/components/canvas/TopologyCanvas.svelte
@@ -816,13 +816,20 @@
     }
   }
 
-  function deleteLink(edgeId: string) {
+  async function deleteLink(edgeId: string) {
     const index = getEdgeIndex(edgeId);
     if (index < 0) {
       return;
     }
 
     const v2Link = localLinks[index];
+    // Capture pre-mutation snapshot for rollback on API failure.
+    const previousLinks = localLinks;
+    const previousNodes = localNodes;
+    const previousNetworks = localNetworks;
+    const previousTopology = localTopology;
+    const linkId = v2Link?.id ?? null;
+
     if (v2Link) {
       if (
         typeof v2Link.from?.node_id === 'number' &&
@@ -849,12 +856,47 @@
     localLinks = localLinks.filter((_, currentIndex) => currentIndex !== index);
     recalculateNetworks();
     publishFlowState();
-    scheduleSave();
     dispatchCanvasChange('topology', {
       nodes: deepClone(localNodes),
       networks: deepClone(localNetworks),
       topology: deepClone(localTopology),
     });
+
+    // Issue #174 follow-up: link deletion is a v2 link operation. Use
+    // DELETE /links/{id} (the proper REST surface) instead of the legacy
+    // PUT /topology — that endpoint regenerates links[] from topology[]
+    // and used to silently wipe ALL surviving links on this lab when the
+    // delete trimmed an entry from a localTopology that was already empty
+    // (v2-only labs). tmp_ ids are placeholders for in-flight POST /links;
+    // skip the DELETE because there's no server-side link yet.
+    if (!linkId || linkId.startsWith('tmp_')) {
+      return;
+    }
+
+    try {
+      await apiRequest(`/labs/${labId}/links/${encodeURIComponent(linkId)}`, {
+        method: 'DELETE',
+        suppressToast: true,
+      });
+    } catch (error) {
+      localLinks = previousLinks;
+      localNodes = previousNodes;
+      localNetworks = previousNetworks;
+      localTopology = previousTopology;
+      publishFlowState();
+      dispatchCanvasChange('topology', {
+        nodes: deepClone(localNodes),
+        networks: deepClone(localNetworks),
+        topology: deepClone(localTopology),
+      });
+      const message =
+        error instanceof ApiError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : 'Failed to delete link';
+      toastStore.push(message, 'error');
+    }
   }
 
   async function setLinkStyle(edgeId: string, style: LinkStyle | null) {


### PR DESCRIPTION
## Summary

Fixes the cascade where deleting any one link to a node caused every other link to that node to lose carrier inside the guest. Builds on PR #177's reconciler-on-write hook.

## Root cause

The frontend's \`deleteLink\` always called \`PUT /topology\` via \`scheduleSave()\`, sending \`topology: localTopology\`. For v2-only labs, \`localTopology\` is empty — so the PUT body was \`{topology: [], nodes: ..., networks: ...}\`. Backend's \`LabService.write_lab_json_static\` then unconditionally regenerated \`links[]\` from \`topology[]\`, producing empty \`links[]\`. The reconciler-on-write correctly tore down every active TAP / \`set_link\` on the node — so all surviving links lost carrier at the kernel/QMP level. The UI kept drawing them because \`localLinks\` still had them.

## Fix (two layers)

**Frontend** (\`TopologyCanvas.svelte\`):
- \`deleteLink\` now calls \`DELETE /api/labs/.../links/{linkId}\` directly.
- Optimistic local removal stays for instant UI feedback.
- \`tmp_*\` ids (in-flight \`POST /links\`) skip the DELETE.
- Failure path restores the pre-mutation snapshot and shows a toast.

**Backend defensive** (\`lab_service.py\`):
- \`write_lab_json_static\` only synthesizes \`links[]\` from \`topology[]\` when \`links[]\` is empty (v1-shaped state). For v2 labs, \`links[]\` stays authoritative even if a buggy caller sends \`topology: []\`.

**Cascade** (\`labs.py\`):
- With \`write_lab_json_static\` no longer regenerating \`links[]\`, the \`delete_node\` and \`delete_network\` handlers (which previously relied on the topology→links regeneration cascade) now explicitly drop matching \`links[]\` entries inline.

## Result for surviving links on a single-link delete

- No \`set_link up=False\` / \`link_set_nomaster\` on survivors.
- No carrier bounce in the guest.
- No need for the UI to re-create links via subsequent \`POST /links\`.
- Reconciler Phase 1 may still issue redundant \`link_master\` / \`link_up\` for survivors, but those are kernel-level no-ops (already in desired state) — invisible to the guest.

## Test plan

- [x] Backend: \`python -m pytest -q\` → 678 passed, 2 skipped, 0 failures.
- [x] Frontend: \`npm run check\` → 0 errors, 0 warnings. \`npm run build\` → success.
- [ ] Live: repeat the original repro (attach Gi2/Gi3/Gi4, delete Gi4, confirm Gi2 + Gi3 stay UP inside vyos-1).

Closes #174 (more completely this time).