### PR TITLE
Docker node extras: add command field appended after image (#181)

### DIFF
--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -2090,6 +2090,20 @@ class NodeRuntimeService:
 
         cmd += [str(node.get("image"))]
 
+        command_override = extras.get("command")
+        if isinstance(command_override, str):
+            if command_override.strip():
+                try:
+                    cmd += shlex.split(command_override)
+                except ValueError as exc:
+                    raise NodeRuntimeError(f"Invalid command: {exc}") from exc
+        elif isinstance(command_override, list):
+            if not all(isinstance(arg, str) for arg in command_override):
+                raise NodeRuntimeError("extras.command list entries must all be strings")
+            cmd += list(command_override)
+        elif command_override is not None:
+            raise NodeRuntimeError("extras.command must be a string or list of strings")
+
         # ----- Step 2: docker run -d --network=none ------------------------
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -285,6 +285,20 @@ def _docker_extras_schema() -> list[dict[str, Any]]:
             "stoppedOnly": True,
             "runtime": True,
         },
+        {
+            "key": "command",
+            "label": "Command (overrides image CMD)",
+            "type": "textarea",
+            "default": "",
+            "placeholder": "tail -f /dev/null",
+            "description": (
+                "Override the container's default CMD. Appended after the image "
+                "in the docker run argv. Shlex-split when given as a string; "
+                "passed verbatim when given as a list of strings."
+            ),
+            "stoppedOnly": True,
+            "runtime": True,
+        },
     ]
 
 

--- a/backend/tests/test_node_extras.py
+++ b/backend/tests/test_node_extras.py
@@ -157,7 +157,7 @@ def test_catalog_surfaces_extras_schema_per_type(populated_templates):
 
     docker_template = by_type[("docker", "docker")]
     docker_keys = {field["key"] for field in docker_template["extras_schema"]}
-    assert {"cpulimit", "restart_policy", "environment", "extra_args"} <= docker_keys
+    assert {"cpulimit", "restart_policy", "environment", "extra_args", "command"} <= docker_keys
 
     iol_template = by_type[("iol", "iol")]
     iol_keys = {field["key"] for field in iol_template["extras_schema"]}
@@ -408,6 +408,117 @@ async def test_docker_runtime_honors_env_restart_and_extra_args(monkeypatch, pop
     assert "BAZ=qux" in env_pairs
 
     assert "--cap-add=NET_ADMIN" in run_cmd
+
+
+def _docker_lab_with_command(command_value):
+    return {
+        "schema": 2,
+        "id": "lab-docker",
+        "meta": {"name": "docker"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            "1": {
+                "id": 1,
+                "name": "alpine-a",
+                "type": "docker",
+                "image": "alpine:latest",
+                "console": "telnet",
+                "cpu": 1,
+                "ram": 256,
+                "ethernet": 1,
+                "interfaces": [],
+                "extras": {"command": command_value},
+            }
+        },
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_docker_runtime_honors_command_string(monkeypatch, populated_templates):
+    (populated_templates.LABS_DIR / "docker.json").write_text(
+        json.dumps(_docker_lab_with_command("tail -f /dev/null"))
+    )
+
+    recorded: list[list[str]] = []
+    containers: dict[str, dict] = {}
+    _stub_docker_subprocess(monkeypatch, recorded, containers)
+
+    response = await labs.start_node("docker.json", 1, current_user=_admin())
+    assert response["code"] == 200
+
+    run_cmd = next(cmd for cmd in recorded if "run" in cmd and "--name" in cmd)
+    assert run_cmd.index("alpine:latest") < run_cmd.index("tail")
+    assert run_cmd.index("tail") < run_cmd.index("-f")
+    assert run_cmd.index("-f") < run_cmd.index("/dev/null")
+
+
+@pytest.mark.asyncio
+async def test_docker_runtime_honors_command_list(monkeypatch, populated_templates):
+    (populated_templates.LABS_DIR / "docker.json").write_text(
+        json.dumps(_docker_lab_with_command(["sleep", "infinity"]))
+    )
+
+    recorded: list[list[str]] = []
+    containers: dict[str, dict] = {}
+    _stub_docker_subprocess(monkeypatch, recorded, containers)
+
+    response = await labs.start_node("docker.json", 1, current_user=_admin())
+    assert response["code"] == 200
+
+    run_cmd = next(cmd for cmd in recorded if "run" in cmd and "--name" in cmd)
+    assert run_cmd.index("alpine:latest") < run_cmd.index("sleep")
+    assert run_cmd.index("sleep") < run_cmd.index("infinity")
+
+
+@pytest.mark.asyncio
+async def test_docker_runtime_rejects_malformed_command_string(monkeypatch, populated_templates):
+    (populated_templates.LABS_DIR / "docker.json").write_text(
+        json.dumps(_docker_lab_with_command("sh -c 'unterminated"))
+    )
+
+    recorded: list[list[str]] = []
+    containers: dict[str, dict] = {}
+    _stub_docker_subprocess(monkeypatch, recorded, containers)
+
+    response = await labs.start_node("docker.json", 1, current_user=_admin())
+    assert response["code"] == 400
+    assert "command" in response["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_docker_runtime_rejects_command_list_with_non_string(monkeypatch, populated_templates):
+    (populated_templates.LABS_DIR / "docker.json").write_text(
+        json.dumps(_docker_lab_with_command(["sleep", 123]))
+    )
+
+    recorded: list[list[str]] = []
+    containers: dict[str, dict] = {}
+    _stub_docker_subprocess(monkeypatch, recorded, containers)
+
+    response = await labs.start_node("docker.json", 1, current_user=_admin())
+    assert response["code"] == 400
+    assert "command" in response["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_docker_runtime_command_empty_is_no_op(monkeypatch, populated_templates):
+    (populated_templates.LABS_DIR / "docker.json").write_text(
+        json.dumps(_docker_lab_with_command(""))
+    )
+
+    recorded: list[list[str]] = []
+    containers: dict[str, dict] = {}
+    _stub_docker_subprocess(monkeypatch, recorded, containers)
+
+    response = await labs.start_node("docker.json", 1, current_user=_admin())
+    assert response["code"] == 200
+
+    run_cmd = next(cmd for cmd in recorded if "run" in cmd and "--name" in cmd)
+    image_idx = run_cmd.index("alpine:latest")
+    assert image_idx == len(run_cmd) - 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #181.

## Summary

- Append `extras.command` (string → `shlex.split`, or list-of-strings) after the image in the docker run argv at `backend/app/services/node_runtime_service.py` (after the existing image-append at line 2091). Mirrors the `extra_args` pattern at lines 2084-2089 (`shlex.split` + `NodeRuntimeError` on `ValueError`).
- Add the `command` field to `_docker_extras_schema()` in `backend/app/services/template_service.py` so the frontend renders it automatically via the existing `extras_schema` dynamic UI (no Svelte change needed).
- 5 new tests in `backend/tests/test_node_extras.py` covering: string command (argv-order), list command (argv-order), malformed string → 400, list-with-non-string → 400, empty-string no-op. Catalog test updated to assert `command` in `docker_keys`.

## Issue scope quoted verbatim (per CC-7)

From GH #181 "Proposal":

> Add a new docker-only extras key `command` that is appended **after** the image, mirroring `docker run [opts] <image> [<command>] [<arg>...]`.
>
> ### Shape
>
> ```jsonc
> {
>   "extras": {
>     "command": "tail -f /dev/null"
>     // or: "command": ["tail", "-f", "/dev/null"]
>   }
> }
> ```
>
> Accept both:
> - a **string** → shlex-split (matches existing `extra_args` style; same error path on bad quoting)
> - a **list of strings** → passed through verbatim
>
> ### Implementation
>
> In `_start_docker_node` (`backend/app/services/node_runtime_service.py` around line 2091, just after `cmd += [str(node.get("image"))]`):
>
> ```python
> command_override = extras.get("command")
> if isinstance(command_override, str) and command_override.strip():
>     try:
>         cmd += shlex.split(command_override)
>     except ValueError as exc:
>         raise NodeRuntimeError(f"Invalid command: {exc}") from exc
> elif isinstance(command_override, list):
>     cmd += [str(arg) for arg in command_override]
> ```
>
> No schema change needed — `extras` is already `Dict[str, Any]` on `NodeBase` / `NodeCreate` / `NodeUpdate` (`backend/app/schemas/node.py:63,101,126,148`).

## Acceptance criteria mapping

| GH #181 criterion | Status | Evidence |
|---|---|---|
| `image: alpine:latest` + `extras.command: "sleep infinity"` succeeds end-to-end | Pending on-VM | Will be exercised against `nova-ve-app-02` (192.168.100.213) after merge of this PR; comment will follow with the test result. |
| String form is shlex-split; clear error on quoting | ✅ | `test_docker_runtime_honors_command_string`, `test_docker_runtime_rejects_malformed_command_string` |
| List form forwarded unchanged | ✅ | `test_docker_runtime_honors_command_list` |
| Existing nodes (no `command`) keep behaving as today | ✅ | `test_docker_runtime_command_empty_is_no_op` + 99 pre-existing tests pass with no regression |
| Backend unit test covers all three paths | ✅ | 5 new tests in `backend/tests/test_node_extras.py`; argv-order asserted via `cmd.index()` so future flag insertions don't silently break the contract |

## Test plan

- [x] `pytest backend/tests/test_node_extras.py -k command` green (5 new tests).
- [x] `pytest backend/tests/test_node_extras.py backend/tests/test_node_runtime.py backend/tests/test_template_capabilities.py backend/tests/test_template_management.py` — 99 passed, 1 skipped, 0 failed (no regressions).
- [ ] On-VM e2e: revert snapshot on `nova-ve-app-02` (.213), pull this branch, restart `nova-ve-backend.service`, create alpine docker node with `extras.command: "sleep infinity"` via API, confirm container stays up + veth setup completes + `docker inspect` shows correct `Args`. (Result will be added as a comment.)

## Implementation note: frontend

GH #181's frontend section is marked optional. Per the project rule that backend templates are the source of truth and the frontend renders dynamically, this PR adds `command` to `_docker_extras_schema()` only — the Svelte `NodeConfigModal` already iterates `extras_schema` and will render the new field on first reload. No frontend file is touched.

## Implementation note: docs

GH #181 suggests updating `deploy/DEPLOYMENT_CONTRACT.md` with an example. That file describes deployment topology (Caddy / FastAPI / Postgres / Guacamole), not node-extras configuration; adding an `extras.command` example there reads as off-topic. There is no current node-extras reference doc under `docs/`. Recommend either (a) keeping this PR docs-free and capturing the field via the inline `description` set on the schema entry (which the UI surfaces as helper text), or (b) filing a follow-up to seed a node-extras reference doc covering all keys (`extra_args`, `restart_policy`, `environment`, `command`). Happy to do either; defer to reviewer.

## Branch / merge

- Branch: `feat/181-docker-extras-command`
- Base: `main`
- Squash-merge recommended.
