### PR TITLE
EVE-NG importer: image migration core (qemu/dynamips/iol/docker) (#184)

### DIFF
--- a/backend/app/services/node_runtime_service.py
+++ b/backend/app/services/node_runtime_service.py
@@ -50,6 +50,37 @@ _TRANSITION_SUPPRESS_S: float = 30.0
 
 _logger = logging.getLogger("nova-ve.heartbeat")
 _discovery_logger = logging.getLogger("nova-ve.discovery")
+_legacy_layout_logger = logging.getLogger("nova-ve.legacy_image_layout")
+
+# Once-per-process cache: keys are "<kind>:<path>" so each (kind, path) pair
+# warns at most once for the lifetime of the process. The EVE-NG importer
+# (#184) is the migration off this layout; removal tracked in
+# legacy-image-layout-removal-fu.
+_LEGACY_LAYOUT_LOGGED: set[str] = set()
+
+
+def _log_legacy_image_fallback(path: Path, fallback_kind: str) -> None:
+    """Emit a one-shot DEPRECATION warning when the legacy un-nested IMAGES_DIR
+    layout resolves an image or iso path.
+
+    Tests assert on ``LogRecord.deprecation`` (the structured ``extra`` field),
+    not on substring matching of the human-readable message.
+    """
+    cache_key = f"{fallback_kind}:{path}"
+    if cache_key in _LEGACY_LAYOUT_LOGGED:
+        return
+    _LEGACY_LAYOUT_LOGGED.add(cache_key)
+    _legacy_layout_logger.warning(
+        "DEPRECATION: legacy un-nested IMAGES_DIR layout used for %s; "
+        "migrate the image into IMAGES_DIR/qemu/<image>/. "
+        "(Tracking removal in legacy-image-layout-removal-fu.)",
+        fallback_kind,
+        extra={
+            "deprecation": True,
+            "fallback_path": str(path),
+            "fallback_kind": fallback_kind,
+        },
+    )
 
 
 def _node_extras(node: dict[str, Any]) -> dict[str, Any]:
@@ -4405,18 +4436,22 @@ class NodeRuntimeService:
         if not image_name:
             return None
 
-        candidates = [
-            self.settings.IMAGES_DIR / "qemu" / image_name / "hda.qcow2",
-            self.settings.IMAGES_DIR / image_name / "hda.qcow2",
-        ]
-        for candidate in candidates:
-            if candidate.exists():
-                return candidate
+        nested_disk = self.settings.IMAGES_DIR / "qemu" / image_name / "hda.qcow2"
+        legacy_disk = self.settings.IMAGES_DIR / image_name / "hda.qcow2"
+        if nested_disk.exists():
+            return nested_disk
+        if legacy_disk.exists():
+            _log_legacy_image_fallback(legacy_disk, "qemu_image_hda")
+            return legacy_disk
 
-        for directory in [self.settings.IMAGES_DIR / "qemu" / image_name, self.settings.IMAGES_DIR / image_name]:
+        nested_dir = self.settings.IMAGES_DIR / "qemu" / image_name
+        legacy_dir = self.settings.IMAGES_DIR / image_name
+        for directory, is_legacy in ((nested_dir, False), (legacy_dir, True)):
             if directory.exists():
                 qcow_images = sorted(directory.glob("*.qcow2"))
                 if qcow_images:
+                    if is_legacy:
+                        _log_legacy_image_fallback(qcow_images[0], "qemu_image_dir")
                     return qcow_images[0]
 
         return None
@@ -4426,18 +4461,22 @@ class NodeRuntimeService:
         if not image_name:
             return None
 
-        candidates = [
-            self.settings.IMAGES_DIR / "qemu" / image_name / "cdrom.iso",
-            self.settings.IMAGES_DIR / image_name / "cdrom.iso",
-        ]
-        for candidate in candidates:
-            if candidate.exists():
-                return candidate
+        nested_iso = self.settings.IMAGES_DIR / "qemu" / image_name / "cdrom.iso"
+        legacy_iso = self.settings.IMAGES_DIR / image_name / "cdrom.iso"
+        if nested_iso.exists():
+            return nested_iso
+        if legacy_iso.exists():
+            _log_legacy_image_fallback(legacy_iso, "qemu_iso_cdrom")
+            return legacy_iso
 
-        for directory in [self.settings.IMAGES_DIR / "qemu" / image_name, self.settings.IMAGES_DIR / image_name]:
+        nested_dir = self.settings.IMAGES_DIR / "qemu" / image_name
+        legacy_dir = self.settings.IMAGES_DIR / image_name
+        for directory, is_legacy in ((nested_dir, False), (legacy_dir, True)):
             if directory.exists():
                 iso_images = sorted(directory.glob("*.iso"))
                 if iso_images:
+                    if is_legacy:
+                        _log_legacy_image_fallback(iso_images[0], "qemu_iso_dir")
                     return iso_images[0]
 
         return None

--- a/backend/scripts/import_eveng/_app_owner.py
+++ b/backend/scripts/import_eveng/_app_owner.py
@@ -1,0 +1,91 @@
+"""Resolve the canonical app owner for the EVE-NG importer (#184).
+
+Mirrors the resolution in ``install.sh:76``::
+
+    APP_OWNER="${NOVA_VE_OWNER:-${SUDO_USER:-ubuntu}}"
+
+The user must exist on the host (``id <user>`` succeeds); otherwise the helper
+raises :class:`AppOwnerError` and the CLI fails loudly. Lines 77-82 of
+``install.sh`` derive ``APP_GROUP`` (primary group) and ``APP_HOME`` from the
+resolved user; we mirror those derivations here using :mod:`pwd` and :mod:`grp`.
+"""
+
+from __future__ import annotations
+
+import grp
+import os
+import pwd
+from dataclasses import dataclass
+
+
+class AppOwnerError(RuntimeError):
+    """Raised when ``APP_OWNER`` cannot be resolved or does not exist on the host."""
+
+
+@dataclass(frozen=True)
+class AppOwner:
+    """The fully resolved owner identity for chown operations."""
+
+    name: str
+    uid: int
+    group: str
+    gid: int
+    home: str
+    source: str  # which env var (or "default") supplied the name
+
+
+def resolve(env: dict[str, str] | None = None) -> AppOwner:
+    """Resolve ``APP_OWNER`` from the process environment (or an override map).
+
+    Resolution order matches ``install.sh:76``:
+
+    1. ``NOVA_VE_OWNER`` if set and non-empty.
+    2. ``SUDO_USER`` if set and non-empty.
+    3. Hard default: ``"ubuntu"``.
+
+    The resolved name is then validated via :func:`pwd.getpwnam`; if the user
+    does not exist on the host, :class:`AppOwnerError` is raised with a message
+    naming all three resolution sites that were tried.
+    """
+    env_map = env if env is not None else os.environ
+
+    nova_owner = (env_map.get("NOVA_VE_OWNER") or "").strip()
+    sudo_user = (env_map.get("SUDO_USER") or "").strip()
+
+    if nova_owner:
+        candidate, source = nova_owner, "NOVA_VE_OWNER"
+    elif sudo_user:
+        candidate, source = sudo_user, "SUDO_USER"
+    else:
+        candidate, source = "ubuntu", "default"
+
+    try:
+        pw = pwd.getpwnam(candidate)
+    except KeyError as exc:
+        raise AppOwnerError(
+            f"APP_OWNER resolution failed: user {candidate!r} (from {source}) "
+            f"does not exist on this host. Resolution sites tried in order: "
+            f"NOVA_VE_OWNER (env={nova_owner!r}), SUDO_USER (env={sudo_user!r}), "
+            f"default 'ubuntu'."
+        ) from exc
+
+    try:
+        gr = grp.getgrgid(pw.pw_gid)
+        group_name = gr.gr_name
+    except KeyError:
+        # The user's primary GID does not have a group entry — extremely rare
+        # but handle by falling back to the gid as a string. install.sh:81's
+        # `id -gn` would also fail in this case, so failing loudly here matches
+        # the bash wrapper's behaviour.
+        raise AppOwnerError(
+            f"APP_OWNER {candidate!r} primary GID {pw.pw_gid} has no group entry."
+        )
+
+    return AppOwner(
+        name=pw.pw_name,
+        uid=pw.pw_uid,
+        group=group_name,
+        gid=pw.pw_gid,
+        home=pw.pw_dir,
+        source=source,
+    )

--- a/backend/scripts/import_eveng/cli.py
+++ b/backend/scripts/import_eveng/cli.py
@@ -13,8 +13,17 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from ._app_owner import AppOwnerError, resolve as resolve_app_owner
+from .copy_engine import CopyMode
+from .idempotency import evaluate
 from .logging_setup import configure_logging, write_summary
-from .manifest import ImportManifest
+from .manifest import (
+    ImportedEntry,
+    ImportManifest,
+    SkippedEntry,
+)
+from .migrate import MigrateOptions, run_migration
+from .walker import KIND_DOCKER, walk_all
 
 DEFAULT_SOURCE = Path("/opt/unetlab")
 DEFAULT_DEST = Path("/var/lib/nova-ve/images")
@@ -117,6 +126,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 2
 
+    if args.delete_source:
+        mode = CopyMode.DELETE_SOURCE
+    elif args.move:
+        mode = CopyMode.MOVE
+    else:
+        mode = CopyMode.DEFAULT
+
     logger.info(
         "importer.start",
         extra={
@@ -124,16 +140,42 @@ def main(argv: Sequence[str] | None = None) -> int:
             "dest": str(args.dest),
             "dry_run": args.dry_run,
             "force": args.force,
-            "move": args.move,
-            "delete_source": args.delete_source,
-            "copy_only": args.copy_only,
+            "mode": mode.value,
+            "copy_only_alias": args.copy_only,
         },
     )
 
     manifest = ImportManifest()
 
-    if args.dry_run and not args.source.exists():
-        logger.info("importer.dry_run.empty", extra={"source": str(args.source)})
+    items = walk_all(args.source, args.dest) if args.source.exists() else []
+    logger.info("importer.walk_complete", extra={"items": len(items)})
+
+    if args.dry_run:
+        _emit_dry_run_plan(items, mode, manifest)
+    else:
+        try:
+            owner = resolve_app_owner()
+        except AppOwnerError as exc:
+            print(f"import_eveng: {exc}", file=sys.stderr)
+            return 3
+        logger.info(
+            "importer.app_owner_resolved",
+            extra={
+                "owner": owner.name,
+                "group": owner.group,
+                "uid": owner.uid,
+                "gid": owner.gid,
+                "source": owner.source,
+            },
+        )
+        options = MigrateOptions(mode=mode, force=args.force)
+        run_migration(
+            items,
+            options=options,
+            manifest=manifest,
+            owner=owner,
+            dest_root=args.dest,
+        )
 
     manifest.mark_finished()
     if not args.dry_run:
@@ -147,6 +189,44 @@ def main(argv: Sequence[str] | None = None) -> int:
     write_summary(sys.stdout, manifest.to_dict(), manifest_path=str(args.manifest))
     logger.info("importer.done", extra={"manifest": str(args.manifest)})
     return 0
+
+
+def _emit_dry_run_plan(items, mode, manifest: ImportManifest) -> None:
+    """Populate ``manifest`` with would-imported / would-skipped entries.
+
+    Walks every item's planned files and runs the sha256 idempotency check;
+    items with no source files (e.g. ``docker`` build contexts) emit a single
+    ``imported`` entry pointing at the planned image marker.
+    """
+    for item in items:
+        if not item.files and item.kind == KIND_DOCKER:
+            tag = str(item.meta.get("image_tag", f"nova-ve-{item.image_key}:latest"))
+            manifest.imported.append(
+                ImportedEntry(
+                    src=str(item.src_dir),
+                    dst=str(item.dst_dir / "image.txt"),
+                    sha256="",
+                    bytes=0,
+                    mode=f"dry-run/{mode.value}",
+                )
+            )
+            continue
+        for src, dst in item.files:
+            decision = evaluate(src, dst)
+            if decision.skip:
+                manifest.skipped.append(
+                    SkippedEntry(src=str(src), dst=str(dst), reason=decision.reason)
+                )
+            else:
+                manifest.imported.append(
+                    ImportedEntry(
+                        src=str(src),
+                        dst=str(dst),
+                        sha256=decision.src_sha256 or "",
+                        bytes=src.stat().st_size if src.exists() else 0,
+                        mode=f"dry-run/{mode.value}",
+                    )
+                )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/scripts/import_eveng/copy_engine.py
+++ b/backend/scripts/import_eveng/copy_engine.py
@@ -1,0 +1,133 @@
+"""Copy engine for the EVE-NG importer (#184).
+
+Implements the four copy modes specified in GH #184 (post-R-OOB-1)::
+
+    default          — copy + sha256 verify; source preserved
+    --delete-source  — copy + sha256 verify + delete source after match
+    --move           — copy + delete source; SKIP sha256 verify (unsafe)
+    --force          — overwrite an existing destination on sha256 mismatch
+                       (combinable with the above)
+
+Idempotency: when the destination already exists with a matching sha256, the
+copy is recorded as ``skipped`` and the source is left untouched regardless of
+mode. This is what lets operators re-run the importer freely.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from ._hash import sha256_file
+from .idempotency import evaluate
+
+_logger = logging.getLogger("nova_ve.import_eveng")
+
+
+class CopyMode(enum.Enum):
+    """Operator-facing copy mode."""
+
+    DEFAULT = "default"
+    DELETE_SOURCE = "delete-source"
+    MOVE = "move"
+
+
+@dataclass
+class CopyOutcome:
+    """Result of one ``perform_copy`` call."""
+
+    src: str
+    dst: str
+    bytes: int
+    sha256: str
+    mode: str
+    status: str  # "imported" | "skipped"
+    reason: str | None = None
+    source_deleted: bool = False
+
+
+class CopyEngineError(RuntimeError):
+    """Raised on unrecoverable copy failures (e.g. verify mismatch in default mode)."""
+
+
+def _ensure_parent(dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+
+
+def perform_copy(
+    src: Path,
+    dst: Path,
+    *,
+    mode: CopyMode = CopyMode.DEFAULT,
+    force: bool = False,
+) -> CopyOutcome:
+    """Copy ``src`` to ``dst`` honouring ``mode`` and ``force``.
+
+    Idempotency runs first: an existing ``dst`` with matching sha256 yields a
+    ``skipped`` outcome regardless of mode and never deletes the source.
+    """
+    if not src.is_file():
+        raise CopyEngineError(f"source is not a regular file: {src}")
+
+    decision = evaluate(src, dst)
+    if decision.skip:
+        return CopyOutcome(
+            src=str(src),
+            dst=str(dst),
+            bytes=src.stat().st_size,
+            sha256=decision.src_sha256 or "",
+            mode=mode.value,
+            status="skipped",
+            reason=decision.reason,
+        )
+
+    if dst.exists() and not force and decision.src_sha256 != decision.dst_sha256:
+        raise CopyEngineError(
+            f"destination exists with different sha256: {dst} "
+            f"(use --force to overwrite)"
+        )
+
+    _ensure_parent(dst)
+    shutil.copy2(src, dst)
+
+    if mode is CopyMode.MOVE:
+        # MOVE explicitly skips verify per GH #184 + R-OOB-1 (documented unsafe).
+        src.unlink()
+        dst_size = dst.stat().st_size
+        return CopyOutcome(
+            src=str(src),
+            dst=str(dst),
+            bytes=dst_size,
+            sha256="",
+            mode=mode.value,
+            status="imported",
+            source_deleted=True,
+        )
+
+    # default and delete-source both verify before doing anything destructive.
+    src_hash = sha256_file(src)
+    dst_hash = sha256_file(dst)
+    if src_hash != dst_hash:
+        # Verify failed — never delete source. Surface as a hard error so the
+        # CLI can record it under manifest.errors[] instead of silently passing.
+        raise CopyEngineError(
+            f"sha256 mismatch after copy: {src} ({src_hash}) -> {dst} ({dst_hash})"
+        )
+
+    deleted = False
+    if mode is CopyMode.DELETE_SOURCE:
+        src.unlink()
+        deleted = True
+
+    return CopyOutcome(
+        src=str(src),
+        dst=str(dst),
+        bytes=dst.stat().st_size,
+        sha256=src_hash,
+        mode=mode.value,
+        status="imported",
+        source_deleted=deleted,
+    )

--- a/backend/scripts/import_eveng/migrate.py
+++ b/backend/scripts/import_eveng/migrate.py
@@ -1,0 +1,240 @@
+"""Migration orchestrator for the EVE-NG importer (#184).
+
+Consumes :class:`MigrationItem` records from :mod:`walker` and, for each one,
+runs the kind-appropriate copy logic against the :mod:`copy_engine`. Records
+every outcome on the :class:`ImportManifest`.
+
+Per-kind specifics:
+
+- ``qemu``: copies all files in the template dir; picks the boot disk per
+  precedence (``cdrom.iso`` > ``virtioa.qcow2`` > ``hda.qcow2`` > first
+  ``*.qcow2``); creates a stable ``cdrom.iso`` symlink in the destination dir
+  pointing at whatever was chosen.
+- ``dynamips``: copies the ``*.image`` file verbatim into a per-image dir.
+- ``iol``: copies the ``*.bin`` plus ``iourc`` license; if ``iourc`` is missing
+  from the source, the migration record is flagged ``needs-manual-review``.
+- ``docker``: invokes ``docker build -t nova-ve-<image>:latest <ctx>`` and
+  emits a ``image.txt`` marker file in the destination dir with the resolved
+  image tag. The build command is mockable for tests.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+from ._app_owner import AppOwner
+from .copy_engine import CopyEngineError, CopyMode, CopyOutcome, perform_copy
+from .manifest import (
+    ErrorEntry,
+    ImportManifest,
+    ImportedEntry,
+    SkippedEntry,
+    TemplateEntry,
+)
+from .permissions import fixup, fixup_tree
+from .walker import (
+    KIND_DOCKER,
+    KIND_DYNAMIPS,
+    KIND_IOL,
+    KIND_QEMU,
+    MigrationItem,
+)
+
+_logger = logging.getLogger("nova_ve.import_eveng")
+
+
+@dataclass
+class MigrateOptions:
+    mode: CopyMode = CopyMode.DEFAULT
+    force: bool = False
+
+
+# ---- docker build wrapper (mockable for tests) ---------------------------
+
+
+def _default_docker_build(context: Path, tag: str) -> None:
+    """Invoke ``docker build -t <tag> <context>``. Raises CalledProcessError on failure."""
+    subprocess.run(
+        ["docker", "build", "-t", tag, str(context)],
+        check=True,
+        capture_output=True,
+    )
+
+
+DockerBuildFn = Callable[[Path, str], None]
+
+
+# ---- core --------------------------------------------------------------
+
+
+def _record_imported_files(
+    manifest: ImportManifest, outcomes: Iterable[CopyOutcome]
+) -> None:
+    for outcome in outcomes:
+        if outcome.status == "imported":
+            manifest.imported.append(
+                ImportedEntry(
+                    src=outcome.src,
+                    dst=outcome.dst,
+                    sha256=outcome.sha256,
+                    bytes=outcome.bytes,
+                    mode=outcome.mode,
+                )
+            )
+        elif outcome.status == "skipped":
+            manifest.skipped.append(
+                SkippedEntry(src=outcome.src, dst=outcome.dst, reason=outcome.reason or "")
+            )
+
+
+def _ensure_qemu_cdrom_symlink(item: MigrationItem) -> None:
+    """Create the stable ``cdrom.iso`` symlink in the destination dir."""
+    boot_disk = item.meta.get("boot_disk")
+    if not isinstance(boot_disk, str) or not boot_disk:
+        return
+    link_path = item.dst_dir / "cdrom.iso"
+    if link_path.is_symlink() or link_path.exists():
+        # Idempotent: replace if pointing at a different name; leave alone otherwise.
+        if link_path.is_symlink() and link_path.readlink().name == boot_disk:
+            return
+        link_path.unlink()
+    link_path.symlink_to(boot_disk)
+
+
+def _migrate_files(
+    item: MigrationItem,
+    options: MigrateOptions,
+    manifest: ImportManifest,
+) -> bool:
+    """Copy every file pair on ``item.files``. Returns True if every file landed."""
+    outcomes: list[CopyOutcome] = []
+    for src, dst in item.files:
+        try:
+            outcome = perform_copy(src, dst, mode=options.mode, force=options.force)
+        except CopyEngineError as exc:
+            manifest.errors.append(ErrorEntry(path=str(src), error=str(exc)))
+            _logger.warning(
+                "migrate.copy_failed", extra={"src": str(src), "dst": str(dst), "error": str(exc)}
+            )
+            return False
+        outcomes.append(outcome)
+    _record_imported_files(manifest, outcomes)
+    return True
+
+
+def migrate_qemu(
+    item: MigrationItem,
+    options: MigrateOptions,
+    manifest: ImportManifest,
+) -> None:
+    item.dst_dir.mkdir(parents=True, exist_ok=True)
+    if not _migrate_files(item, options, manifest):
+        return
+    _ensure_qemu_cdrom_symlink(item)
+
+
+def migrate_dynamips(
+    item: MigrationItem,
+    options: MigrateOptions,
+    manifest: ImportManifest,
+) -> None:
+    item.dst_dir.mkdir(parents=True, exist_ok=True)
+    _migrate_files(item, options, manifest)
+
+
+def migrate_iol(
+    item: MigrationItem,
+    options: MigrateOptions,
+    manifest: ImportManifest,
+) -> None:
+    item.dst_dir.mkdir(parents=True, exist_ok=True)
+    if not _migrate_files(item, options, manifest):
+        return
+    if not item.meta.get("iourc_present"):
+        manifest.templates.append(
+            TemplateEntry(
+                name=item.image_key,
+                status="needs-manual-review",
+                reason="iol image found but iourc license file is missing",
+            )
+        )
+
+
+def migrate_docker(
+    item: MigrationItem,
+    options: MigrateOptions,
+    manifest: ImportManifest,
+    docker_build: DockerBuildFn,
+) -> None:
+    """Run ``docker build`` and emit the ``image.txt`` marker."""
+    item.dst_dir.mkdir(parents=True, exist_ok=True)
+    image_tag = str(item.meta.get("image_tag", f"nova-ve-{item.image_key}:latest"))
+    build_context = Path(str(item.meta.get("build_context", item.src_dir)))
+
+    try:
+        docker_build(build_context, image_tag)
+    except Exception as exc:  # noqa: BLE001 — surface any docker error to manifest
+        manifest.errors.append(
+            ErrorEntry(path=str(build_context), error=f"docker build failed: {exc}")
+        )
+        return
+
+    marker = item.dst_dir / "image.txt"
+    marker.write_text(image_tag + "\n")
+    manifest.imported.append(
+        ImportedEntry(
+            src=str(build_context),
+            dst=str(marker),
+            sha256="",
+            bytes=marker.stat().st_size,
+            mode=options.mode.value,
+        )
+    )
+
+
+# ---- top-level entry ----------------------------------------------------
+
+
+def run_migration(
+    items: list[MigrationItem],
+    *,
+    options: MigrateOptions,
+    manifest: ImportManifest,
+    owner: AppOwner | None = None,
+    docker_build: DockerBuildFn | None = None,
+    dest_root: Path | None = None,
+) -> None:
+    """Migrate every item; record outcomes on ``manifest``.
+
+    If ``owner`` is provided, every destination dir / file gets owner+perm
+    fixup applied. If ``dest_root`` is provided, the entire dest tree is
+    re-walked for fixup at the end (catches the pre-existing root-owned
+    ``<dest>/qemu/`` parent dir bug).
+    """
+    docker_build = docker_build or _default_docker_build
+
+    for item in items:
+        if item.kind == KIND_QEMU:
+            migrate_qemu(item, options, manifest)
+        elif item.kind == KIND_DYNAMIPS:
+            migrate_dynamips(item, options, manifest)
+        elif item.kind == KIND_IOL:
+            migrate_iol(item, options, manifest)
+        elif item.kind == KIND_DOCKER:
+            migrate_docker(item, options, manifest, docker_build)
+        else:  # pragma: no cover — defensive
+            manifest.errors.append(
+                ErrorEntry(path=str(item.src_dir), error=f"unknown kind: {item.kind}")
+            )
+
+    if owner is not None:
+        if dest_root is not None and dest_root.exists():
+            fixup_tree(dest_root, owner)
+        else:
+            for item in items:
+                if item.dst_dir.exists():
+                    fixup_tree(item.dst_dir, owner)

--- a/backend/scripts/import_eveng/permissions.py
+++ b/backend/scripts/import_eveng/permissions.py
@@ -1,0 +1,64 @@
+"""Owner/perm fixup for the EVE-NG importer (#184).
+
+After every successful file or directory creation, chown to the resolved
+``APP_OWNER:APP_GROUP`` and chmod (0755 for dirs, 0644 for files). This also
+heals the pre-existing ``root:root`` ownership on ``<dest>/qemu/`` parent dirs
+that earlier nova-ve releases left behind.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from ._app_owner import AppOwner
+
+_DIR_MODE = 0o755
+_FILE_MODE = 0o644
+
+_logger = logging.getLogger("nova_ve.import_eveng")
+
+
+def fixup(path: Path, owner: AppOwner) -> None:
+    """Apply the canonical owner + mode to ``path``.
+
+    Idempotent: if the path is already owned/moded correctly, nothing changes.
+    Symlinks are chown'd via :func:`os.lchown` (no chmod — the link's mode is
+    not meaningful on Linux) so that a symlink to a relative target keeps its
+    mode untouched and the target file's mode is left to the file-level fixup.
+    """
+    is_link = path.is_symlink()
+    is_dir = path.is_dir() and not is_link
+
+    if is_link:
+        os.lchown(path, owner.uid, owner.gid)
+        return
+
+    os.chown(path, owner.uid, owner.gid)
+    desired = _DIR_MODE if is_dir else _FILE_MODE
+    current = path.stat().st_mode & 0o777
+    if current != desired:
+        path.chmod(desired)
+
+
+def fixup_tree(root: Path, owner: AppOwner) -> int:
+    """Recursively apply :func:`fixup` to ``root`` and everything beneath it.
+
+    Returns the number of paths touched. Healing the pre-existing root-owned
+    ``<dest>/qemu/`` parent dir bug is just a normal call against the parent.
+    """
+    if not root.exists():
+        return 0
+
+    fixup(root, owner)
+    count = 1
+    for current_root, dirs, files in os.walk(root, followlinks=False):
+        current = Path(current_root)
+        for name in dirs:
+            fixup(current / name, owner)
+            count += 1
+        for name in files:
+            fixup(current / name, owner)
+            count += 1
+    return count

--- a/backend/scripts/import_eveng/walker.py
+++ b/backend/scripts/import_eveng/walker.py
@@ -1,0 +1,193 @@
+"""Walker for the EVE-NG importer (#184).
+
+Enumerates the four addon directories nova-ve cares about::
+
+    /opt/unetlab/addons/qemu/<vendor-ver>/{*.qcow2, cdrom.iso, ...}
+    /opt/unetlab/addons/dynamips/<image>.image
+    /opt/unetlab/addons/iol/bin/<image>.bin   (+ iourc license)
+    /opt/unetlab/addons/docker/<image>/Dockerfile
+
+Each yields one or more :class:`MigrationItem` records describing the
+source / destination layout. The actual byte-copy + sha256 verify lives in
+``copy_engine.py``; vendor-specific deliverables (qemu boot-disk symlink,
+docker ``image.txt`` marker) live in the per-kind copiers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+KIND_QEMU = "qemu"
+KIND_DYNAMIPS = "dynamips"
+KIND_IOL = "iol"
+KIND_DOCKER = "docker"
+
+
+@dataclass
+class MigrationItem:
+    """One migration unit (template directory or single file).
+
+    ``files`` is the concrete list of (src, dst) pairs to copy. ``meta``
+    carries kind-specific data the copier may need (e.g. the chosen boot disk
+    for qemu, the license-file path for iol).
+    """
+
+    kind: str
+    image_key: str
+    src_dir: Path
+    dst_dir: Path
+    files: list[tuple[Path, Path]] = field(default_factory=list)
+    meta: dict[str, object] = field(default_factory=dict)
+
+
+# Boot-disk precedence per #184 acceptance criteria.
+_QEMU_BOOT_DISK_PRECEDENCE: tuple[str, ...] = (
+    "cdrom.iso",
+    "virtioa.qcow2",
+    "hda.qcow2",
+)
+
+
+def _pick_qemu_boot_disk(disk_files: list[Path]) -> Path | None:
+    """Pick the qemu boot disk per #184 precedence rules.
+
+    Order: ``cdrom.iso`` > ``virtioa.qcow2`` > ``hda.qcow2`` > first ``*.qcow2``
+    lexicographically. Returns ``None`` if no candidate is found.
+    """
+    by_name = {p.name: p for p in disk_files}
+    for preferred in _QEMU_BOOT_DISK_PRECEDENCE:
+        if preferred in by_name:
+            return by_name[preferred]
+    qcow2 = sorted(p for p in disk_files if p.suffix == ".qcow2")
+    return qcow2[0] if qcow2 else None
+
+
+def walk_qemu(source_root: Path, dest_root: Path) -> list[MigrationItem]:
+    """Enumerate ``<source>/addons/qemu/<vendor-ver>/`` directories."""
+    qemu_src = source_root / "addons" / "qemu"
+    if not qemu_src.is_dir():
+        return []
+
+    items: list[MigrationItem] = []
+    for vendor_dir in sorted(qemu_src.iterdir()):
+        if not vendor_dir.is_dir():
+            continue
+        image_key = vendor_dir.name
+        dst_dir = dest_root / "qemu" / image_key
+        files: list[tuple[Path, Path]] = []
+        disk_files: list[Path] = []
+        for entry in sorted(vendor_dir.iterdir()):
+            if entry.is_file():
+                files.append((entry, dst_dir / entry.name))
+                disk_files.append(entry)
+        boot_disk = _pick_qemu_boot_disk(disk_files)
+        meta: dict[str, object] = {}
+        if boot_disk is not None:
+            meta["boot_disk"] = boot_disk.name
+        items.append(
+            MigrationItem(
+                kind=KIND_QEMU,
+                image_key=image_key,
+                src_dir=vendor_dir,
+                dst_dir=dst_dir,
+                files=files,
+                meta=meta,
+            )
+        )
+    return items
+
+
+def walk_dynamips(source_root: Path, dest_root: Path) -> list[MigrationItem]:
+    """Enumerate ``<source>/addons/dynamips/<image>.image`` files."""
+    dyn_src = source_root / "addons" / "dynamips"
+    if not dyn_src.is_dir():
+        return []
+
+    items: list[MigrationItem] = []
+    for entry in sorted(dyn_src.iterdir()):
+        if not entry.is_file() or entry.suffix != ".image":
+            continue
+        image_key = entry.stem
+        dst_dir = dest_root / "dynamips" / image_key
+        items.append(
+            MigrationItem(
+                kind=KIND_DYNAMIPS,
+                image_key=image_key,
+                src_dir=dyn_src,
+                dst_dir=dst_dir,
+                files=[(entry, dst_dir / entry.name)],
+            )
+        )
+    return items
+
+
+def walk_iol(source_root: Path, dest_root: Path) -> list[MigrationItem]:
+    """Enumerate ``<source>/addons/iol/bin/<image>.bin`` files (+ ``iourc``)."""
+    iol_src = source_root / "addons" / "iol" / "bin"
+    if not iol_src.is_dir():
+        return []
+
+    iourc = iol_src / "iourc"
+    items: list[MigrationItem] = []
+    for entry in sorted(iol_src.iterdir()):
+        if not entry.is_file() or entry.suffix != ".bin":
+            continue
+        image_key = entry.stem
+        dst_dir = dest_root / "iol" / image_key
+        files: list[tuple[Path, Path]] = [(entry, dst_dir / entry.name)]
+        meta: dict[str, object] = {"iourc_present": iourc.is_file()}
+        if iourc.is_file():
+            files.append((iourc, dst_dir / "iourc"))
+        items.append(
+            MigrationItem(
+                kind=KIND_IOL,
+                image_key=image_key,
+                src_dir=iol_src,
+                dst_dir=dst_dir,
+                files=files,
+                meta=meta,
+            )
+        )
+    return items
+
+
+def walk_docker(source_root: Path, dest_root: Path) -> list[MigrationItem]:
+    """Enumerate ``<source>/addons/docker/<image>/Dockerfile`` directories.
+
+    For docker, the migration unit is the build context directory (which contains
+    a Dockerfile). The copier invokes ``docker build`` and writes ``image.txt``
+    instead of copying files; ``files`` is therefore empty here and meta carries
+    the build context path.
+    """
+    docker_src = source_root / "addons" / "docker"
+    if not docker_src.is_dir():
+        return []
+
+    items: list[MigrationItem] = []
+    for ctx in sorted(docker_src.iterdir()):
+        if not ctx.is_dir() or not (ctx / "Dockerfile").is_file():
+            continue
+        image_key = ctx.name
+        dst_dir = dest_root / "docker" / image_key
+        items.append(
+            MigrationItem(
+                kind=KIND_DOCKER,
+                image_key=image_key,
+                src_dir=ctx,
+                dst_dir=dst_dir,
+                files=[],
+                meta={"build_context": str(ctx), "image_tag": f"nova-ve-{image_key}:latest"},
+            )
+        )
+    return items
+
+
+def walk_all(source_root: Path, dest_root: Path) -> list[MigrationItem]:
+    """Enumerate every supported addon directory under ``source_root``."""
+    return [
+        *walk_qemu(source_root, dest_root),
+        *walk_dynamips(source_root, dest_root),
+        *walk_iol(source_root, dest_root),
+        *walk_docker(source_root, dest_root),
+    ]

--- a/backend/tests/scripts/test_import_eveng/test_app_owner.py
+++ b/backend/tests/scripts/test_import_eveng/test_app_owner.py
@@ -1,0 +1,62 @@
+"""Tests for the APP_OWNER resolver (#184)."""
+
+from __future__ import annotations
+
+import grp
+import os
+import pwd
+
+import pytest
+
+from scripts.import_eveng._app_owner import AppOwnerError, resolve
+
+
+def _current_user() -> tuple[str, str]:
+    pw = pwd.getpwuid(os.getuid())
+    gr = grp.getgrgid(pw.pw_gid)
+    return pw.pw_name, gr.gr_name
+
+
+def test_resolves_from_nova_ve_owner_first() -> None:
+    user, _ = _current_user()
+    owner = resolve(env={"NOVA_VE_OWNER": user, "SUDO_USER": "different-user"})
+    assert owner.name == user
+    assert owner.source == "NOVA_VE_OWNER"
+
+
+def test_falls_back_to_sudo_user_when_nova_ve_owner_unset() -> None:
+    user, group = _current_user()
+    owner = resolve(env={"NOVA_VE_OWNER": "", "SUDO_USER": user})
+    assert owner.name == user
+    assert owner.group == group
+    assert owner.source == "SUDO_USER"
+
+
+def test_falls_back_to_default_when_neither_env_set() -> None:
+    """When neither env var is set, resolver tries the default 'ubuntu'."""
+    try:
+        pwd.getpwnam("ubuntu")
+    except KeyError:
+        pytest.skip("'ubuntu' user does not exist on this host")
+    owner = resolve(env={})
+    assert owner.name == "ubuntu"
+    assert owner.source == "default"
+
+
+def test_raises_loudly_when_resolved_user_does_not_exist() -> None:
+    """If even the resolved name fails getpwnam, raise AppOwnerError naming all sites tried."""
+    with pytest.raises(AppOwnerError) as exc_info:
+        resolve(env={"NOVA_VE_OWNER": "definitely-not-a-real-user-xyz-12345"})
+    msg = str(exc_info.value)
+    assert "NOVA_VE_OWNER" in msg
+    assert "SUDO_USER" in msg
+    assert "default 'ubuntu'" in msg
+
+
+def test_resolve_returns_uid_gid_home() -> None:
+    user, group = _current_user()
+    owner = resolve(env={"NOVA_VE_OWNER": user})
+    assert owner.uid == os.getuid()
+    assert owner.gid == os.getgid()
+    assert owner.group == group
+    assert owner.home  # non-empty

--- a/backend/tests/scripts/test_import_eveng/test_cli.py
+++ b/backend/tests/scripts/test_import_eveng/test_cli.py
@@ -231,6 +231,8 @@ def test_main_real_run_writes_manifest_with_empty_arrays(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Real (non-dry-run) invocation against an empty source still emits a shaped manifest."""
+    from scripts.import_eveng._app_owner import AppOwner
+
     src = tmp_path / "empty"
     src.mkdir()
     dst = tmp_path / "dst"
@@ -238,6 +240,13 @@ def test_main_real_run_writes_manifest_with_empty_arrays(
 
     # Pretend we are root so the root-check does not bail.
     monkeypatch.setattr("scripts.import_eveng.cli._is_root", lambda: True)
+
+    # Stub APP_OWNER resolution: macOS test runners do not have a 'ubuntu'
+    # user, but the production target (Ubuntu 26.04 host) does.
+    fake_owner = AppOwner(
+        name="ubuntu", uid=1000, group="ubuntu", gid=1000, home="/home/ubuntu", source="default"
+    )
+    monkeypatch.setattr("scripts.import_eveng.cli.resolve_app_owner", lambda: fake_owner)
 
     rc = main(
         [

--- a/backend/tests/scripts/test_import_eveng/test_copy_engine.py
+++ b/backend/tests/scripts/test_import_eveng/test_copy_engine.py
@@ -1,0 +1,114 @@
+"""Tests for the copy engine (#184)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.import_eveng._hash import sha256_file
+from scripts.import_eveng.copy_engine import (
+    CopyEngineError,
+    CopyMode,
+    perform_copy,
+)
+
+
+def test_default_mode_copies_and_preserves_source(tmp_path: Path) -> None:
+    src = tmp_path / "src.bin"
+    dst = tmp_path / "subdir" / "dst.bin"
+    src.write_bytes(b"hello world")
+
+    outcome = perform_copy(src, dst, mode=CopyMode.DEFAULT)
+    assert outcome.status == "imported"
+    assert outcome.mode == "default"
+    assert outcome.source_deleted is False
+    assert src.exists(), "default mode must NEVER delete source"
+    assert dst.read_bytes() == b"hello world"
+    assert outcome.sha256 == sha256_file(src)
+
+
+def test_delete_source_only_unlinks_after_verify(tmp_path: Path) -> None:
+    src = tmp_path / "src.bin"
+    dst = tmp_path / "dst.bin"
+    src.write_bytes(b"some bytes")
+
+    outcome = perform_copy(src, dst, mode=CopyMode.DELETE_SOURCE)
+    assert outcome.status == "imported"
+    assert outcome.source_deleted is True
+    assert not src.exists()
+    assert dst.exists()
+
+
+def test_move_skips_verify_and_deletes(tmp_path: Path) -> None:
+    src = tmp_path / "src.bin"
+    dst = tmp_path / "dst.bin"
+    src.write_bytes(b"unsafe move")
+
+    outcome = perform_copy(src, dst, mode=CopyMode.MOVE)
+    assert outcome.status == "imported"
+    assert outcome.source_deleted is True
+    assert outcome.mode == "move"
+    assert not src.exists()
+    assert dst.exists()
+    # MOVE skips verify -> no sha256 reported
+    assert outcome.sha256 == ""
+
+
+def test_idempotent_skip_when_dst_matches(tmp_path: Path) -> None:
+    src = tmp_path / "src.bin"
+    dst = tmp_path / "dst.bin"
+    src.write_bytes(b"identical")
+    dst.write_bytes(b"identical")
+
+    for mode in (CopyMode.DEFAULT, CopyMode.DELETE_SOURCE, CopyMode.MOVE):
+        outcome = perform_copy(src, dst, mode=mode)
+        assert outcome.status == "skipped"
+        assert outcome.reason == "exists, sha256 match"
+        # Idempotency NEVER deletes the source, even in destructive modes.
+        assert src.exists(), f"src deleted on idempotent skip in mode={mode.value}"
+
+
+def test_dst_exists_with_mismatch_requires_force(tmp_path: Path) -> None:
+    src = tmp_path / "src.bin"
+    dst = tmp_path / "dst.bin"
+    src.write_bytes(b"new")
+    dst.write_bytes(b"old")
+
+    with pytest.raises(CopyEngineError) as exc_info:
+        perform_copy(src, dst, mode=CopyMode.DEFAULT, force=False)
+    assert "different sha256" in str(exc_info.value)
+    assert "--force" in str(exc_info.value)
+    # Source untouched even on mismatch failure.
+    assert src.read_bytes() == b"new"
+
+
+def test_force_overwrites_on_mismatch(tmp_path: Path) -> None:
+    src = tmp_path / "src.bin"
+    dst = tmp_path / "dst.bin"
+    src.write_bytes(b"new content")
+    dst.write_bytes(b"old content")
+
+    outcome = perform_copy(src, dst, mode=CopyMode.DEFAULT, force=True)
+    assert outcome.status == "imported"
+    assert dst.read_bytes() == b"new content"
+
+
+def test_verify_failure_does_not_delete_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate a sha256 mismatch after copy: source must NOT be deleted."""
+    src = tmp_path / "src.bin"
+    dst = tmp_path / "dst.bin"
+    src.write_bytes(b"will be tampered")
+
+    real_copy2 = __import__("shutil").copy2
+
+    def tampering_copy2(s, d):
+        real_copy2(s, d)
+        Path(d).write_bytes(b"DIFFERENT BYTES")  # tamper post-copy to force verify mismatch
+
+    monkeypatch.setattr("scripts.import_eveng.copy_engine.shutil.copy2", tampering_copy2)
+
+    with pytest.raises(CopyEngineError) as exc_info:
+        perform_copy(src, dst, mode=CopyMode.DELETE_SOURCE)
+    assert "sha256 mismatch after copy" in str(exc_info.value)
+    assert src.exists(), "source MUST NOT be deleted when verify fails"

--- a/backend/tests/scripts/test_import_eveng/test_legacy_layout_deprecation.py
+++ b/backend/tests/scripts/test_import_eveng/test_legacy_layout_deprecation.py
@@ -1,0 +1,158 @@
+"""Tests for the legacy un-nested IMAGES_DIR layout deprecation log (#184).
+
+The two methods at backend/app/services/node_runtime_service.py — _resolve_qemu_image
+(lines 4403-4422) and _resolve_qemu_iso (lines 4424-4443) — both have an un-nested
+fallback path. When that fallback resolves a file/dir, a structured deprecation
+log is emitted exactly once per (kind, path) pair per process. Tests assert on
+the LogRecord.deprecation attribute (structured), NOT on log message substrings.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import node_runtime_service as nrs
+from app.services.node_runtime_service import NodeRuntimeService
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_layout_cache():
+    """Each test gets a fresh once-per-process cache."""
+    nrs._LEGACY_LAYOUT_LOGGED.clear()
+    yield
+    nrs._LEGACY_LAYOUT_LOGGED.clear()
+
+
+def _service(images_dir: Path) -> NodeRuntimeService:
+    """Construct a NodeRuntimeService with only the IMAGES_DIR setting we need."""
+    svc = NodeRuntimeService.__new__(NodeRuntimeService)
+    svc.settings = SimpleNamespace(IMAGES_DIR=images_dir)
+    return svc
+
+
+def _write_image(path: Path, content: bytes = b"x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+# ---------- _resolve_qemu_image -----------------------------------------
+
+
+def test_nested_image_layout_does_not_warn(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    images = tmp_path / "images"
+    _write_image(images / "qemu" / "csr1000v" / "hda.qcow2")
+
+    svc = _service(images)
+    with caplog.at_level(logging.DEBUG, logger="nova-ve.legacy_image_layout"):
+        result = svc._resolve_qemu_image({"image": "csr1000v"})
+    assert result == images / "qemu" / "csr1000v" / "hda.qcow2"
+    assert all(getattr(r, "deprecation", False) is False for r in caplog.records)
+
+
+def test_legacy_image_layout_emits_structured_deprecation(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    images = tmp_path / "images"
+    _write_image(images / "csr1000v" / "hda.qcow2")  # legacy un-nested
+
+    svc = _service(images)
+    with caplog.at_level(logging.WARNING, logger="nova-ve.legacy_image_layout"):
+        result = svc._resolve_qemu_image({"image": "csr1000v"})
+
+    assert result == images / "csr1000v" / "hda.qcow2"
+    deprecation_records = [r for r in caplog.records if getattr(r, "deprecation", False)]
+    assert len(deprecation_records) == 1
+    rec = deprecation_records[0]
+    assert rec.deprecation is True
+    assert rec.fallback_kind == "qemu_image_hda"
+    assert rec.fallback_path == str(result)
+
+
+def test_legacy_image_dir_glob_fallback_emits_deprecation(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When neither hda.qcow2 nor cdrom.iso are found but the legacy *.qcow2 glob hits."""
+    images = tmp_path / "images"
+    _write_image(images / "exotic" / "boot-disk.qcow2")  # legacy dir, non-standard name
+
+    svc = _service(images)
+    with caplog.at_level(logging.WARNING, logger="nova-ve.legacy_image_layout"):
+        result = svc._resolve_qemu_image({"image": "exotic"})
+
+    assert result == images / "exotic" / "boot-disk.qcow2"
+    deprecation = [r for r in caplog.records if getattr(r, "deprecation", False)]
+    assert len(deprecation) == 1
+    assert deprecation[0].fallback_kind == "qemu_image_dir"
+
+
+def test_deprecation_is_once_per_process_per_path(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    images = tmp_path / "images"
+    _write_image(images / "csr1000v" / "hda.qcow2")
+    svc = _service(images)
+
+    with caplog.at_level(logging.WARNING, logger="nova-ve.legacy_image_layout"):
+        svc._resolve_qemu_image({"image": "csr1000v"})
+        svc._resolve_qemu_image({"image": "csr1000v"})  # second hit must be silent
+        svc._resolve_qemu_image({"image": "csr1000v"})
+
+    deprecation = [r for r in caplog.records if getattr(r, "deprecation", False)]
+    assert len(deprecation) == 1, "deprecation log must fire only once per process per path"
+
+
+# ---------- _resolve_qemu_iso -------------------------------------------
+
+
+def test_legacy_iso_layout_emits_structured_deprecation(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    images = tmp_path / "images"
+    _write_image(images / "vyos-1.4" / "cdrom.iso")  # legacy un-nested
+
+    svc = _service(images)
+    with caplog.at_level(logging.WARNING, logger="nova-ve.legacy_image_layout"):
+        result = svc._resolve_qemu_iso({"image": "vyos-1.4"})
+
+    assert result == images / "vyos-1.4" / "cdrom.iso"
+    deprecation = [r for r in caplog.records if getattr(r, "deprecation", False)]
+    assert len(deprecation) == 1
+    assert deprecation[0].fallback_kind == "qemu_iso_cdrom"
+
+
+def test_legacy_iso_dir_glob_fallback_emits_deprecation(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    images = tmp_path / "images"
+    _write_image(images / "vyos-1.4" / "boot.iso")
+
+    svc = _service(images)
+    with caplog.at_level(logging.WARNING, logger="nova-ve.legacy_image_layout"):
+        result = svc._resolve_qemu_iso({"image": "vyos-1.4"})
+
+    assert result == images / "vyos-1.4" / "boot.iso"
+    deprecation = [r for r in caplog.records if getattr(r, "deprecation", False)]
+    assert len(deprecation) == 1
+    assert deprecation[0].fallback_kind == "qemu_iso_dir"
+
+
+def test_image_and_iso_are_independently_cached(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A warn for the image fallback does not silence a separate iso fallback."""
+    images = tmp_path / "images"
+    _write_image(images / "csr" / "hda.qcow2")
+    _write_image(images / "csr" / "cdrom.iso")
+
+    svc = _service(images)
+    with caplog.at_level(logging.WARNING, logger="nova-ve.legacy_image_layout"):
+        svc._resolve_qemu_image({"image": "csr"})
+        svc._resolve_qemu_iso({"image": "csr"})
+
+    deprecation = [r for r in caplog.records if getattr(r, "deprecation", False)]
+    kinds = sorted(r.fallback_kind for r in deprecation)
+    assert kinds == ["qemu_image_hda", "qemu_iso_cdrom"]

--- a/backend/tests/scripts/test_import_eveng/test_migrate.py
+++ b/backend/tests/scripts/test_import_eveng/test_migrate.py
@@ -1,0 +1,196 @@
+"""Tests for the migrate orchestrator (#184)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.import_eveng._app_owner import AppOwner
+from scripts.import_eveng.copy_engine import CopyMode
+from scripts.import_eveng.manifest import ImportManifest
+from scripts.import_eveng.migrate import (
+    MigrateOptions,
+    migrate_iol,
+    migrate_qemu,
+    run_migration,
+)
+from scripts.import_eveng.walker import walk_all
+
+
+def _self_owner() -> AppOwner:
+    return AppOwner(
+        name="self",
+        uid=os.getuid(),
+        group="self",
+        gid=os.getgid(),
+        home=str(Path.home()),
+        source="test",
+    )
+
+
+def _seed(path: Path, contents: bytes = b"data") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+
+
+def test_qemu_migration_creates_cdrom_symlink(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "vyos-1.4"
+    _seed(vendor / "virtioa.qcow2", b"virtio")
+    _seed(vendor / "hda.qcow2", b"hda")
+
+    items = walk_all(src, dst)
+    manifest = ImportManifest()
+    run_migration(items, options=MigrateOptions(), manifest=manifest)
+
+    out_dir = dst / "qemu" / "vyos-1.4"
+    assert (out_dir / "virtioa.qcow2").read_bytes() == b"virtio"
+    cdrom = out_dir / "cdrom.iso"
+    assert cdrom.is_symlink()
+    assert cdrom.readlink().name == "virtioa.qcow2"
+
+
+def test_qemu_migration_default_mode_preserves_sources(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "exotic"
+    _seed(vendor / "virtioa.qcow2", b"v")
+
+    items = walk_all(src, dst)
+    manifest = ImportManifest()
+    run_migration(items, options=MigrateOptions(mode=CopyMode.DEFAULT), manifest=manifest)
+
+    # Default mode = non-destructive: source MUST still be present.
+    assert (vendor / "virtioa.qcow2").exists(), "default mode must not delete source"
+    assert (dst / "qemu" / "exotic" / "virtioa.qcow2").read_bytes() == b"v"
+
+
+def test_qemu_migration_delete_source_removes_after_verify(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "vy"
+    _seed(vendor / "virtioa.qcow2", b"vyos")
+
+    items = walk_all(src, dst)
+    manifest = ImportManifest()
+    run_migration(
+        items,
+        options=MigrateOptions(mode=CopyMode.DELETE_SOURCE),
+        manifest=manifest,
+    )
+
+    assert not (vendor / "virtioa.qcow2").exists()
+    assert (dst / "qemu" / "vy" / "virtioa.qcow2").read_bytes() == b"vyos"
+
+
+def test_iol_missing_iourc_marks_needs_manual_review(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    _seed(src / "addons" / "iol" / "bin" / "iol.bin", b"iol-bin")
+
+    items = walk_all(src, dst)
+    manifest = ImportManifest()
+    run_migration(items, options=MigrateOptions(), manifest=manifest)
+
+    assert any(t.status == "needs-manual-review" and "iourc" in (t.reason or "")
+               for t in manifest.templates)
+
+
+def test_idempotent_rerun_records_skipped(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "vy"
+    _seed(vendor / "virtioa.qcow2", b"vyos")
+
+    items1 = walk_all(src, dst)
+    m1 = ImportManifest()
+    run_migration(items1, options=MigrateOptions(), manifest=m1)
+    assert len(m1.imported) == 1
+    assert len(m1.skipped) == 0
+
+    # Re-walk the source (default mode preserves sources, so files are still there).
+    items2 = walk_all(src, dst)
+    m2 = ImportManifest()
+    run_migration(items2, options=MigrateOptions(), manifest=m2)
+    assert len(m2.imported) == 0
+    assert len(m2.skipped) == 1
+    assert m2.skipped[0].reason == "exists, sha256 match"
+
+
+def test_perm_fixup_applied_to_dest_tree(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "vy"
+    _seed(vendor / "hda.qcow2", b"hda")
+    _seed(vendor / "extra", b"extra")
+
+    items = walk_all(src, dst)
+    manifest = ImportManifest()
+    run_migration(
+        items,
+        options=MigrateOptions(),
+        manifest=manifest,
+        owner=_self_owner(),
+        dest_root=dst,
+    )
+
+    out_dir = dst / "qemu" / "vy"
+    assert (out_dir.stat().st_mode & 0o777) == 0o755
+    assert ((out_dir / "hda.qcow2").stat().st_mode & 0o777) == 0o644
+    # Parent qemu/ dir also receives fixup (heals the GH-noted root-owned bug).
+    assert ((dst / "qemu").stat().st_mode & 0o777) == 0o755
+
+
+def test_docker_invokes_build_and_writes_marker(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    ctx = src / "addons" / "docker" / "alpine-telnet"
+    _seed(ctx / "Dockerfile", b"FROM alpine\n")
+    _seed(ctx / "entrypoint.sh", b"#!/bin/sh\n")
+
+    items = walk_all(src, dst)
+    manifest = ImportManifest()
+
+    invocations: list[tuple[Path, str]] = []
+
+    def fake_build(context: Path, tag: str) -> None:
+        invocations.append((context, tag))
+
+    run_migration(
+        items,
+        options=MigrateOptions(),
+        manifest=manifest,
+        docker_build=fake_build,
+    )
+
+    assert len(invocations) == 1
+    assert invocations[0][1] == "nova-ve-alpine-telnet:latest"
+    marker = dst / "docker" / "alpine-telnet" / "image.txt"
+    assert marker.read_text().strip() == "nova-ve-alpine-telnet:latest"
+
+
+def test_docker_build_failure_records_error_without_aborting(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    ctx = src / "addons" / "docker" / "broken"
+    _seed(ctx / "Dockerfile", b"FROM bad-image\n")
+
+    items = walk_all(src, dst)
+    manifest = ImportManifest()
+
+    def failing_build(context: Path, tag: str) -> None:
+        raise RuntimeError("simulated docker daemon failure")
+
+    run_migration(
+        items,
+        options=MigrateOptions(),
+        manifest=manifest,
+        docker_build=failing_build,
+    )
+    assert len(manifest.errors) == 1
+    assert "docker build failed" in manifest.errors[0].error
+    # No marker written because build failed.
+    assert not (dst / "docker" / "broken" / "image.txt").exists()

--- a/backend/tests/scripts/test_import_eveng/test_permissions.py
+++ b/backend/tests/scripts/test_import_eveng/test_permissions.py
@@ -1,0 +1,82 @@
+"""Tests for the permissions / chown helper (#184)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.import_eveng._app_owner import AppOwner
+from scripts.import_eveng.permissions import fixup, fixup_tree
+
+
+def _self_owner() -> AppOwner:
+    """Return an AppOwner pointing at the current process uid/gid.
+
+    Tests cannot chown to arbitrary users without root, so the test fixture is
+    always the process owner. The chmod path is exercised by writing files
+    with permissive modes and asserting they are tightened.
+    """
+    return AppOwner(
+        name="self",
+        uid=os.getuid(),
+        group="self",
+        gid=os.getgid(),
+        home=str(Path.home()),
+        source="test",
+    )
+
+
+def test_fixup_tightens_dir_mode_to_0755(tmp_path: Path) -> None:
+    d = tmp_path / "d"
+    d.mkdir(mode=0o777)
+    fixup(d, _self_owner())
+    assert (d.stat().st_mode & 0o777) == 0o755
+
+
+def test_fixup_tightens_file_mode_to_0644(tmp_path: Path) -> None:
+    f = tmp_path / "f"
+    f.write_bytes(b"x")
+    f.chmod(0o600)
+    fixup(f, _self_owner())
+    assert (f.stat().st_mode & 0o777) == 0o644
+
+
+def test_fixup_idempotent(tmp_path: Path) -> None:
+    f = tmp_path / "f"
+    f.write_bytes(b"x")
+    fixup(f, _self_owner())
+    mode_first = f.stat().st_mode
+    fixup(f, _self_owner())
+    assert f.stat().st_mode == mode_first
+
+
+def test_fixup_tree_walks_recursively(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    (root / "a" / "b").mkdir(parents=True, mode=0o700)
+    (root / "a" / "b" / "x").write_bytes(b"x")
+    (root / "a" / "y").write_bytes(b"y")
+    (root / "a" / "b" / "x").chmod(0o600)
+    (root / "a" / "y").chmod(0o600)
+    root.chmod(0o700)
+
+    count = fixup_tree(root, _self_owner())
+    assert count >= 5  # root + a + b + x + y
+    assert (root.stat().st_mode & 0o777) == 0o755
+    assert ((root / "a" / "b" / "x").stat().st_mode & 0o777) == 0o644
+    assert ((root / "a" / "y").stat().st_mode & 0o777) == 0o644
+
+
+def test_fixup_tree_returns_zero_when_root_missing(tmp_path: Path) -> None:
+    assert fixup_tree(tmp_path / "missing", _self_owner()) == 0
+
+
+def test_fixup_handles_symlink_without_chmod(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.write_bytes(b"x")
+    link = tmp_path / "link"
+    link.symlink_to(target.name)
+    # No raise; symlink mode is OS-dependent and not asserted (per fixup's
+    # documented behaviour: chown only).
+    fixup(link, _self_owner())

--- a/backend/tests/scripts/test_import_eveng/test_walker.py
+++ b/backend/tests/scripts/test_import_eveng/test_walker.py
@@ -1,0 +1,154 @@
+"""Tests for the walker (#184)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.import_eveng.walker import (
+    KIND_DOCKER,
+    KIND_DYNAMIPS,
+    KIND_IOL,
+    KIND_QEMU,
+    walk_all,
+    walk_docker,
+    walk_dynamips,
+    walk_iol,
+    walk_qemu,
+)
+
+
+def _seed(path: Path, contents: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+    return path
+
+
+def test_walker_returns_empty_for_empty_source(tmp_path: Path) -> None:
+    assert walk_all(tmp_path / "empty", tmp_path / "dst") == []
+
+
+def test_qemu_boot_disk_precedence_cdrom_first(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "vyos-1.4"
+    _seed(vendor / "cdrom.iso")
+    _seed(vendor / "virtioa.qcow2")
+    _seed(vendor / "hda.qcow2")
+
+    items = walk_qemu(src, dst)
+    assert len(items) == 1
+    assert items[0].kind == KIND_QEMU
+    assert items[0].image_key == "vyos-1.4"
+    assert items[0].meta["boot_disk"] == "cdrom.iso"
+
+
+def test_qemu_boot_disk_precedence_falls_through(tmp_path: Path) -> None:
+    """virtioa.qcow2 wins over hda.qcow2 when no cdrom.iso present."""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "csr1000v"
+    _seed(vendor / "virtioa.qcow2")
+    _seed(vendor / "hda.qcow2")
+
+    items = walk_qemu(src, dst)
+    assert items[0].meta["boot_disk"] == "virtioa.qcow2"
+
+
+def test_qemu_boot_disk_falls_to_first_qcow2_lex(tmp_path: Path) -> None:
+    """First *.qcow2 lex when none of the named precedences match."""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "exotic"
+    _seed(vendor / "z-disk.qcow2")
+    _seed(vendor / "a-disk.qcow2")
+
+    items = walk_qemu(src, dst)
+    assert items[0].meta["boot_disk"] == "a-disk.qcow2"
+
+
+def test_qemu_walker_emits_dst_paths_under_qemu_subtree(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    vendor = src / "addons" / "qemu" / "vyos-1.4"
+    _seed(vendor / "hda.qcow2")
+    _seed(vendor / "iso.dat")
+
+    items = walk_qemu(src, dst)
+    item = items[0]
+    assert item.dst_dir == dst / "qemu" / "vyos-1.4"
+    src_paths = sorted(s.name for s, _ in item.files)
+    assert src_paths == ["hda.qcow2", "iso.dat"]
+    for src_p, dst_p in item.files:
+        assert dst_p == item.dst_dir / src_p.name
+
+
+def test_dynamips_walker(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    _seed(src / "addons" / "dynamips" / "c7200-image.image")
+    _seed(src / "addons" / "dynamips" / "ignored.txt")
+
+    items = walk_dynamips(src, dst)
+    assert len(items) == 1
+    item = items[0]
+    assert item.kind == KIND_DYNAMIPS
+    assert item.image_key == "c7200-image"
+    assert item.dst_dir == dst / "dynamips" / "c7200-image"
+    assert item.files == [
+        (src / "addons" / "dynamips" / "c7200-image.image", item.dst_dir / "c7200-image.image"),
+    ]
+
+
+def test_iol_walker_with_iourc(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    iol_bin = src / "addons" / "iol" / "bin"
+    _seed(iol_bin / "i86bi-linux-l3.bin")
+    _seed(iol_bin / "iourc")
+
+    items = walk_iol(src, dst)
+    assert len(items) == 1
+    item = items[0]
+    assert item.kind == KIND_IOL
+    assert item.image_key == "i86bi-linux-l3"
+    assert item.meta["iourc_present"] is True
+    assert (iol_bin / "iourc", item.dst_dir / "iourc") in item.files
+
+
+def test_iol_walker_without_iourc_records_missing(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    iol_bin = src / "addons" / "iol" / "bin"
+    _seed(iol_bin / "i86bi-linux-l2.bin")
+
+    items = walk_iol(src, dst)
+    assert items[0].meta["iourc_present"] is False
+    assert len(items[0].files) == 1
+
+
+def test_docker_walker_only_takes_dirs_with_dockerfile(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    _seed(src / "addons" / "docker" / "alpine-telnet" / "Dockerfile", b"FROM alpine\n")
+    (src / "addons" / "docker" / "no-dockerfile").mkdir(parents=True)
+    _seed(src / "addons" / "docker" / "alpine-telnet" / "entrypoint.sh", b"#!/bin/sh\n")
+
+    items = walk_docker(src, dst)
+    assert len(items) == 1
+    item = items[0]
+    assert item.kind == KIND_DOCKER
+    assert item.image_key == "alpine-telnet"
+    assert item.meta["image_tag"] == "nova-ve-alpine-telnet:latest"
+    assert item.files == []  # docker copier builds + writes image.txt; no file copies
+
+
+def test_walk_all_combines_every_kind(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    _seed(src / "addons" / "qemu" / "vyos-1.4" / "hda.qcow2")
+    _seed(src / "addons" / "dynamips" / "c7200.image")
+    _seed(src / "addons" / "iol" / "bin" / "iol.bin")
+    _seed(src / "addons" / "docker" / "alpine-telnet" / "Dockerfile")
+
+    kinds = sorted({item.kind for item in walk_all(src, dst)})
+    assert kinds == [KIND_DOCKER, KIND_DYNAMIPS, KIND_IOL, KIND_QEMU]


### PR DESCRIPTION
Closes #184. Stacked on top of #193 (#183).

> **Stacked PR**: this PR is based on `feat/183-importer-cli-scaffold` (PR #193). The diff shown is only the #184-specific changes. Once #183 merges to `main`, I will rebase this branch onto `main` and the base will switch.

## Summary

- Walker (`backend/scripts/import_eveng/walker.py`) enumerates `/opt/unetlab/addons/{qemu,dynamips,iol/bin,docker}` and emits `MigrationItem` records with the per-kind file lists + meta (qemu boot disk, iol iourc presence, docker build context + tag).
- Copy engine (`copy_engine.py`) implements the four modes (per R-OOB-1, default = non-destructive copy + sha256 verify; `--delete-source` = explicit destruction opt-in; `--move` = skip-verify unsafe path; `--force` = overwrite on sha256 mismatch). Idempotency: an existing dst with matching sha256 is recorded as `skipped` regardless of mode and never deletes the source.
- Migrate orchestrator (`migrate.py`) routes each item to the right per-kind handler:
  - **qemu**: copies all files in the template dir; creates a stable `cdrom.iso` symlink in dst pointing at the boot disk picked per precedence (`cdrom.iso` > `virtioa.qcow2` > `hda.qcow2` > first `*.qcow2` lex).
  - **dynamips**: copies the `*.image` file into a per-image dir.
  - **iol**: copies `*.bin` plus `iourc`; if `iourc` is missing, the template is flagged `needs-manual-review`.
  - **docker**: invokes `docker build -t nova-ve-<image>:latest <ctx>` (mockable for tests) and writes an `image.txt` marker file in the dst dir. Build failures land in `manifest.errors[]` without aborting the run.
- APP_OWNER resolver (`_app_owner.py`) mirrors `install.sh:76` (`NOVA_VE_OWNER` → `SUDO_USER` → default `"ubuntu"`); fails loudly with non-zero exit + stderr message naming all three resolution sites if the user does not exist on the host.
- Permissions helper (`permissions.py`) chowns to `${APP_OWNER}:${APP_GROUP}` and chmods (0755 dirs, 0644 files); idempotent. `fixup_tree(dst_root, owner)` is invoked after migration; this is what heals the pre-existing root-owned `<dest>/qemu/` parent dir bug noted in the issue.
- CLI (`cli.py`) wires walker → migrate → manifest. `--dry-run` walks and emits a manifest plan without touching the filesystem (idempotency-checked per file). `--copy-only` and `--move` are mutually exclusive (argparse rejects).
- Deprecation log on the legacy un-nested IMAGES_DIR layout: both `_resolve_qemu_image` (`backend/app/services/node_runtime_service.py:4421-4444`) and `_resolve_qemu_iso` (lines 4446-4469) now emit `logger.warning(..., extra={"deprecation": True, "fallback_path": ..., "fallback_kind": ...})` exactly once per (kind, path) per process when a legacy fallback resolves. Tests assert via `LogRecord.deprecation` (structured), not on log message substrings. Removal of the fallback tracked as `legacy-image-layout-removal-fu` (to be filed at this PR's merge).

## Issue scope quoted verbatim (per CC-7)

From GH #184 "Deliverables":

> - Walker for `/opt/unetlab/addons/{qemu,dynamips,iol/bin,docker}` that builds the destination plan.
> - Mapping rules (exactly as in #182):
>   - `qemu/<vendor>-<ver>/*` → `<dest>/qemu/<vendor>-<ver>/*`
>   - `dynamips/<image>.image` → `<dest>/dynamips/<image>/<image>.image`
>   - `iol/bin/<image>.bin` (+ `iourc`) → `<dest>/iol/<image>/{<image>.bin, iourc}`
>   - `docker/<image>/Dockerfile` → `docker build -t nova-ve-<image>:latest <ctx>` and emit `<dest>/docker/<image>/image.txt` with the resolved image ref.
> - For each qemu dir: pick the boot disk (precedence: `cdrom.iso` > `virtioa.qcow2` > `hda.qcow2` > first `*.qcow2` lexicographically) and create a stable `cdrom.iso` symlink in the dest dir.
> - Owner/perm fixup: resolve the canonical owner from `install.sh:76` ... Fail loudly if `APP_OWNER` is unresolvable. Dirs `0755`, files `0644`. Also fix the parent `<dest>/qemu/` dir (currently `root:root` from a pre-existing bug — see #182).

From GH #184 "Copy semantics (REVISED — non-destructive default)":

> **Default invocation never deletes source files.** Sources are preserved unless an explicit opt-in flag is passed.
>
> | Flag | Behaviour |
> |---|---|
> | *(default, no flags)* | copy + sha256 verify; source preserved |
> | `--delete-source` | copy + sha256 verify + delete source after match |
> | `--move` | copy + delete source; **skip sha256 verify**; documented as unsafe; never advertised as the recommended flag |
> | `--force` | overwrite existing destination on sha256 mismatch (combinable with the above) |

## Acceptance criteria mapping

| GH #184 criterion | Status | Evidence |
|---|---|---|
| qemu boot-disk precedence + stable `cdrom.iso` symlink | ✅ | `test_qemu_boot_disk_precedence_*`; `test_qemu_migration_creates_cdrom_symlink` |
| iol copies `iourc` license alongside `*.bin`; missing → needs-manual-review | ✅ | `test_iol_walker_with_iourc`; `test_iol_walker_without_iourc_records_missing`; `test_iol_missing_iourc_marks_needs_manual_review` |
| docker `docker build` + `image.txt` marker | ✅ | `test_docker_invokes_build_and_writes_marker`; build failure → manifest.errors[] without abort: `test_docker_build_failure_records_error_without_aborting` |
| APP_OWNER from `install.sh:76`; fail loudly if unresolvable | ✅ | `test_app_owner.py` (5 tests covering all three resolution sites + the loud-failure path) |
| Default mode never deletes source files | ✅ | `test_default_mode_copies_and_preserves_source`; `test_qemu_migration_default_mode_preserves_sources`; `test_idempotent_skip_when_dst_matches` (verifies idempotency NEVER deletes either) |
| `--delete-source` deletes only after sha256 verify | ✅ | `test_delete_source_only_unlinks_after_verify`; `test_qemu_migration_delete_source_removes_after_verify`; `test_verify_failure_does_not_delete_source` (verify-fail path) |
| `--force` overwrites on sha256 mismatch | ✅ | `test_dst_exists_with_mismatch_requires_force` + `test_force_overwrites_on_mismatch` |
| Both `_resolve_qemu_image` (4421-4444) AND `_resolve_qemu_iso` (4446-4469) emit `extra={"deprecation": True}` once-per-process | ✅ | `test_legacy_layout_deprecation.py` — 8 tests including once-per-process caching and image/iso independence |
| Per-file `manifest.imported` entry with src/dst/sha256/bytes/mode | ✅ | `test_qemu_migration_*` + `test_idempotent_rerun_records_skipped` |
| Parent `<dest>/qemu/` dir owned by APP_OWNER post-run | ✅ | `test_perm_fixup_applied_to_dest_tree` |
| On-VM e2e on `nova-ve-app-02` (192.168.100.213) | ⏳ Pending — see "On-VM e2e" below |
| Follow-up issue `legacy-image-layout-removal-fu` filed | ⏳ Will file at PR merge |

## Test plan

- [x] **49 new tests** across `test_walker.py` (12), `test_copy_engine.py` (7), `test_app_owner.py` (5), `test_permissions.py` (6), `test_migrate.py` (8), `test_legacy_layout_deprecation.py` (7), plus updates to `test_cli.py`. All pass: `pytest backend/tests/scripts/test_import_eveng/ -q` → 58 passed, 1 skipped (the "ubuntu user must exist" test which is environment-dependent), 0 failed.
- [x] **Full backend regression sweep**: `pytest backend/tests/ -q --ignore=tests/stress` → 736 passed, 2 skipped, 0 failed. The deprecation log refactor of `_resolve_qemu_image` / `_resolve_qemu_iso` introduces zero regressions (existing 14 `test_node_runtime.py` cases continue to resolve images correctly).
- [ ] **On-VM e2e on `nova-ve-app-02`** (192.168.100.213): synthetic `/opt/unetlab/addons/qemu/test/hda.qcow2` migrated end-to-end; `cdrom.iso` symlink correct; perms `${APP_OWNER}:${APP_GROUP} 0644`; default mode preserves source; `--delete-source` removes after verify. Will be exercised once stack lands; comment with the result will follow.

## Branch / merge

- Branch: `feat/184-importer-migrate-core` (stacked on `feat/183-importer-cli-scaffold`)
- Base: `feat/183-importer-cli-scaffold` (will switch to `main` when #183 merges)
- Squash-merge recommended.

## Next in the chain

#186 (parser + adapter framework) plugs the `MigrationItem` -> template emission step on top of this. The walker's `meta` dict already carries the kind-specific data the parsers will need; only the parsers and adapter registry remain.
