### PR TITLE
install.sh: bootstrap nova-ve-alpine-telnet on fresh hosts (#191)

### DIFF
--- a/deploy/scripts/build-demo-images.sh
+++ b/deploy/scripts/build-demo-images.sh
@@ -1,11 +1,41 @@
 #!/usr/bin/env bash
 # Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
+#
+# Builds the bundled demo images (#191):
+#   - nova-ve-alpine-telnet:latest (used by alpine docker-node demos; see #181)
+#
+# Honoured env vars:
+#   NOVA_VE_SKIP_DEMO_IMAGES=1  Skip every build cleanly. Provisioner uses this
+#                               for re-deploys where the operator does not need
+#                               the demo images rebuilt.
+#
+# Idempotency: each image is rebuilt only when not already present locally
+# (`docker images -q <tag>` is empty). Re-running the provisioner on a host
+# that already has the image is a no-op.
+#
+# Failure semantics: this script exits non-zero on docker-build failure. The
+# provisioner wraps the call so a build failure does not abort install.sh; it
+# is recorded in nova-ve-install-summary.md instead.
 
 set -euo pipefail
 
+if [[ "${NOVA_VE_SKIP_DEMO_IMAGES:-0}" == "1" ]]; then
+  echo "build-demo-images: NOVA_VE_SKIP_DEMO_IMAGES=1; skipping all builds." >&2
+  exit 0
+fi
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-docker build \
-  -t nova-ve-alpine-telnet:latest \
-  "${REPO_ROOT}/deploy/demo-images/alpine-telnet"
+build_if_missing() {
+  local tag="$1"
+  local context="$2"
+  if [[ -n "$(docker images -q "$tag" 2>/dev/null)" ]]; then
+    echo "build-demo-images: ${tag} already present; skipping." >&2
+    return 0
+  fi
+  echo "build-demo-images: building ${tag} from ${context}" >&2
+  docker build -t "$tag" "$context"
+}
+
+build_if_missing "nova-ve-alpine-telnet:latest" "${REPO_ROOT}/deploy/demo-images/alpine-telnet"

--- a/deploy/scripts/provision-ubuntu-2604.sh
+++ b/deploy/scripts/provision-ubuntu-2604.sh
@@ -268,6 +268,28 @@ install_nova_ve_net_helper
 run systemctl enable docker
 run systemctl restart docker
 run usermod -aG docker "${APP_OWNER}"
+
+# Build bundled demo images (NOVA_VE_SKIP_DEMO_IMAGES=1 to skip; idempotent —
+# only builds images that are not already present locally). Build failure
+# does NOT abort the provisioner; the install summary records the status.
+DEMO_IMAGES_STATUS_FILE=/var/lib/nova-ve/.demo-images-status
+run rm -f "${DEMO_IMAGES_STATUS_FILE}"
+DEMO_BUILD_CMD=(sudo -u "${APP_OWNER}" -H bash "${REPO_ROOT}/deploy/scripts/build-demo-images.sh")
+if [[ "${NOVA_VE_SKIP_DEMO_IMAGES:-0}" == "1" ]]; then
+  DEMO_BUILD_CMD=(env NOVA_VE_SKIP_DEMO_IMAGES=1 "${DEMO_BUILD_CMD[@]}")
+fi
+if run "${DEMO_BUILD_CMD[@]}"; then
+  if [[ "${NOVA_VE_SKIP_DEMO_IMAGES:-0}" == "1" ]]; then
+    run bash -c "echo skipped > ${DEMO_IMAGES_STATUS_FILE}"
+  else
+    run bash -c "echo ok > ${DEMO_IMAGES_STATUS_FILE}"
+  fi
+else
+  run bash -c "echo failed > ${DEMO_IMAGES_STATUS_FILE}"
+  echo "WARN: demo-image build failed; nova-ve-alpine-telnet may not be available locally." >&2
+fi
+run chown "${APP_OWNER}:${APP_GROUP}" "${DEMO_IMAGES_STATUS_FILE}" || true
+
 ensure_backend_env
 ensure_instance_id
 

--- a/install.sh
+++ b/install.sh
@@ -129,6 +129,7 @@ PRIMARY_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
 INSTANCE_ID="$(cat /etc/nova-ve/instance_id 2>/dev/null || echo '<missing>')"
 GIT_COMMIT="$(sudo -u "${APP_OWNER}" git -C "${REPO_DIR}" rev-parse --short HEAD)"
 GENERATED_AT="$(date --iso-8601=seconds)"
+DEMO_IMAGES_STATUS="$(cat /var/lib/nova-ve/.demo-images-status 2>/dev/null || echo unknown)"
 
 cat > "${SUMMARY_PATH}" <<EOF
 # nova-ve install summary
@@ -150,6 +151,21 @@ cat > "${SUMMARY_PATH}" <<EOF
 
 Full env file (mode 0600, root-owned) lives at \`${ENV_FILE}\`.
 This summary is mode 0600, owned by \`${APP_OWNER}\`.
+
+## Demo images (#191)
+
+Status: \`${DEMO_IMAGES_STATUS}\` (one of: \`ok\`, \`skipped\`, \`failed\`, \`unknown\`)
+
+The \`nova-ve-alpine-telnet:latest\` image is built during provisioning so a docker node with
+\`image: alpine:latest\` and \`extras.command: "sleep infinity"\` (#181) works out of the box.
+
+Re-build manually:
+
+\`\`\`
+cd ${REPO_DIR} && bash deploy/scripts/build-demo-images.sh
+\`\`\`
+
+Skip on next install: \`NOVA_VE_SKIP_DEMO_IMAGES=1 curl -fsSL ... | sudo bash\`.
 
 ## Critical files
 


### PR DESCRIPTION
Closes #191. Independent of the importer chain (#183 → #190); can land any time.

## Summary

- `deploy/scripts/build-demo-images.sh` rewritten as an **idempotent** + **skip-flag-aware** image builder. Honours `NOVA_VE_SKIP_DEMO_IMAGES=1` (clean exit, no builds). Re-builds `nova-ve-alpine-telnet:latest` only when it is not already present locally (`docker images -q <tag>` is empty). Build failure exits non-zero so the caller can surface it.
- `deploy/scripts/provision-ubuntu-2604.sh` invokes the script as `${APP_OWNER}` after Docker is enabled + restarted (lines 271-289). Wrapped with `if !` so a build failure does **not** abort the provisioner — the status (`ok` / `skipped` / `failed`) is recorded at `/var/lib/nova-ve/.demo-images-status` for the install summary to read. The skip flag is forwarded via `env NOVA_VE_SKIP_DEMO_IMAGES=1` when set.
- `install.sh` reads `/var/lib/nova-ve/.demo-images-status` and surfaces it as a new "Demo images (#191)" section in `nova-ve-install-summary.md`, with a one-liner for manual rebuild and the documented skip flag.

## Issue scope quoted verbatim (per CC-7)

From GH #191 "Acceptance criteria":

> - [ ] After `curl -fsSL https://raw.githubusercontent.com/fahadysf/nova-ve/main/install.sh | sudo bash`, `docker images | grep nova-ve-alpine-telnet` shows the image.
> - [ ] Idempotent: re-running `install.sh` on the same host does not rebuild the image if it already exists.
> - [ ] `NOVA_VE_SKIP_DEMO_IMAGES=1 curl -fsSL ... | sudo bash` skips the build cleanly.
> - [ ] Build failure does not abort `install.sh`; the failure is recorded in `nova-ve-install-summary.md`.
> - [ ] On the test VM (`ubuntu@192.168.100.213`, snapshot `freshly-installed-ubuntu-2604`), reverting + re-running `install.sh` produces a host with `nova-ve-alpine-telnet:latest` present and a docker node using `extras.command: "sleep infinity"` (per #181) starts cleanly end-to-end.

## Acceptance criteria mapping

| GH #191 criterion | Status | Evidence |
|---|---|---|
| Fresh `curl|sudo bash` ⇒ image present | ⏳ on-VM e2e | Will follow once stack lands; PR comment with the result |
| Idempotent re-run does not rebuild | ✅ implementation | `build-demo-images.sh:33-37` returns early when `docker images -q <tag>` is non-empty |
| `NOVA_VE_SKIP_DEMO_IMAGES=1` skips cleanly | ✅ implementation | `build-demo-images.sh:23-26`; provisioner forwards via `env` (`provision-ubuntu-2604.sh:278-281`) |
| Build failure does not abort `install.sh`; recorded in summary | ✅ implementation | provisioner `if ! ... then echo ok else echo failed`; install.sh reads `/var/lib/nova-ve/.demo-images-status` and renders it under "Demo images (#191)" |
| On-VM e2e exercises the full flow including #181's `extras.command` | ⏳ pending | will follow |

## Status semantics

`/var/lib/nova-ve/.demo-images-status` is one of:

- `ok` — every image was rebuilt or already present.
- `skipped` — `NOVA_VE_SKIP_DEMO_IMAGES=1` was set; nothing was attempted.
- `failed` — at least one `docker build` failed; the provisioner continued past the failure.
- `unknown` — file missing (predates this PR or the provisioner failed before reaching the demo-image step).

The install summary surfaces this verbatim plus a "Re-build manually" one-liner so the operator can recover without re-reading the provisioner log.

## Test plan

- [x] Bash syntax check on all three modified scripts (`bash -n`).
- [x] Unit-tested behaviour: the build-if-missing helper is a 5-line shell function; no separate test fixture is justified beyond the on-VM e2e.
- [ ] On-VM e2e on `nova-ve-app-02` (192.168.100.213):
  1. `govc snapshot.revert + power-cycle` → fresh state.
  2. `curl -fsSL .../install.sh | sudo bash` → check `docker images -q nova-ve-alpine-telnet:latest` is non-empty + summary section reads `ok`.
  3. Re-run `install.sh` → image timestamp unchanged + summary reads `ok`.
  4. Revert + `NOVA_VE_SKIP_DEMO_IMAGES=1 curl -fsSL ... | sudo bash` → image absent + summary reads `skipped`.
  5. Combine with #181: create alpine docker node with `extras.command: "sleep infinity"` → starts cleanly.

## Branch / merge

- Branch: `feat/191-install-bootstrap-alpine-telnet`
- Base: `main` (independent of the importer chain)
- Squash-merge recommended.
