### PR TITLE
EVE-NG importer: Cisco adapters (IOSv, IOSv-L2, CSR1000v/Cat8000v, IOL) (#187)

### DIFF
--- a/backend/scripts/import_eveng/adapters/__init__.py
+++ b/backend/scripts/import_eveng/adapters/__init__.py
@@ -23,6 +23,10 @@ This layout keeps the per-PR conflict surface here predictable and small.
 from __future__ import annotations
 
 from .base import NeedsManualReview, VendorAdapter
+from .cisco_csr1000v import CiscoCSR1000vAdapter
+from .cisco_iol import CiscoIOLAdapter
+from .cisco_iosv_l2 import CiscoIOSvL2Adapter
+from .cisco_iosv_l3 import CiscoIOSvL3Adapter
 from .generic_linux import GenericLinuxAdapter
 
 ADAPTERS: list[VendorAdapter] = []
@@ -36,6 +40,10 @@ def register(adapter: VendorAdapter) -> None:
 def reset_registry_for_tests() -> None:
     """Clear and re-prime the registry. Test-only: do not call from production paths."""
     ADAPTERS.clear()
+    register(CiscoCSR1000vAdapter())
+    register(CiscoIOLAdapter())
+    register(CiscoIOSvL2Adapter())
+    register(CiscoIOSvL3Adapter())
     register(GenericLinuxAdapter())
 
 
@@ -53,11 +61,19 @@ def select_adapter(raw: dict) -> VendorAdapter | None:
 
 
 # Built-in registrations. Vendor PRs prepend their entries above this line.
+register(CiscoCSR1000vAdapter())
+register(CiscoIOLAdapter())
+register(CiscoIOSvL2Adapter())
+register(CiscoIOSvL3Adapter())
 register(GenericLinuxAdapter())
 
 
 __all__ = [
     "ADAPTERS",
+    "CiscoCSR1000vAdapter",
+    "CiscoIOLAdapter",
+    "CiscoIOSvL2Adapter",
+    "CiscoIOSvL3Adapter",
     "GenericLinuxAdapter",
     "NeedsManualReview",
     "VendorAdapter",

--- a/backend/scripts/import_eveng/adapters/cisco_csr1000v.py
+++ b/backend/scripts/import_eveng/adapters/cisco_csr1000v.py
@@ -1,0 +1,50 @@
+"""Cisco CSR1000v / Cat8000v adapter (#187).
+
+Matches both ``csr1000v-universalk9*.qcow2`` and ``cat8kv-universalk9*.qcow2``
+(Cat8000v is the modern rename of the same VM family). virtio-net NICs,
+serial-over-tcp console.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(
+    r"(?:csr1000v-universalk9|cat8kv-universalk9).*\.qcow2$", re.IGNORECASE
+)
+
+
+class CiscoCSR1000vAdapter(VendorAdapter):
+    name: ClassVar[str] = "cisco_csr1000v"
+    priority: ClassVar[int] = 80
+    REQUIRED_FIELDS: ClassVar[set[str]] = {"image", "ram"}
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image = str(raw["image"])
+        is_cat8k = "cat8kv" in image.lower()
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or image),
+            "name": str(raw.get("name") or ("Cisco Cat8000v" if is_cat8k else "Cisco CSR1000v")),
+            "vendor": "cisco",
+            "kind": "qemu",
+            "image": image,
+            "cpu": int(raw.get("cpu", 2)),
+            "ram": int(raw["ram"]),
+            "ethernet": int(raw.get("ethernet", 4)),
+            "console": str(raw.get("console_type", "serial")),
+            "extras": {
+                "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
+                "qemu_options": str(raw.get("qemu_options", "")),
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/scripts/import_eveng/adapters/cisco_iol.py
+++ b/backend/scripts/import_eveng/adapters/cisco_iol.py
@@ -1,0 +1,50 @@
+"""Cisco IOL adapter (#187).
+
+Matches ``i86bi-linux*`` binaries. Special-case: emits
+``extras.iol_license_path`` pointing at ``${IMAGES_DIR}/iol/<image-key>/iourc``
+(relative-style for portability across hosts as long as the iol image dir is
+intact). kind=``iol`` (not qemu).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"i86bi-linux", re.IGNORECASE)
+
+
+class CiscoIOLAdapter(VendorAdapter):
+    name: ClassVar[str] = "cisco_iol"
+    priority: ClassVar[int] = 80
+    REQUIRED_FIELDS: ClassVar[set[str]] = {"image", "ram"}
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image = str(raw["image"])
+        # Derive image key from the image filename (drop extension for iol bin keys).
+        image_key = Path(image).stem or image
+        license_path = f"${{IMAGES_DIR}}/iol/{image_key}/iourc"
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or image),
+            "name": str(raw.get("name") or "Cisco IOL"),
+            "vendor": "cisco",
+            "kind": "iol",
+            "image": image,
+            "cpu": int(raw.get("cpu", 1)),
+            "ram": int(raw["ram"]),
+            "ethernet": int(raw.get("ethernet", 4)),
+            "console": str(raw.get("console_type", "telnet")),
+            "extras": {
+                "iol_license_path": license_path,
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/scripts/import_eveng/adapters/cisco_iosv_l2.py
+++ b/backend/scripts/import_eveng/adapters/cisco_iosv_l2.py
@@ -1,0 +1,45 @@
+"""Cisco IOSv L2 adapter (#187).
+
+Matches ``vios_l2-*.qcow2``. e1000 NICs, telnet console.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"vios_l2-.*\.qcow2$", re.IGNORECASE)
+
+
+class CiscoIOSvL2Adapter(VendorAdapter):
+    name: ClassVar[str] = "cisco_iosv_l2"
+    priority: ClassVar[int] = 80
+    REQUIRED_FIELDS: ClassVar[set[str]] = {"image", "ram", "console_type"}
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image = str(raw["image"])
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or image),
+            "name": str(raw.get("name") or "Cisco IOSv L2"),
+            "vendor": "cisco",
+            "kind": "qemu",
+            "image": image,
+            "cpu": int(raw.get("cpu", 1)),
+            "ram": int(raw["ram"]),
+            "ethernet": int(raw.get("ethernet", 4)),
+            "console": str(raw["console_type"]),
+            "extras": {
+                "qemu_nic": str(raw.get("qemu_nic", "e1000")),
+                "qemu_options": str(raw.get("qemu_options", "")),
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/scripts/import_eveng/adapters/cisco_iosv_l3.py
+++ b/backend/scripts/import_eveng/adapters/cisco_iosv_l3.py
@@ -1,0 +1,46 @@
+"""Cisco IOSv L3 adapter (#187).
+
+Matches ``vios-adventerprise*.qcow2``. Emits a qemu node with e1000 NICs,
+telnet console, and a default ethernet count of 8.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"vios-adventerprise.*\.qcow2$", re.IGNORECASE)
+
+
+class CiscoIOSvL3Adapter(VendorAdapter):
+    name: ClassVar[str] = "cisco_iosv_l3"
+    priority: ClassVar[int] = 80
+    REQUIRED_FIELDS: ClassVar[set[str]] = {"image", "ram", "console_type"}
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image = str(raw["image"])
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or image),
+            "name": str(raw.get("name") or "Cisco IOSv L3"),
+            "vendor": "cisco",
+            "kind": "qemu",
+            "image": image,
+            "cpu": int(raw.get("cpu", 1)),
+            "ram": int(raw["ram"]),
+            "ethernet": int(raw.get("ethernet", 8)),
+            "console": str(raw["console_type"]),
+            "extras": {
+                "qemu_nic": str(raw.get("qemu_nic", "e1000")),
+                "qemu_options": str(raw.get("qemu_options", "")),
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/tests/scripts/test_import_eveng/test_adapters_cisco.py
+++ b/backend/tests/scripts/test_import_eveng/test_adapters_cisco.py
@@ -1,0 +1,218 @@
+"""Tests for the Cisco adapters (#187)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.import_eveng.adapters import (
+    CiscoCSR1000vAdapter,
+    CiscoIOLAdapter,
+    CiscoIOSvL2Adapter,
+    CiscoIOSvL3Adapter,
+    iter_adapters,
+    select_adapter,
+)
+
+
+# ---- IOSv L3 ------------------------------------------------------------
+
+
+def test_cisco_iosv_l3_matches_canonical_filename() -> None:
+    a = CiscoIOSvL3Adapter()
+    assert a.match({"image": "vios-adventerprise-15.6.2t.qcow2"}) is True
+    assert a.match({"image": "vios-adventerprisek9-m.156-2.T.qcow2"}) is True
+
+
+def test_cisco_iosv_l3_rejects_other_vendor_images() -> None:
+    a = CiscoIOSvL3Adapter()
+    assert a.match({"image": "vios_l2-adventerprisek9-m.qcow2"}) is False
+    assert a.match({"image": "csr1000v-universalk9.16.09.qcow2"}) is False
+    assert a.match({"image": "i86bi-linux-l3-15.5.bin"}) is False
+    assert a.match({"image": "vEOS-lab-4.21.0F.qcow2"}) is False
+
+
+def test_cisco_iosv_l3_convert_snapshot() -> None:
+    a = CiscoIOSvL3Adapter()
+    raw: dict[str, Any] = {
+        "image": "vios-adventerprise-15.6.qcow2",
+        "ram": 512,
+        "console_type": "telnet",
+    }
+    out = a.convert(raw, Path("/var/lib/nova-ve/images/qemu/cisco-iosv-l3"))
+    assert out == {
+        "schema": 1,
+        "id": "vios-adventerprise-15.6.qcow2",
+        "name": "Cisco IOSv L3",
+        "vendor": "cisco",
+        "kind": "qemu",
+        "image": "vios-adventerprise-15.6.qcow2",
+        "cpu": 1,
+        "ram": 512,
+        "ethernet": 8,
+        "console": "telnet",
+        "extras": {
+            "qemu_nic": "e1000",
+            "qemu_options": "",
+            "_eveng_raw": raw,
+        },
+    }
+
+
+# ---- IOSv L2 ------------------------------------------------------------
+
+
+def test_cisco_iosv_l2_matches_canonical_filename() -> None:
+    a = CiscoIOSvL2Adapter()
+    assert a.match({"image": "vios_l2-adventerprisek9-m.SSA.high_iron.qcow2"}) is True
+
+
+def test_cisco_iosv_l2_rejects_l3() -> None:
+    a = CiscoIOSvL2Adapter()
+    assert a.match({"image": "vios-adventerprise-15.6.qcow2"}) is False
+
+
+def test_cisco_iosv_l2_convert_snapshot() -> None:
+    a = CiscoIOSvL2Adapter()
+    raw = {"image": "vios_l2-adventerprisek9.qcow2", "ram": 512, "console_type": "telnet"}
+    out = a.convert(raw, Path("."))
+    assert out["vendor"] == "cisco"
+    assert out["kind"] == "qemu"
+    assert out["ethernet"] == 4
+    assert out["extras"]["qemu_nic"] == "e1000"
+    assert out["console"] == "telnet"
+
+
+# ---- CSR1000v / Cat8000v -----------------------------------------------
+
+
+def test_cisco_csr1000v_matches_both_filenames() -> None:
+    """CSR1000v adapter claims both csr1000v-universalk9 AND cat8kv-universalk9."""
+    a = CiscoCSR1000vAdapter()
+    assert a.match({"image": "csr1000v-universalk9.16.09.04.qcow2"}) is True
+    assert a.match({"image": "cat8kv-universalk9.17.10.01a.qcow2"}) is True
+
+
+def test_cisco_csr1000v_rejects_other_cisco_images() -> None:
+    a = CiscoCSR1000vAdapter()
+    assert a.match({"image": "vios-adventerprise-15.6.qcow2"}) is False
+    assert a.match({"image": "vios_l2-adventerprisek9.qcow2"}) is False
+    assert a.match({"image": "i86bi-linux-l3.bin"}) is False
+
+
+def test_cisco_csr1000v_convert_csr_name() -> None:
+    a = CiscoCSR1000vAdapter()
+    raw = {"image": "csr1000v-universalk9.16.09.qcow2", "ram": 4096}
+    out = a.convert(raw, Path("."))
+    assert out["name"] == "Cisco CSR1000v"
+    assert out["extras"]["qemu_nic"] == "virtio-net-pci"
+
+
+def test_cisco_csr1000v_convert_cat8k_name() -> None:
+    """cat8kv images get a different default name even though the adapter is shared."""
+    a = CiscoCSR1000vAdapter()
+    raw = {"image": "cat8kv-universalk9.17.10.qcow2", "ram": 4096}
+    out = a.convert(raw, Path("."))
+    assert out["name"] == "Cisco Cat8000v"
+
+
+# ---- IOL ----------------------------------------------------------------
+
+
+def test_cisco_iol_matches_canonical_filename() -> None:
+    a = CiscoIOLAdapter()
+    assert a.match({"image": "i86bi-linux-l3-adventerprisek9-15.5.2T.bin"}) is True
+    assert a.match({"image": "i86bi-linux-l2-15.7.bin"}) is True
+
+
+def test_cisco_iol_rejects_qemu_images() -> None:
+    a = CiscoIOLAdapter()
+    assert a.match({"image": "vios-adventerprise-15.6.qcow2"}) is False
+    assert a.match({"image": "csr1000v-universalk9.qcow2"}) is False
+
+
+def test_cisco_iol_emits_iol_license_path() -> None:
+    """IOL adapter must emit extras.iol_license_path; per #187 acceptance criterion 3."""
+    a = CiscoIOLAdapter()
+    raw = {"image": "i86bi-linux-l3-15.5.bin", "ram": 1024}
+    out = a.convert(raw, Path("."))
+    assert out["kind"] == "iol"
+    assert out["extras"]["iol_license_path"] == "${IMAGES_DIR}/iol/i86bi-linux-l3-15.5/iourc"
+
+
+# ---- match() tightness across all four adapters -----------------------
+
+
+def _all_adapters():
+    return [
+        CiscoIOSvL3Adapter(),
+        CiscoIOSvL2Adapter(),
+        CiscoCSR1000vAdapter(),
+        CiscoIOLAdapter(),
+    ]
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "vios-adventerprise-15.6.qcow2",  # iosv_l3
+        "vios_l2-adventerprisek9.qcow2",  # iosv_l2
+        "csr1000v-universalk9.16.09.qcow2",  # csr1000v
+        "cat8kv-universalk9.17.10.qcow2",  # csr1000v
+        "i86bi-linux-l3-15.5.bin",  # iol
+    ],
+)
+def test_exactly_one_cisco_adapter_matches_per_image(image: str) -> None:
+    """No two Cisco adapters claim the same image — false-positive bound check."""
+    matchers = [a for a in _all_adapters() if a.match({"image": image})]
+    assert len(matchers) == 1, f"image {image} matched {[a.name for a in matchers]}"
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "vEOS-lab-4.21.0F.qcow2",  # arista (out of scope here)
+        "chr-7.10.img",  # mikrotik
+        "vmx-bundle-22.4R1.S1.qcow2",  # juniper
+        "media-vsrx-vmdisk-15.1X49.qcow2",  # juniper
+        "ubuntu-22.04-cloudimg-amd64.img",  # generic linux
+    ],
+)
+def test_no_cisco_adapter_claims_other_vendor_images(image: str) -> None:
+    """Cisco adapters must not match Juniper / Arista / Mikrotik / generic images."""
+    for a in _all_adapters():
+        assert a.match({"image": image}) is False, f"{a.name} false-matched {image}"
+
+
+# ---- registry integration ---------------------------------------------
+
+
+def test_all_four_cisco_adapters_register_before_generic_linux() -> None:
+    """The four Cisco adapters must dispatch before generic_linux."""
+    names = [a.name for a in iter_adapters()]
+    cisco_names = {"cisco_iosv_l3", "cisco_iosv_l2", "cisco_csr1000v", "cisco_iol"}
+    assert cisco_names <= set(names)
+    # generic_linux must remain the last entry.
+    assert names[-1] == "generic_linux"
+    # Every Cisco adapter must precede generic_linux.
+    cisco_indices = [i for i, n in enumerate(names) if n in cisco_names]
+    assert max(cisco_indices) < names.index("generic_linux")
+
+
+def test_select_adapter_routes_iosv_l3_to_cisco_not_generic() -> None:
+    """A real IOSv L3 image must dispatch to cisco_iosv_l3, not the catch-all."""
+    matched = select_adapter({"image": "vios-adventerprise-15.6.qcow2"})
+    assert matched is not None and matched.name == "cisco_iosv_l3"
+
+
+def test_select_adapter_routes_iol_to_cisco_iol() -> None:
+    matched = select_adapter({"image": "i86bi-linux-l3-15.5.bin"})
+    assert matched is not None and matched.name == "cisco_iol"
+
+
+def test_select_adapter_falls_through_to_generic_for_unknown_image() -> None:
+    """An image no Cisco adapter recognises must fall through to generic_linux."""
+    matched = select_adapter({"image": "ubuntu-22.04-cloudimg-amd64.img"})
+    assert matched is not None and matched.name == "generic_linux"

--- a/backend/tests/scripts/test_import_eveng/test_adapters_framework.py
+++ b/backend/tests/scripts/test_import_eveng/test_adapters_framework.py
@@ -25,9 +25,17 @@ FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "required_fields"
 
 @pytest.fixture(autouse=True)
 def _isolated_registry():
-    """Snapshot/restore the registry around each test so registrations don't leak."""
+    """Snapshot/restore the registry around each test so registrations don't leak.
+
+    Resets to a minimal baseline (generic_linux only) for framework-level tests
+    that exercise sort order / tiebreaker / dispatch invariants without the
+    noise of every shipped vendor adapter. Vendor-specific tests (e.g.
+    test_adapters_cisco) call ``reset_registry_for_tests()`` themselves to get
+    the full production registry.
+    """
     saved = list(adapter_registry.ADAPTERS)
-    reset_registry_for_tests()
+    adapter_registry.ADAPTERS.clear()
+    register(GenericLinuxAdapter())
     yield
     adapter_registry.ADAPTERS.clear()
     adapter_registry.ADAPTERS.extend(saved)
@@ -108,8 +116,22 @@ def test_required_fields_is_presence_only_not_semantic() -> None:
 # ---- registry order ----------------------------------------------------
 
 
-def test_registry_starts_with_generic_linux() -> None:
-    """Bare registry has only generic_linux; iter_adapters() returns it as last."""
+def test_registry_default_state_has_generic_linux_last() -> None:
+    """After reset_registry_for_tests, generic_linux must be the LAST entry.
+
+    The exact set of preceding adapters depends on which vendor PRs have landed
+    (Cisco from #187, Juniper from #188, etc.) — what's invariant is that
+    generic_linux remains the structural fallback.
+    """
+    adapters = iter_adapters()
+    assert len(adapters) >= 1
+    assert isinstance(adapters[-1], GenericLinuxAdapter)
+
+
+def test_registry_with_only_generic_linux_when_cleared() -> None:
+    """Manually clearing the registry and registering only generic_linux yields a 1-element registry."""
+    adapter_registry.ADAPTERS.clear()
+    register(GenericLinuxAdapter())
     adapters = iter_adapters()
     assert len(adapters) == 1
     assert isinstance(adapters[0], GenericLinuxAdapter)


### PR DESCRIPTION
Closes #187. Stacked on top of #196 (#186) → #194 (#184) → #193 (#183).

## Summary

Four concrete `VendorAdapter` subclasses for Cisco virtual platforms, each declaring `priority = 80` and a tight `match()` regex.

| Adapter | match | NIC | Console | Default ethernet |
|---|---|---|---|---|
| `cisco_iosv_l3` | `vios-adventerprise*.qcow2` | e1000 | telnet | 8 |
| `cisco_iosv_l2` | `vios_l2-*.qcow2` | e1000 | telnet | 4 |
| `cisco_csr1000v` | `csr1000v-universalk9*.qcow2` AND `cat8kv-universalk9*.qcow2` | virtio-net-pci | serial | 4 |
| `cisco_iol` | `i86bi-linux*` | (IOL stub) | telnet | 4 |

`cisco_iol` is special-cased: `kind="iol"` (not `qemu`), and `extras.iol_license_path` is populated as `${IMAGES_DIR}/iol/<image-key>/iourc` (relative-style for portability across hosts).

CSR1000v and Cat8000v share one adapter because they're the same VM family (Cisco renamed `csr1000v` → `cat8000v` in 17.x). The adapter's `convert()` picks the right human-readable name based on which filename matched.

## Issue scope quoted verbatim (per CC-7)

From GH #187 "Deliverables":

> - `adapters/cisco_iosv_l2.py` — `vios_l2-adventerprisek9*.qcow2`. SMP-disabled, e1000 NICs, telnet console.
> - `adapters/cisco_iosv_l3.py` — `vios-adventerprise*.qcow2`. e1000 NICs, telnet console, default 8 ethernet.
> - `adapters/cisco_csr1000v.py` — covers `csr1000v-universalk9*.qcow2` and `cat8kv-universalk9*.qcow2`. virtio-net NICs, serial-over-tcp.
> - `adapters/cisco_iol.py` — `i86bi-linux*` binaries. Special-case: emits `extras.iol_license_path` pointing at `${IMAGES_DIR}/iol/<image-key>/iourc`. Console mode = telnet, NIC type = the IOL stub (no actual `-net` flag).

From GH #187 "Acceptance criteria":

> - [ ] Each adapter, given a real EVE-NG template fixture, emits a nova-ve node template that successfully instantiates a node which boots to the IOS / IOS-L2 / IOS-XE / IOL prompt.
> - [ ] Each adapter declares `match()` with a regex tight enough to not collide with any other adapter (verified by an integration test).
> - [ ] IOL adapter's emitted node template references a relative `iourc` path so the template is portable across hosts as long as the iol image dir is intact.

## Acceptance criteria mapping

| GH #187 criterion | Status | Evidence |
|---|---|---|
| Each adapter's `match()` regex tight; no inter-adapter collision | ✅ | `test_exactly_one_cisco_adapter_matches_per_image` (parametrised over the 5 priority filenames) + `test_no_cisco_adapter_claims_other_vendor_images` (parametrised over Juniper / Arista / Mikrotik / generic filenames) |
| Per-adapter `convert()` snapshot tests | ✅ | `test_cisco_iosv_l3_convert_snapshot`, `test_cisco_iosv_l2_convert_snapshot`, `test_cisco_csr1000v_convert_csr_name`, `test_cisco_csr1000v_convert_cat8k_name`, `test_cisco_iol_emits_iol_license_path` |
| IOL emits relative `iourc` license path | ✅ | `test_cisco_iol_emits_iol_license_path` asserts `extras.iol_license_path == "${IMAGES_DIR}/iol/<image-key>/iourc"` |
| All four registered before `generic_linux` | ✅ | `test_all_four_cisco_adapters_register_before_generic_linux`; `test_select_adapter_routes_iosv_l3_to_cisco_not_generic`; `test_select_adapter_routes_iol_to_cisco_iol`; `test_select_adapter_falls_through_to_generic_for_unknown_image` |
| Per-adapter REQUIRED_FIELDS declared | ✅ | `cisco_iosv_l3` / `cisco_iosv_l2`: `{image, ram, console_type}`; `cisco_csr1000v` / `cisco_iol`: `{image, ram}` |
| Boots to vendor prompt (full IOS/L2/IOL boot) | ⏳ Manual on-VM verification deferred | Requires real Cisco binaries (out of CI scope per CC-1 no-proprietary-fixtures policy); tracked for post-merge manual verification |

## Test plan

- [x] **18 new tests** in `backend/tests/scripts/test_import_eveng/test_adapters_cisco.py` covering: per-adapter `match()` accepts canonical filenames; per-adapter `match()` rejects every other priority-vendor image; per-adapter `convert()` snapshot; IOL `iol_license_path` shape; registry order; dispatch routing.
- [x] Framework test fixture updated: `_isolated_registry` now resets to a minimal `generic_linux`-only baseline so US-186's sort / tiebreaker invariants are exercised without Cisco-adapter noise. The Cisco adapter tests get the full production registry by default.
- [x] **All importer tests**: 110 passed, 1 skipped, 0 failed (`pytest backend/tests/scripts/test_import_eveng/ -q`).
- [x] **Full backend regression sweep**: 788 passed, 2 skipped, 0 failed (`pytest backend/tests/ -q --ignore=tests/stress`).

## Refinement vs the GH body

GH #187 mentions "SMP-disabled" for IOSv L2. SMP-disabled is a runtime hint that does not appear in any other VM template extras_schema in the codebase today; if needed, the operator can pass it via `extras.qemu_options="-smp 1"`. Out of scope for this PR; a follow-up could promote it to a typed extras field if it turns out to be load-bearing for IOSv L2 boot.

## Branch / merge

- Branch: `feat/187-importer-cisco-adapters`
- Base: `feat/186-importer-parsers-adapters` (stacked: #196 → #194 → #193 → main)
- Squash-merge recommended.

## Next in the chain

#188 (Juniper) and #189 (Arista/Mikrotik/VyOS) are independent of this PR — they branch off `feat/186` in parallel. The conflict surface in `adapters/__init__.py` is bounded: each PR adds 1-3 alphabetical import lines + corresponding `register()` calls.
