### PR TITLE
EVE-NG importer: Arista vEOS, Mikrotik CHR, VyOS adapters (#189)

### DIFF
--- a/backend/scripts/import_eveng/adapters/__init__.py
+++ b/backend/scripts/import_eveng/adapters/__init__.py
@@ -22,8 +22,11 @@ This layout keeps the per-PR conflict surface here predictable and small.
 
 from __future__ import annotations
 
+from .arista_veos import AristaVEosAdapter
 from .base import NeedsManualReview, VendorAdapter
 from .generic_linux import GenericLinuxAdapter
+from .mikrotik_chr import MikrotikCHRAdapter
+from .vyos import VyOSAdapter
 
 ADAPTERS: list[VendorAdapter] = []
 
@@ -36,6 +39,9 @@ def register(adapter: VendorAdapter) -> None:
 def reset_registry_for_tests() -> None:
     """Clear and re-prime the registry. Test-only: do not call from production paths."""
     ADAPTERS.clear()
+    register(AristaVEosAdapter())
+    register(MikrotikCHRAdapter())
+    register(VyOSAdapter())
     register(GenericLinuxAdapter())
 
 
@@ -53,14 +59,20 @@ def select_adapter(raw: dict) -> VendorAdapter | None:
 
 
 # Built-in registrations. Vendor PRs prepend their entries above this line.
+register(AristaVEosAdapter())
+register(MikrotikCHRAdapter())
+register(VyOSAdapter())
 register(GenericLinuxAdapter())
 
 
 __all__ = [
     "ADAPTERS",
+    "AristaVEosAdapter",
     "GenericLinuxAdapter",
+    "MikrotikCHRAdapter",
     "NeedsManualReview",
     "VendorAdapter",
+    "VyOSAdapter",
     "iter_adapters",
     "register",
     "reset_registry_for_tests",

--- a/backend/scripts/import_eveng/adapters/arista_veos.py
+++ b/backend/scripts/import_eveng/adapters/arista_veos.py
@@ -1,0 +1,48 @@
+"""Arista vEOS adapter (#189).
+
+Matches both ``vEOS-lab-*.vmdk`` and ``vEOS-lab-*.qcow2``. Aboot+vEOS uses a
+two-disk layout: ``aboot-veos.iso`` is the boot CD-ROM and ``vEOS-lab*.qcow2``
+is the system disk. The adapter emits a qemu template referencing both.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"vEOS-lab-.*\.(?:qcow2|vmdk)$", re.IGNORECASE)
+
+
+class AristaVEosAdapter(VendorAdapter):
+    name: ClassVar[str] = "arista_veos"
+    priority: ClassVar[int] = 70
+    REQUIRED_FIELDS: ClassVar[set[str]] = {"image", "ram"}
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image = str(raw["image"])
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or image),
+            "name": str(raw.get("name") or "Arista vEOS"),
+            "vendor": "arista",
+            "kind": "qemu",
+            "image": image,
+            "cpu": int(raw.get("cpu", 1)),
+            "ram": int(raw["ram"]),
+            "ethernet": int(raw.get("ethernet", 4)),
+            "console": str(raw.get("console_type", "serial")),
+            "extras": {
+                "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
+                "qemu_options": str(raw.get("qemu_options", "")),
+                "boot_cdrom": "aboot-veos.iso",
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/scripts/import_eveng/adapters/mikrotik_chr.py
+++ b/backend/scripts/import_eveng/adapters/mikrotik_chr.py
@@ -1,0 +1,48 @@
+"""Mikrotik CHR adapter (#189).
+
+Matches ``chr-*.img`` and ``chr-*.qcow2``. CHR (Cloud Hosted Router) is
+sensitive to NIC model, so the adapter forces e1000 (not virtio-net). Console
+is telnet-via-serial. License-aware: any license file present in the image
+dir is preserved by the migrate orchestrator's per-file copy logic.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"chr-.*\.(?:qcow2|img)$", re.IGNORECASE)
+
+
+class MikrotikCHRAdapter(VendorAdapter):
+    name: ClassVar[str] = "mikrotik_chr"
+    priority: ClassVar[int] = 70
+    REQUIRED_FIELDS: ClassVar[set[str]] = {"image", "ram"}
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image = str(raw["image"])
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or image),
+            "name": str(raw.get("name") or "Mikrotik CHR"),
+            "vendor": "mikrotik",
+            "kind": "qemu",
+            "image": image,
+            "cpu": int(raw.get("cpu", 1)),
+            "ram": int(raw["ram"]),
+            "ethernet": int(raw.get("ethernet", 4)),
+            "console": str(raw.get("console_type", "telnet")),
+            "extras": {
+                "qemu_nic": "e1000",  # CHR is sensitive: forced e1000, not virtio
+                "qemu_options": str(raw.get("qemu_options", "")),
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/scripts/import_eveng/adapters/vyos.py
+++ b/backend/scripts/import_eveng/adapters/vyos.py
@@ -1,0 +1,89 @@
+"""VyOS adapter (#189).
+
+Wraps the existing ``deploy/scripts/install-vyos-template.sh`` output: when an
+operator imports a VyOS image, the adapter checks whether the resulting node
+template body's sha256 matches a list of known-pristine hashes. Pristine
+templates dispatch as ``vyos_status="pristine"``; customised templates (any
+sha256 not in the pristine list) dispatch as ``vyos_status="customised"`` so
+the operator's hand edits are surfaced for review rather than blindly
+overwritten.
+
+Per Architect refinement: the marker check is **content-aware** (sha256 of
+the body vs a known-pristine list), NOT a string-substring match on a
+specific marker comment that operators might preserve while editing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"vyos.*\.(?:qcow2|img|iso)$", re.IGNORECASE)
+
+
+# Module-level registry of known-pristine sha256 digests. Test fixtures
+# register their own pristine hashes via :func:`register_pristine_hash`.
+_VYOS_PRISTINE_HASHES: set[str] = set()
+
+
+def register_pristine_hash(digest_hex: str) -> None:
+    """Register ``digest_hex`` as a known-pristine VyOS body hash."""
+    _VYOS_PRISTINE_HASHES.add(digest_hex.lower())
+
+
+def clear_pristine_hashes() -> None:
+    """Clear the pristine-hash registry. Test-only."""
+    _VYOS_PRISTINE_HASHES.clear()
+
+
+def is_pristine_body(body: bytes) -> bool:
+    """Return True iff the sha256 of ``body`` is in the pristine-hash registry."""
+    return hashlib.sha256(body).hexdigest() in _VYOS_PRISTINE_HASHES
+
+
+def vyos_status_for_path(path: Path) -> str:
+    """Return ``"pristine"`` / ``"customised"`` / ``"unknown"`` for ``path``."""
+    if not path.is_file():
+        return "unknown"
+    return "pristine" if is_pristine_body(path.read_bytes()) else "customised"
+
+
+class VyOSAdapter(VendorAdapter):
+    name: ClassVar[str] = "vyos"
+    priority: ClassVar[int] = 70
+    REQUIRED_FIELDS: ClassVar[set[str]] = {"image"}
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image = str(raw["image"])
+        # If the operator passed a vyos_template_path, classify it.
+        template_path = raw.get("vyos_template_path")
+        vyos_status = "unknown"
+        if isinstance(template_path, (str, Path)):
+            vyos_status = vyos_status_for_path(Path(template_path))
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or image),
+            "name": str(raw.get("name") or "VyOS"),
+            "vendor": "vyos",
+            "kind": "qemu",
+            "image": image,
+            "cpu": int(raw.get("cpu", 1)),
+            "ram": int(raw.get("ram", 512)),
+            "ethernet": int(raw.get("ethernet", 4)),
+            "console": str(raw.get("console_type", "serial")),
+            "extras": {
+                "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
+                "qemu_options": str(raw.get("qemu_options", "")),
+                "vyos_status": vyos_status,
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/tests/scripts/test_import_eveng/test_adapters_arista_mikrotik_vyos.py
+++ b/backend/tests/scripts/test_import_eveng/test_adapters_arista_mikrotik_vyos.py
@@ -1,0 +1,190 @@
+"""Tests for the Arista vEOS, Mikrotik CHR, and VyOS adapters (#189)."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from scripts.import_eveng.adapters import (
+    AristaVEosAdapter,
+    GenericLinuxAdapter,
+    MikrotikCHRAdapter,
+    VyOSAdapter,
+    iter_adapters,
+    select_adapter,
+)
+from scripts.import_eveng.adapters import vyos as vyos_module
+
+
+@pytest.fixture(autouse=True)
+def _isolated_vyos_pristine_hashes():
+    """Each test gets a fresh pristine-hash registry."""
+    vyos_module.clear_pristine_hashes()
+    yield
+    vyos_module.clear_pristine_hashes()
+
+
+# ---- Arista vEOS -------------------------------------------------------
+
+
+def test_arista_veos_matches_qcow2_and_vmdk() -> None:
+    a = AristaVEosAdapter()
+    assert a.match({"image": "vEOS-lab-4.21.0F.qcow2"}) is True
+    assert a.match({"image": "vEOS-lab-4.21.0F.vmdk"}) is True
+    assert a.match({"image": "vEOS-Lab-4.21.0F.QCOW2"}) is True  # case-insensitive
+
+
+def test_arista_veos_rejects_other_vendor_images() -> None:
+    a = AristaVEosAdapter()
+    assert a.match({"image": "csr1000v-universalk9.qcow2"}) is False
+    assert a.match({"image": "chr-7.10.img"}) is False
+    assert a.match({"image": "vyos-1.4.qcow2"}) is False
+    assert a.match({"image": "vmx-bundle-22.4.qcow2"}) is False
+
+
+def test_arista_veos_convert_emits_aboot_cdrom_marker() -> None:
+    a = AristaVEosAdapter()
+    raw = {"image": "vEOS-lab-4.21.0F.qcow2", "ram": 2048}
+    out = a.convert(raw, Path("."))
+    assert out["vendor"] == "arista"
+    assert out["kind"] == "qemu"
+    assert out["extras"]["boot_cdrom"] == "aboot-veos.iso"
+    assert out["extras"]["qemu_nic"] == "virtio-net-pci"
+    assert out["console"] == "serial"
+
+
+# ---- Mikrotik CHR -----------------------------------------------------
+
+
+def test_mikrotik_chr_matches_img_and_qcow2() -> None:
+    a = MikrotikCHRAdapter()
+    assert a.match({"image": "chr-7.10.img"}) is True
+    assert a.match({"image": "chr-7.10.qcow2"}) is True
+
+
+def test_mikrotik_chr_rejects_other_vendor_images() -> None:
+    a = MikrotikCHRAdapter()
+    assert a.match({"image": "vEOS-lab-4.21.qcow2"}) is False
+    assert a.match({"image": "vyos-1.4.qcow2"}) is False
+    assert a.match({"image": "csr1000v-universalk9.qcow2"}) is False
+
+
+def test_mikrotik_chr_forces_e1000_nic() -> None:
+    """CHR is sensitive to NIC model — adapter forces e1000 even if raw says virtio."""
+    a = MikrotikCHRAdapter()
+    raw = {"image": "chr-7.10.img", "ram": 256, "qemu_nic": "virtio-net-pci"}
+    out = a.convert(raw, Path("."))
+    assert out["vendor"] == "mikrotik"
+    assert out["extras"]["qemu_nic"] == "e1000"  # forced; raw's virtio request ignored
+
+
+# ---- VyOS -------------------------------------------------------------
+
+
+def test_vyos_matches_qcow2_img_iso() -> None:
+    a = VyOSAdapter()
+    assert a.match({"image": "vyos-1.4.qcow2"}) is True
+    assert a.match({"image": "vyos-rolling.img"}) is True
+    assert a.match({"image": "vyos-1.5.iso"}) is True
+
+
+def test_vyos_rejects_other_vendor_images() -> None:
+    a = VyOSAdapter()
+    assert a.match({"image": "vEOS-lab-4.21.qcow2"}) is False
+    assert a.match({"image": "chr-7.10.img"}) is False
+
+
+def test_vyos_unknown_status_when_no_template_path(tmp_path: Path) -> None:
+    """Without a vyos_template_path, the adapter cannot classify; emits 'unknown'."""
+    a = VyOSAdapter()
+    out = a.convert({"image": "vyos-1.4.qcow2", "ram": 512}, tmp_path)
+    assert out["extras"]["vyos_status"] == "unknown"
+
+
+def test_vyos_pristine_template_detected_via_known_hash(tmp_path: Path) -> None:
+    """Body sha256 in pristine list -> vyos_status='pristine'."""
+    body = b"# Pristine VyOS template\nset interfaces ethernet eth0\n"
+    body_path = tmp_path / "vyos.tpl"
+    body_path.write_bytes(body)
+    expected_hash = hashlib.sha256(body).hexdigest()
+    vyos_module.register_pristine_hash(expected_hash)
+
+    a = VyOSAdapter()
+    out = a.convert(
+        {"image": "vyos-1.4.qcow2", "ram": 512, "vyos_template_path": str(body_path)},
+        tmp_path,
+    )
+    assert out["extras"]["vyos_status"] == "pristine"
+
+
+def test_vyos_customised_template_detected_via_hash_mismatch(tmp_path: Path) -> None:
+    """A whitespace edit changes the hash -> vyos_status='customised'."""
+    pristine_body = b"# Pristine VyOS template\nset interfaces ethernet eth0\n"
+    customised_body = pristine_body + b"# operator hand-edit\n"
+
+    pristine_hash = hashlib.sha256(pristine_body).hexdigest()
+    vyos_module.register_pristine_hash(pristine_hash)
+
+    body_path = tmp_path / "vyos.tpl"
+    body_path.write_bytes(customised_body)
+
+    a = VyOSAdapter()
+    out = a.convert(
+        {"image": "vyos-1.4.qcow2", "ram": 512, "vyos_template_path": str(body_path)},
+        tmp_path,
+    )
+    assert out["extras"]["vyos_status"] == "customised"
+
+
+def test_vyos_marker_check_is_content_aware_not_substring() -> None:
+    """Refinement N5 / Architect: marker check is sha256 of body, NOT substring match.
+
+    A customised template that happens to contain the literal word 'pristine' or any
+    other token is still classified by hash, not by string presence.
+    """
+    a_body = b"set marker pristine here\n"  # contains the word 'pristine'
+    a_hash = hashlib.sha256(a_body).hexdigest()
+    # We do NOT register a_hash; the body should be 'customised' despite
+    # containing the word 'pristine'.
+
+    p = Path("/tmp/_vyos_marker_check_substring.tpl")
+    try:
+        p.write_bytes(a_body)
+        assert vyos_module.vyos_status_for_path(p) == "customised"
+    finally:
+        p.unlink(missing_ok=True)
+
+
+# ---- registry integration --------------------------------------------
+
+
+def test_all_three_vendor_adapters_register_before_generic_linux() -> None:
+    names = [a.name for a in iter_adapters()]
+    expected = {"arista_veos", "mikrotik_chr", "vyos"}
+    assert expected <= set(names)
+    # generic_linux remains structurally last regardless of vendor adapters added.
+    assert names[-1] == "generic_linux"
+    for vendor_name in expected:
+        assert names.index(vendor_name) < names.index("generic_linux")
+
+
+def test_select_adapter_routes_veos_to_arista_not_generic() -> None:
+    matched = select_adapter({"image": "vEOS-lab-4.21.qcow2"})
+    assert matched is not None and matched.name == "arista_veos"
+
+
+def test_select_adapter_routes_chr_to_mikrotik() -> None:
+    matched = select_adapter({"image": "chr-7.10.img"})
+    assert matched is not None and matched.name == "mikrotik_chr"
+
+
+def test_select_adapter_routes_vyos_image() -> None:
+    matched = select_adapter({"image": "vyos-1.4.qcow2"})
+    assert matched is not None and matched.name == "vyos"
+
+
+def test_generic_linux_catches_completely_unknown_image() -> None:
+    matched = select_adapter({"image": "exotic-vendor-x.qcow2"})
+    assert matched is not None and matched.name == "generic_linux"

--- a/backend/tests/scripts/test_import_eveng/test_adapters_framework.py
+++ b/backend/tests/scripts/test_import_eveng/test_adapters_framework.py
@@ -25,9 +25,16 @@ FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "required_fields"
 
 @pytest.fixture(autouse=True)
 def _isolated_registry():
-    """Snapshot/restore the registry around each test so registrations don't leak."""
+    """Snapshot/restore the registry around each test so registrations don't leak.
+
+    Resets to a minimal baseline (generic_linux only) for framework-level tests
+    that exercise sort order / tiebreaker / dispatch invariants without the
+    noise of every shipped vendor adapter. Vendor-specific tests call
+    ``reset_registry_for_tests()`` themselves to get the full production registry.
+    """
     saved = list(adapter_registry.ADAPTERS)
-    reset_registry_for_tests()
+    adapter_registry.ADAPTERS.clear()
+    register(GenericLinuxAdapter())
     yield
     adapter_registry.ADAPTERS.clear()
     adapter_registry.ADAPTERS.extend(saved)


### PR DESCRIPTION
Closes #189. Stacked on top of #196 (#186) → #194 (#184) → #193 (#183). Sibling of #197 (#187 Cisco) — both branch off `feat/186` in parallel.

## Summary

Three concrete `VendorAdapter` subclasses at `priority = 70` (one tier below Cisco's `priority = 80`).

| Adapter | match | NIC | Console | Notes |
|---|---|---|---|---|
| `arista_veos` | `vEOS-lab-*.qcow2` AND `vEOS-lab-*.vmdk` | virtio-net-pci | serial | emits `extras.boot_cdrom = "aboot-veos.iso"` for the two-disk Aboot+vEOS layout |
| `mikrotik_chr` | `chr-*.img` AND `chr-*.qcow2` | **e1000 (forced)** | telnet | CHR is sensitive to NIC model; the adapter overrides any virtio-net request from the raw template |
| `vyos` | `vyos*.qcow2 / .img / .iso` | virtio-net-pci | serial | content-aware sha256 of optional `vyos_template_path` vs a pristine-hash registry; emits `extras.vyos_status = "pristine" / "customised" / "unknown"` |

## VyOS marker design (Architect refinement N5)

The VyOS adapter detects whether an operator-provided template body is the stock VyOS template or has been hand-edited by comparing the sha256 of the file's bytes against a registered set of known-pristine hashes. **This is content-aware, not a string-substring match** on a marker comment — an operator that hand-edits the body but happens to preserve a marker comment is still classified as `customised` (because the hash differs).

The registry is module-level: `register_pristine_hash(digest_hex)` is the only mutating entry, `clear_pristine_hashes()` is exposed for tests, and `is_pristine_body(body) -> bool` / `vyos_status_for_path(Path) -> str` are the read paths. The migrate orchestrator (or a future installation hook) can pre-populate the registry from a curated list shipped with the importer.

## Issue scope quoted verbatim (per CC-7)

From GH #189 "Deliverables":

> - `adapters/arista_veos.py` — `vEOS-lab-*.vmdk` / `vEOS-lab-*.qcow2`. virtio-net, serial console. Aboot+vEOS two-disk shape: `aboot-veos.iso` is the cdrom, `vEOS-lab*.qcow2` is the system disk.
> - `adapters/mikrotik_chr.py` — `chr-*.img` / `chr-*.qcow2`. e1000 NICs (CHR is picky), telnet console via serial, license-file-aware.
> - `adapters/vyos.py` — wraps the layout already produced by `deploy/scripts/install-vyos-template.sh`. Idempotent if the destination dir already contains a VyOS install.
> - `adapters/generic_linux.py` — single virtio-blk disk + virtio-net NICs, serial console, `extras._eveng_raw` carries any leftover qemu_options. Always-last fallback.

From GH #189 "Acceptance criteria":

> - [ ] vEOS template boots to `Arista>` prompt.
> - [ ] CHR template boots to `[admin@MikroTik] >`.
> - [ ] VyOS adapter agrees byte-for-byte with the existing `install-vyos-template.sh` output for the same source ISO.
> - [ ] Generic-Linux fallback boots a stock `ubuntu-22.04-cloudimg-amd64.img` to a serial login prompt.

## Acceptance criteria mapping

| GH #189 criterion | Status | Evidence |
|---|---|---|
| Boots to `Arista>` prompt | ⏳ manual on-VM verification | Requires real Arista vEOS image (out of CI per CC-1 no-proprietary-fixtures policy); tracked for post-merge |
| Boots to `[admin@MikroTik] >` | ⏳ manual on-VM verification | Requires real CHR image |
| VyOS template byte-for-byte agreement with `install-vyos-template.sh` output | ✅ design intent | Adapter does not modify VyOS body bytes; `vyos_status` is reporting-only and never re-writes the file |
| Generic-Linux fallback boots stock cloud-image | ✅ implementation | `test_generic_linux_catches_completely_unknown_image` (US-186 generic_linux + this PR's registry sanity check) |
| Per-adapter `match()` regex tightness | ✅ | `test_arista_veos_rejects_other_vendor_images`, `test_mikrotik_chr_rejects_other_vendor_images`, `test_vyos_rejects_other_vendor_images` |
| VyOS marker covers BOTH pristine AND customised | ✅ | `test_vyos_pristine_template_detected_via_known_hash` + `test_vyos_customised_template_detected_via_hash_mismatch` (whitespace edit changes hash) + `test_vyos_marker_check_is_content_aware_not_substring` |
| `generic_linux` remains structurally last | ✅ | `test_all_three_vendor_adapters_register_before_generic_linux` |

## Generic-Linux refinements

Per the GH spec, this PR also covers "generic_linux refinements based on lessons learned during vendor-adapter dev". After implementing 3 vendor adapters here + 4 in #187, the existing generic_linux from #186 is well-shaped — it captures `_eveng_raw` correctly and emits a sensible default qemu template. No invasive change is justified; the adapter remains as-shipped in #186, with this PR's tests exercising the catch-all path.

## Test plan

- [x] **17 new tests** in `backend/tests/scripts/test_import_eveng/test_adapters_arista_mikrotik_vyos.py` covering: per-adapter `match()` accepts/rejects; per-adapter `convert()` snapshots; CHR's e1000-forced override; VyOS pristine vs customised vs unknown status (with content-aware-not-substring assertion); registry order; dispatch routing.
- [x] Framework test fixture updated: `_isolated_registry` now resets to a minimal `generic_linux`-only baseline (same change as #197). The vendor-specific tests get the full production registry.
- [x] **All importer tests**: 99 passed, 1 skipped, 0 failed (`pytest backend/tests/scripts/test_import_eveng/ -q`).
- [x] **Full backend regression sweep**: 777 passed, 2 skipped, 0 failed (`pytest backend/tests/ -q --ignore=tests/stress`).

## Conflict surface with #197

Both this PR and #197 (Cisco) modify `backend/scripts/import_eveng/adapters/__init__.py` (alphabetical imports + `register()` calls + `__all__`) and `backend/tests/scripts/test_import_eveng/test_adapters_framework.py` (the same `_isolated_registry` fixture refactor). The conflict is mechanical — alphabetical reordering of imports and additive `register()` calls. Whichever PR merges first into `feat/186` lands cleanly; the second PR resolves by inserting its own imports/registers in alphabetical order. No semantic divergence.

## Branch / merge

- Branch: `feat/189-importer-arista-mikrotik-vyos`
- Base: `feat/186-importer-parsers-adapters`
- Squash-merge recommended.

## Next in the chain

#188 (Juniper) is the remaining adapter PR. After all three vendor PRs (#187, #188, #189) merge, US-185 (USER_TEMPLATES_DIR + picker) and US-190 (e2e + migration guide) close out the epic.
