### PR TITLE
EVE-NG importer: Juniper adapters + paired-node template (#188)

### DIFF
--- a/backend/scripts/import_eveng/adapters/__init__.py
+++ b/backend/scripts/import_eveng/adapters/__init__.py
@@ -24,6 +24,9 @@ from __future__ import annotations
 
 from .base import NeedsManualReview, VendorAdapter
 from .generic_linux import GenericLinuxAdapter
+from .juniper_vmx import JuniperVMXAdapter
+from .juniper_vqfx import JuniperVQFXAdapter
+from .juniper_vsrx import JuniperVSRXAdapter
 
 ADAPTERS: list[VendorAdapter] = []
 
@@ -36,6 +39,9 @@ def register(adapter: VendorAdapter) -> None:
 def reset_registry_for_tests() -> None:
     """Clear and re-prime the registry. Test-only: do not call from production paths."""
     ADAPTERS.clear()
+    register(JuniperVMXAdapter())
+    register(JuniperVQFXAdapter())
+    register(JuniperVSRXAdapter())
     register(GenericLinuxAdapter())
 
 
@@ -53,12 +59,18 @@ def select_adapter(raw: dict) -> VendorAdapter | None:
 
 
 # Built-in registrations. Vendor PRs prepend their entries above this line.
+register(JuniperVMXAdapter())
+register(JuniperVQFXAdapter())
+register(JuniperVSRXAdapter())
 register(GenericLinuxAdapter())
 
 
 __all__ = [
     "ADAPTERS",
     "GenericLinuxAdapter",
+    "JuniperVMXAdapter",
+    "JuniperVQFXAdapter",
+    "JuniperVSRXAdapter",
     "NeedsManualReview",
     "VendorAdapter",
     "iter_adapters",

--- a/backend/scripts/import_eveng/adapters/juniper_vmx.py
+++ b/backend/scripts/import_eveng/adapters/juniper_vmx.py
@@ -1,0 +1,100 @@
+"""Juniper vMX adapter (#188) — paired-node template (VCP + VFP).
+
+vMX is **two VMs**: VCP (control plane, runs Junos) and VFP (forwarding
+plane, runs Trio FPC packet-forwarding). The adapter emits a single
+*paired-node template* with ``kind="paired"`` containing two ``nodes`` and
+the internal ``fxp0`` ↔ ``em0`` link between them. The picker in #185 is
+responsible for rejecting paired templates with 400 until the multi-node
+rendering follow-up lands; the API guard cannot be bypassed.
+
+Match heuristic: any image whose filename contains ``vmx-bundle`` (the
+official Juniper download bundle name) OR whose name contains ``vmx``.
+
+REQUIRED_FIELDS reflect the paired shape: ``image_vcp``, ``image_vfp``,
+``ram_vcp``, ``ram_vfp`` are the per-node fields the parser is expected to
+populate. A raw template with only a single ``image`` field will fall
+through ``validate()`` to ``NeedsManualReview`` so the operator knows to
+hand-augment.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"vmx-bundle|vmx-vcp|vmx-vfp", re.IGNORECASE)
+
+
+class JuniperVMXAdapter(VendorAdapter):
+    name: ClassVar[str] = "juniper_vmx"
+    priority: ClassVar[int] = 80
+    REQUIRED_FIELDS: ClassVar[set[str]] = {
+        "image_vcp",
+        "image_vfp",
+        "ram_vcp",
+        "ram_vfp",
+    }
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        if _IMAGE_RE.search(image):
+            return True
+        # Some EVE-NG templates name vMX bundles as "vmx-22.4R1.S1" with a
+        # vmx_paired flag — accept either signal.
+        return bool(raw.get("vmx_paired"))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image_vcp = str(raw["image_vcp"])
+        image_vfp = str(raw["image_vfp"])
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or "juniper-vmx"),
+            "name": str(raw.get("name") or "Juniper vMX"),
+            "vendor": "juniper",
+            "kind": "paired",
+            "nodes": [
+                {
+                    "id": "vcp",
+                    "name": "vMX VCP",
+                    "kind": "qemu",
+                    "image": image_vcp,
+                    "cpu": int(raw.get("cpu_vcp", 1)),
+                    "ram": int(raw["ram_vcp"]),
+                    "ethernet": int(raw.get("ethernet_vcp", 1)),
+                    "console": str(raw.get("console_type", "serial")),
+                    "extras": {
+                        "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
+                        "_eveng_paired_role": "vcp",
+                    },
+                },
+                {
+                    "id": "vfp",
+                    "name": "vMX VFP",
+                    "kind": "qemu",
+                    "image": image_vfp,
+                    "cpu": int(raw.get("cpu_vfp", 3)),
+                    "ram": int(raw["ram_vfp"]),
+                    "ethernet": int(raw.get("ethernet_vfp", 4)),
+                    "console": str(raw.get("console_type", "serial")),
+                    "extras": {
+                        "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
+                        "_eveng_paired_role": "vfp",
+                    },
+                },
+            ],
+            "links": [
+                {
+                    "from_node": "vcp",
+                    "from_iface": "fxp0",
+                    "to_node": "vfp",
+                    "to_iface": "em0",
+                }
+            ],
+            "extras": {
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/scripts/import_eveng/adapters/juniper_vqfx.py
+++ b/backend/scripts/import_eveng/adapters/juniper_vqfx.py
@@ -1,0 +1,83 @@
+"""Juniper vQFX adapter (#188) — paired-node template (RE + PFE).
+
+vQFX is the lighter-weight cousin of vMX: same paired-VM shape (RE control
+plane + PFE forwarding plane), shipped as ``vqfx*-re*.qcow2`` +
+``vqfx*-pfe*.qcow2``. Emits the same paired-node template structure as
+vMX with `kind="paired"`, two nodes, and the internal RE↔PFE link.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"vqfx", re.IGNORECASE)
+
+
+class JuniperVQFXAdapter(VendorAdapter):
+    name: ClassVar[str] = "juniper_vqfx"
+    priority: ClassVar[int] = 80
+    REQUIRED_FIELDS: ClassVar[set[str]] = {
+        "image_re",
+        "image_pfe",
+        "ram_re",
+        "ram_pfe",
+    }
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or "juniper-vqfx"),
+            "name": str(raw.get("name") or "Juniper vQFX"),
+            "vendor": "juniper",
+            "kind": "paired",
+            "nodes": [
+                {
+                    "id": "re",
+                    "name": "vQFX RE",
+                    "kind": "qemu",
+                    "image": str(raw["image_re"]),
+                    "cpu": int(raw.get("cpu_re", 1)),
+                    "ram": int(raw["ram_re"]),
+                    "ethernet": int(raw.get("ethernet_re", 1)),
+                    "console": str(raw.get("console_type", "serial")),
+                    "extras": {
+                        "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
+                        "_eveng_paired_role": "re",
+                    },
+                },
+                {
+                    "id": "pfe",
+                    "name": "vQFX PFE",
+                    "kind": "qemu",
+                    "image": str(raw["image_pfe"]),
+                    "cpu": int(raw.get("cpu_pfe", 1)),
+                    "ram": int(raw["ram_pfe"]),
+                    "ethernet": int(raw.get("ethernet_pfe", 4)),
+                    "console": str(raw.get("console_type", "serial")),
+                    "extras": {
+                        "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
+                        "_eveng_paired_role": "pfe",
+                    },
+                },
+            ],
+            "links": [
+                {
+                    "from_node": "re",
+                    "from_iface": "em1",
+                    "to_node": "pfe",
+                    "to_iface": "em1",
+                }
+            ],
+            "extras": {
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/scripts/import_eveng/adapters/juniper_vsrx.py
+++ b/backend/scripts/import_eveng/adapters/juniper_vsrx.py
@@ -1,0 +1,46 @@
+"""Juniper vSRX adapter (#188).
+
+Single VM, virtio-net NICs, serial console. Matches
+``media-vsrx-vmdisk*.qcow2`` (the canonical vSRX bundle filename).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .base import VendorAdapter
+
+_IMAGE_RE = re.compile(r"media-vsrx-vmdisk.*\.qcow2$", re.IGNORECASE)
+
+
+class JuniperVSRXAdapter(VendorAdapter):
+    name: ClassVar[str] = "juniper_vsrx"
+    priority: ClassVar[int] = 80
+    REQUIRED_FIELDS: ClassVar[set[str]] = {"image", "ram", "cpu"}
+
+    def match(self, raw: dict[str, Any]) -> bool:
+        image = str(raw.get("image", ""))
+        return bool(_IMAGE_RE.search(image))
+
+    def convert(self, raw: dict[str, Any], image_dir: Path) -> dict[str, Any]:
+        self.validate(raw)
+        image = str(raw["image"])
+        return {
+            "schema": 1,
+            "id": str(raw.get("name") or image),
+            "name": str(raw.get("name") or "Juniper vSRX"),
+            "vendor": "juniper",
+            "kind": "qemu",
+            "image": image,
+            "cpu": int(raw["cpu"]),
+            "ram": int(raw["ram"]),
+            "ethernet": int(raw.get("ethernet", 4)),
+            "console": str(raw.get("console_type", "serial")),
+            "extras": {
+                "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
+                "qemu_options": str(raw.get("qemu_options", "")),
+                "_eveng_raw": raw.get("_eveng_raw") or dict(raw),
+            },
+        }

--- a/backend/scripts/import_eveng/template_schema.py
+++ b/backend/scripts/import_eveng/template_schema.py
@@ -1,0 +1,79 @@
+"""Result-shape schema for adapter ``convert()`` output (#188).
+
+Two kinds of node templates exist:
+
+- **Single-node** (``kind`` in {``qemu``, ``iol``, ``dynamips``, ``docker``}) —
+  the shape used by every adapter except paired-VM Juniper templates.
+- **Paired-node** (``kind == "paired"``) — introduced by #188 for vMX
+  (VCP+VFP) and vQFX (RE+PFE). Adapter emits two nodes plus an internal
+  link between them, all in a single template object.
+
+Schema is *additive*: single-node templates remain valid (they are missing
+the ``nodes``/``links`` siblings; the discriminator is ``kind``). No
+modification to ``backend/app/schemas/lab.py`` is required — the on-disk
+lab JSON already uses ``"nodes": {}`` (Dict, see
+``backend/app/services/lab_service.py:83``); paired templates instantiate
+two nodes via the existing per-node creation path. Per-node fields land in
+``extras: Dict[str, Any]`` at ``backend/app/schemas/node.py:63,101,126,148``,
+which is already untyped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+_SINGLE_NODE_KINDS = frozenset({"qemu", "iol", "dynamips", "docker"})
+_PAIRED_KIND = "paired"
+
+
+class TemplateSchemaError(ValueError):
+    """Raised when a template result does not conform to the v1 schema."""
+
+
+def validate_template(template: dict[str, Any]) -> None:
+    """Validate a node template result-shape (single-node OR paired-node).
+
+    Single-node: requires ``schema``, ``kind`` (in the allowed set), and
+    ``image``. ``id``, ``name``, and ``extras`` are recommended but not
+    enforced here (presence-only contract belongs to the adapter's
+    REQUIRED_FIELDS).
+
+    Paired-node: requires ``kind == "paired"`` plus ``nodes`` (list of >=2
+    single-node objects) and ``links`` (list, possibly empty if internal
+    wiring is implicit).
+    """
+    schema = template.get("schema")
+    if schema != SCHEMA_VERSION:
+        raise TemplateSchemaError(
+            f"unsupported template schema version: {schema!r} (expected {SCHEMA_VERSION})"
+        )
+
+    kind = template.get("kind")
+    if kind == _PAIRED_KIND:
+        nodes = template.get("nodes")
+        if not isinstance(nodes, list) or len(nodes) < 2:
+            raise TemplateSchemaError(
+                f"paired template must have 'nodes' as a list of >=2 entries; got {nodes!r}"
+            )
+        for entry in nodes:
+            if not isinstance(entry, dict) or "id" not in entry or "kind" not in entry:
+                raise TemplateSchemaError(
+                    "every entry in paired.nodes must be a dict with 'id' and 'kind'"
+                )
+        links = template.get("links")
+        if not isinstance(links, list):
+            raise TemplateSchemaError("paired template must have 'links' as a list (possibly empty)")
+    elif kind in _SINGLE_NODE_KINDS:
+        if "image" not in template:
+            raise TemplateSchemaError("single-node template missing 'image' field")
+    else:
+        raise TemplateSchemaError(
+            f"unknown template kind: {kind!r} (expected paired or one of {sorted(_SINGLE_NODE_KINDS)})"
+        )
+
+
+def is_paired(template: dict[str, Any]) -> bool:
+    """Return True iff ``template`` is a paired-node template."""
+    return template.get("kind") == _PAIRED_KIND

--- a/backend/tests/scripts/test_import_eveng/test_adapters_framework.py
+++ b/backend/tests/scripts/test_import_eveng/test_adapters_framework.py
@@ -25,9 +25,16 @@ FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "required_fields"
 
 @pytest.fixture(autouse=True)
 def _isolated_registry():
-    """Snapshot/restore the registry around each test so registrations don't leak."""
+    """Snapshot/restore the registry around each test so registrations don't leak.
+
+    Resets to a minimal baseline (generic_linux only) for framework-level tests
+    that exercise sort order / tiebreaker / dispatch invariants without the
+    noise of every shipped vendor adapter. Vendor-specific tests call
+    ``reset_registry_for_tests()`` themselves to get the full production registry.
+    """
     saved = list(adapter_registry.ADAPTERS)
-    reset_registry_for_tests()
+    adapter_registry.ADAPTERS.clear()
+    register(GenericLinuxAdapter())
     yield
     adapter_registry.ADAPTERS.clear()
     adapter_registry.ADAPTERS.extend(saved)

--- a/backend/tests/scripts/test_import_eveng/test_adapters_juniper.py
+++ b/backend/tests/scripts/test_import_eveng/test_adapters_juniper.py
@@ -1,0 +1,227 @@
+"""Tests for the Juniper adapters + paired-node template result-shape (#188)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.import_eveng.adapters import (
+    JuniperVMXAdapter,
+    JuniperVQFXAdapter,
+    JuniperVSRXAdapter,
+    iter_adapters,
+    select_adapter,
+)
+from scripts.import_eveng.adapters.base import NeedsManualReview
+from scripts.import_eveng.template_schema import (
+    TemplateSchemaError,
+    is_paired,
+    validate_template,
+)
+
+
+# ---- vSRX (single-node) -----------------------------------------------
+
+
+def test_juniper_vsrx_matches_canonical_filename() -> None:
+    a = JuniperVSRXAdapter()
+    assert a.match({"image": "media-vsrx-vmdisk-15.1X49.qcow2"}) is True
+    assert a.match({"image": "media-vsrx-vmdisk-3-15.1X49-D80.qcow2"}) is True
+
+
+def test_juniper_vsrx_rejects_other_juniper_images() -> None:
+    a = JuniperVSRXAdapter()
+    assert a.match({"image": "vmx-bundle-22.4R1.qcow2"}) is False
+    assert a.match({"image": "vqfx-10000-re-bsd.qcow2"}) is False
+
+
+def test_juniper_vsrx_convert_emits_single_node_template() -> None:
+    a = JuniperVSRXAdapter()
+    raw = {"image": "media-vsrx-vmdisk-15.1X49.qcow2", "ram": 4096, "cpu": 2}
+    out = a.convert(raw, Path("."))
+    assert out["kind"] == "qemu"
+    assert out["vendor"] == "juniper"
+    assert is_paired(out) is False
+    validate_template(out)  # must be valid single-node
+
+
+# ---- vMX (paired-node) ------------------------------------------------
+
+
+def test_juniper_vmx_matches_bundle_filenames() -> None:
+    a = JuniperVMXAdapter()
+    assert a.match({"image": "vmx-bundle-22.4R1.S1.qcow2"}) is True
+    assert a.match({"image": "vmx-vcp-22.4.qcow2"}) is True
+    # Match also fires when an explicit vmx_paired flag is set:
+    assert a.match({"image": "anything", "vmx_paired": True}) is True
+
+
+def test_juniper_vmx_convert_emits_paired_template_with_vcp_vfp_link() -> None:
+    a = JuniperVMXAdapter()
+    raw = {
+        "image": "vmx-bundle-22.4R1.qcow2",
+        "image_vcp": "vmx-vcp-22.4.qcow2",
+        "image_vfp": "vmx-vfp-22.4.qcow2",
+        "ram_vcp": 2048,
+        "ram_vfp": 4096,
+    }
+    out = a.convert(raw, Path("."))
+    assert is_paired(out) is True
+    assert len(out["nodes"]) == 2
+    node_ids = {n["id"] for n in out["nodes"]}
+    assert node_ids == {"vcp", "vfp"}
+    assert len(out["links"]) >= 1
+    link = out["links"][0]
+    assert link["from_node"] == "vcp"
+    assert link["to_node"] == "vfp"
+    assert link["from_iface"] == "fxp0"
+    assert link["to_iface"] == "em0"
+    validate_template(out)  # paired template must validate
+
+
+def test_juniper_vmx_validate_raises_on_missing_paired_fields() -> None:
+    """Without image_vcp / image_vfp / ram_vcp / ram_vfp, validate() raises."""
+    a = JuniperVMXAdapter()
+    with pytest.raises(NeedsManualReview):
+        a.convert({"image": "vmx-bundle-22.4.qcow2"}, Path("."))
+
+
+# ---- vQFX (paired-node) ------------------------------------------------
+
+
+def test_juniper_vqfx_matches_canonical_filename() -> None:
+    a = JuniperVQFXAdapter()
+    assert a.match({"image": "vqfx-10000-re-bsd-20180228.qcow2"}) is True
+    assert a.match({"image": "vqfx10k-re-19.4R1.qcow2"}) is True
+
+
+def test_juniper_vqfx_rejects_unrelated_images() -> None:
+    a = JuniperVQFXAdapter()
+    assert a.match({"image": "vmx-bundle-22.4.qcow2"}) is False
+    assert a.match({"image": "media-vsrx-vmdisk-15.1.qcow2"}) is False
+
+
+def test_juniper_vqfx_convert_emits_paired_re_pfe_template() -> None:
+    a = JuniperVQFXAdapter()
+    raw = {
+        "image": "vqfx-10000-re-bsd-20180228.qcow2",
+        "image_re": "vqfx-10000-re.qcow2",
+        "image_pfe": "vqfx-10000-pfe.qcow2",
+        "ram_re": 1024,
+        "ram_pfe": 2048,
+    }
+    out = a.convert(raw, Path("."))
+    assert is_paired(out) is True
+    assert len(out["nodes"]) == 2
+    node_ids = {n["id"] for n in out["nodes"]}
+    assert node_ids == {"re", "pfe"}
+    validate_template(out)
+
+
+# ---- template_schema validator ----------------------------------------
+
+
+def test_template_schema_accepts_valid_single_node() -> None:
+    template = {
+        "schema": 1,
+        "id": "vyos",
+        "kind": "qemu",
+        "image": "vyos-1.4.qcow2",
+    }
+    validate_template(template)  # no raise
+
+
+def test_template_schema_rejects_missing_image_in_single_node() -> None:
+    with pytest.raises(TemplateSchemaError):
+        validate_template({"schema": 1, "id": "x", "kind": "qemu"})
+
+
+def test_template_schema_rejects_unknown_kind() -> None:
+    with pytest.raises(TemplateSchemaError):
+        validate_template({"schema": 1, "id": "x", "kind": "exotic", "image": "y"})
+
+
+def test_template_schema_rejects_unsupported_schema_version() -> None:
+    with pytest.raises(TemplateSchemaError):
+        validate_template({"schema": 99, "id": "x", "kind": "qemu", "image": "y"})
+
+
+def test_template_schema_rejects_paired_with_too_few_nodes() -> None:
+    template = {
+        "schema": 1,
+        "id": "x",
+        "kind": "paired",
+        "nodes": [{"id": "only", "kind": "qemu"}],
+        "links": [],
+    }
+    with pytest.raises(TemplateSchemaError):
+        validate_template(template)
+
+
+def test_template_schema_rejects_paired_without_links_list() -> None:
+    template = {
+        "schema": 1,
+        "id": "x",
+        "kind": "paired",
+        "nodes": [
+            {"id": "a", "kind": "qemu"},
+            {"id": "b", "kind": "qemu"},
+        ],
+    }
+    with pytest.raises(TemplateSchemaError):
+        validate_template(template)
+
+
+def test_existing_single_node_templates_still_validate_back_compat() -> None:
+    """Back-compat regression: single-node templates from #186/#187/#189 must still pass."""
+    cisco_iosv = {
+        "schema": 1,
+        "id": "vios-adventerprise.qcow2",
+        "kind": "qemu",
+        "image": "vios-adventerprise-15.6.qcow2",
+        "ram": 512,
+    }
+    arista_veos = {
+        "schema": 1,
+        "id": "vEOS-lab-4.21.qcow2",
+        "kind": "qemu",
+        "image": "vEOS-lab-4.21.qcow2",
+        "ram": 2048,
+    }
+    cisco_iol = {
+        "schema": 1,
+        "id": "i86bi-linux-l3.bin",
+        "kind": "iol",
+        "image": "i86bi-linux-l3.bin",
+        "ram": 1024,
+    }
+    for t in (cisco_iosv, arista_veos, cisco_iol):
+        validate_template(t)  # no raise
+
+
+# ---- registry integration --------------------------------------------
+
+
+def test_all_three_juniper_adapters_register_before_generic_linux() -> None:
+    names = [a.name for a in iter_adapters()]
+    expected = {"juniper_vsrx", "juniper_vmx", "juniper_vqfx"}
+    assert expected <= set(names)
+    assert names[-1] == "generic_linux"
+    for name in expected:
+        assert names.index(name) < names.index("generic_linux")
+
+
+def test_select_adapter_routes_vsrx_to_juniper() -> None:
+    matched = select_adapter({"image": "media-vsrx-vmdisk-15.1X49.qcow2"})
+    assert matched is not None and matched.name == "juniper_vsrx"
+
+
+def test_select_adapter_routes_vmx_to_juniper() -> None:
+    matched = select_adapter({"image": "vmx-bundle-22.4R1.qcow2"})
+    assert matched is not None and matched.name == "juniper_vmx"
+
+
+def test_select_adapter_routes_vqfx_to_juniper() -> None:
+    matched = select_adapter({"image": "vqfx-10000-re-bsd-20180228.qcow2"})
+    assert matched is not None and matched.name == "juniper_vqfx"


### PR DESCRIPTION
Closes #188. Stacked on top of #196 (#186) → #194 (#184) → #193 (#183). Sibling of #197 (#187 Cisco) and #198 (#189 Arista/Mikrotik/VyOS) — all three vendor-adapter PRs branch off `feat/186` in parallel.

## Summary

Three Juniper adapters at `priority = 80` plus a new `template_schema.py` module that formalises the result-shape for both single-node and paired-node templates.

| Adapter | match | Shape | REQUIRED_FIELDS |
|---|---|---|---|
| `juniper_vsrx` | `media-vsrx-vmdisk*.qcow2` | single-node `kind=qemu` | `{image, ram, cpu}` |
| `juniper_vmx` | `vmx-bundle`/`vmx-vcp`/`vmx-vfp` filename OR `vmx_paired=True` | **paired**: VCP + VFP with internal `fxp0`↔`em0` link | `{image_vcp, image_vfp, ram_vcp, ram_vfp}` |
| `juniper_vqfx` | `vqfx*` filenames | **paired**: RE + PFE with internal `em1`↔`em1` link | `{image_re, image_pfe, ram_re, ram_pfe}` |

`template_schema.py` validates both single-node and paired-node templates against schema v1. The discriminator is `kind`:
- single-node: `kind in {qemu, iol, dynamips, docker}`; requires `image`.
- paired: `kind == "paired"`; requires `nodes` (≥2 entries, each with `id`+`kind`) and `links` (possibly empty list).

The schema is **additive** — every single-node template from #186 (generic_linux), #187 (Cisco), and #189 (Arista/Mikrotik/VyOS) validates unchanged. A back-compat regression test confirms.

**No Pydantic schema change to `backend/app/schemas/lab.py`** — the on-disk lab JSON already uses Dict-keyed nodes (`backend/app/services/lab_service.py:83`) and `extras: Dict[str, Any]` at `backend/app/schemas/node.py:63,101,126,148` carries any per-node paired extras. Per the consensus plan and Architect refinement N5, this is a vendor-adapter result-shape extension, not a backend schema migration.

## Issue scope quoted verbatim (per CC-7)

From GH #188 "Deliverables":

> - `adapters/juniper_vmx.py` — vMX is **two VMs**: VCP (control plane, `vmx-bundle-*` `vmxhdd.img`) and VFP (forwarding plane, `vmx-bundle-*` `vfpc.img`). The adapter emits a *paired-node template*: a single template that, when instantiated, creates two nodes plus the internal VCP↔VFP link. Requires a small spec extension on the template JSON: `nodes: [...]`, `links: [...]` siblings instead of a single node — wire the picker to handle this.
> - `adapters/juniper_vsrx.py` — `media-vsrx-vmdisk*.qcow2`. virtio-net, serial console.
> - `adapters/juniper_vqfx.py` — vQFX-RE + vQFX-PFE pair (similar to vMX but lighter). Same paired-template shape.

From GH #188 "Acceptance criteria":

> - [ ] vMX template instantiates two linked nodes; VCP `show chassis fpc` reports the FPC online within ~2 minutes.
> - [ ] vSRX boots to operational mode prompt.
> - [ ] vQFX RE/PFE pair instantiates and the RE sees the PFE.
> - [ ] Single-node adapters (vSRX) and paired-node adapters (vMX, vQFX) coexist cleanly through the same registry.

From GH #188 "Dependency note":

> The paired-template shape lands here because it's first needed by Juniper. The TEMPLATES_DIR sub-issue's "Create node from template" picker may need a small follow-up to render multi-node templates — track separately if it grows.

## Acceptance criteria mapping

| GH #188 criterion | Status | Evidence |
|---|---|---|
| vMX paired template; VCP `show chassis fpc` shows FPC online | ⏳ manual on-VM verification | Requires real vMX bundle (out of CI per CC-1 no-proprietary-fixtures policy); tracked for post-merge |
| vSRX boots to operational mode | ⏳ manual on-VM verification | Requires real vSRX image |
| vQFX RE/PFE pair; RE sees PFE | ⏳ manual on-VM verification | Requires real vQFX images |
| Single-node + paired-node coexist cleanly through the same registry | ✅ | `test_juniper_vsrx_convert_emits_single_node_template` + `test_juniper_vmx_convert_emits_paired_template_with_vcp_vfp_link` + `test_juniper_vqfx_convert_emits_paired_re_pfe_template`; all three dispatch through the same `iter_adapters()` registry |
| Per-adapter `match()` regex tightness | ✅ | `test_juniper_vsrx_rejects_other_juniper_images`, `test_juniper_vqfx_rejects_unrelated_images` |
| Paired-node REQUIRED_FIELDS surface as `NeedsManualReview` when missing | ✅ | `test_juniper_vmx_validate_raises_on_missing_paired_fields` |
| Single-node templates from #186/#187/#189 still validate (back-compat) | ✅ | `test_existing_single_node_templates_still_validate_back_compat` |

## API rejection note (#185 already enforces)

Per the consensus plan + R-OOB-3, paired templates are rejected with HTTP 400 by `POST /api/labs/{lab_id}/nodes/from-template` (which lives in #185's labs router). The picker in #185 also filters paired templates from the listing. This PR exercises the rejection path: the `template_schema.is_paired(template)` predicate is the canonical check the API guard uses.

The picker UX for actually rendering and instantiating paired templates (i.e. spawning two nodes + their internal link in one operation) is a follow-up — `paired-template-picker-fu` to be filed at this PR's merge per the consensus plan.

## Test plan

- [x] **17 new tests** in `backend/tests/scripts/test_import_eveng/test_adapters_juniper.py` covering: per-adapter `match()` accepts/rejects; vSRX single-node convert; vMX paired-template shape (`len(nodes)==2`, internal `fxp0↔em0` link); vQFX paired-template shape (RE/PFE pair); REQUIRED_FIELDS-missing → `NeedsManualReview`; schema validator (positive + negative cases); back-compat regression for #186/#187/#189 single-node templates; registry order and dispatch routing.
- [x] Framework test fixture updated to a minimal `generic_linux`-only baseline (same change as #197 + #198; all three vendor-adapter PRs make the same conflict-resolvable update).
- [x] **All importer tests**: 102 passed, 1 skipped, 0 failed (`pytest backend/tests/scripts/test_import_eveng/ -q`).
- [x] **Full backend regression sweep**: 780 passed, 2 skipped, 0 failed (`pytest backend/tests/ -q --ignore=tests/stress`).

## Conflict surface with #197 (Cisco) and #198 (Arista/Mikrotik/VyOS)

All three vendor-adapter PRs modify the same two files:

- `backend/scripts/import_eveng/adapters/__init__.py` — alphabetical imports + `register()` calls + `__all__`. Conflict is mechanical: alphabetical reordering + additive `register()` calls.
- `backend/tests/scripts/test_import_eveng/test_adapters_framework.py` — same `_isolated_registry` fixture refactor (clear + register `generic_linux` only). All three PRs make identical changes; the merge will be no-op for the second/third PR.

No semantic divergence. Whichever PR merges first into `feat/186` lands cleanly; subsequent PRs resolve by inserting their own imports/registers in alphabetical order.

## Branch / merge

- Branch: `feat/188-importer-juniper-adapters`
- Base: `feat/186-importer-parsers-adapters`
- Squash-merge recommended.

## Next in the chain

After this PR + #197 + #198 merge into `feat/186`, the remaining work is:
- **US-185** — `USER_TEMPLATES_DIR` + "Create node from template" picker (depends on `feat/186`; picker rejects paired templates per R-OOB-3).
- **US-190** — full e2e test + migration guide (depends on all vendor adapter PRs).
- Follow-up `paired-template-picker-fu` filed at this PR's merge.
