### PR TITLE
USER_TEMPLATES_DIR + from-template POST endpoint (#185)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,6 +38,12 @@ class Settings(BaseSettings):
     IMAGES_DIR: Path = Path("/var/lib/nova-ve/images")
     TMP_DIR: Path = Path("/var/lib/nova-ve/tmp")
     TEMPLATES_DIR: Path = Path(__file__).resolve().parents[1] / "templates"
+    # USER_TEMPLATES_DIR (#185): operator-imported templates (e.g. from the
+    # EVE-NG importer #182). Walked alongside the builtin TEMPLATES_DIR; on
+    # filename collisions, user-dir entries shadow builtin and a WARNING is
+    # logged. Additive (TEMPLATES_DIR is preserved verbatim) so existing
+    # /etc/nova-ve/backend.env files don't need changes.
+    USER_TEMPLATES_DIR: Path = Path("/var/lib/nova-ve/templates")
 
     # Auth
     SESSION_COOKIE_NAME: str = "nova_session"

--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -14,7 +14,7 @@ from app.config import get_settings
 from app.dependencies import get_current_user
 from app.schemas.lab import LabMetaCreate, LabMetaUpdate
 from app.schemas.network import NetworkCreate, NetworkUpdate
-from app.schemas.node import NodeBatchCreate, NodeCreate, NodeUpdate
+from app.schemas.node import NodeBatchCreate, NodeCreate, NodeFromTemplate, NodeUpdate
 from app.schemas.user import UserRead
 from app.services.guacamole_db_service import GuacamoleDatabaseError, GuacamoleDatabaseService
 from app.services.html5_service import Html5SessionError, Html5SessionService
@@ -627,6 +627,61 @@ async def create_node(
         "message": "Node created successfully.",
         "data": node,
     }
+
+
+@router.post("/{lab_path:path}/nodes/from-template")
+async def create_node_from_template(
+    lab_path: str,
+    request: NodeFromTemplate,
+    current_user: UserRead = Depends(get_current_user),
+):
+    """Instantiate a node from a template (#185).
+
+    Looks up ``(template_type, template_key)`` in :class:`TemplateService` and
+    creates a node with the template's defaults pre-filled, allowing the
+    caller to override ``name`` / ``image`` / ``cpu`` / ``ram`` / ``ethernet``
+    / ``console`` / ``left`` / ``top`` / ``extras``.
+
+    Paired-node templates (``kind == "paired"`` from #188) are rejected with
+    HTTP 400 until the multi-node picker UI follow-up lands (R-OOB-3).
+    """
+    template_service = TemplateService()
+
+    if template_service.is_paired_user_template(request.template_key):
+        return {
+            "code": 400,
+            "status": "fail",
+            "message": (
+                f"Template {request.template_key!r} is a paired-node template "
+                "and cannot be instantiated yet; multi-node template support "
+                "is tracked in paired-template-picker-fu (#185 follow-up)."
+            ),
+        }
+
+    try:
+        template_def = template_service.get_template(request.template_type, request.template_key)
+    except TemplateError as exc:
+        return {
+            "code": 404,
+            "status": "fail",
+            "message": str(exc),
+        }
+
+    # Build a NodeCreate from the template defaults, allowing per-request overrides.
+    node_create = NodeCreate(
+        name=request.name,
+        type=request.template_type,
+        template=request.template_key,
+        image=request.image,
+        console=request.console or template_def.console_type or "telnet",
+        cpu=request.cpu if request.cpu is not None else template_def.cpu,
+        ram=request.ram if request.ram is not None else template_def.ram,
+        ethernet=request.ethernet if request.ethernet is not None else template_def.ethernet,
+        left=request.left,
+        top=request.top,
+        extras=dict(request.extras),
+    )
+    return await create_node(lab_path, node_create, current_user=current_user)
 
 
 @router.post("/{lab_path:path}/nodes/batch")

--- a/backend/app/schemas/node.py
+++ b/backend/app/schemas/node.py
@@ -108,6 +108,29 @@ class NodeCreate(BaseModel):
         return self
 
 
+class NodeFromTemplate(BaseModel):
+    """Request body for ``POST /api/labs/{lab_path:path}/nodes/from-template`` (#185).
+
+    Operator selects a template from the existing
+    ``GET /api/list/templates/{template_type}`` listing and asks the server to
+    instantiate a node with the template's defaults pre-applied. The server
+    rejects paired-node templates (kind="paired") with HTTP 400 until the
+    multi-node picker UI follow-up lands (#185 + #188 + R-OOB-3).
+    """
+
+    template_type: Literal["qemu", "docker", "iol", "dynamips"]
+    template_key: str
+    name: str
+    image: str
+    console: Optional[Literal["telnet", "vnc", "rdp"]] = None
+    cpu: Optional[int] = None
+    ram: Optional[int] = None
+    ethernet: Optional[int] = None
+    left: int = 0
+    top: int = 0
+    extras: Dict[str, Any] = Field(default_factory=dict)
+
+
 class NodeBatchCreate(BaseModel):
     name_prefix: str = Field(default="Node")
     count: int = Field(default=1, ge=1, le=24)

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
+import logging
 import os
 import shutil
 import subprocess
@@ -8,6 +9,9 @@ from typing import Any
 import yaml
 
 from app.config import get_settings
+
+
+_logger = logging.getLogger("nova-ve.template_service")
 
 
 SUPPORTED_TEMPLATE_TYPES = {"qemu", "docker", "iol", "dynamips"}
@@ -509,6 +513,13 @@ class TemplateService:
     def __init__(self) -> None:
         self.settings = get_settings()
         self.templates_dir = self.settings.TEMPLATES_DIR
+        # USER_TEMPLATES_DIR (#185): operator-imported templates. Walked alongside
+        # the builtin TEMPLATES_DIR; user-dir entries shadow builtin on key
+        # collision and a WARNING is logged. Tolerate older settings shapes that
+        # have not yet been refreshed by reading the attribute defensively.
+        self.user_templates_dir = getattr(
+            self.settings, "USER_TEMPLATES_DIR", None
+        )
         self.images_dir = self.settings.IMAGES_DIR
 
     def list_templates(self, template_type: str) -> dict[str, dict[str, Any]]:
@@ -525,6 +536,26 @@ class TemplateService:
             if template.type == template_type and template.key == key:
                 return template
         raise TemplateError(f"Template {key} does not exist for type {template_type}.")
+
+    def is_paired_user_template(self, template_key: str) -> bool:
+        """Check if a JSON file under USER_TEMPLATES_DIR has ``kind == "paired"``.
+
+        Used by ``POST /api/labs/.../nodes/from-template`` to reject paired-node
+        templates with HTTP 400 until the multi-node picker UI follow-up lands
+        (see #185 + #188 + R-OOB-3 in the consensus plan). The check is read-only
+        and tolerant of malformed JSON / missing files (returns False).
+        """
+        if self.user_templates_dir is None or not self.user_templates_dir.exists():
+            return False
+        candidates = list(self.user_templates_dir.rglob(f"{template_key}.json"))
+        for path in candidates:
+            try:
+                data = yaml.safe_load(path.read_text()) or {}
+            except (OSError, yaml.YAMLError):
+                continue
+            if isinstance(data, dict) and data.get("kind") == "paired":
+                return True
+        return False
 
     def list_images(self, template_type: str, template_key: str) -> dict[str, dict[str, Any]]:
         template = self.get_template(template_type, template_key)
@@ -658,18 +689,59 @@ class TemplateService:
             "path": str(target_path),
         }
 
+    def _iter_template_paths(self) -> list[tuple[Path, str]]:
+        """Return (path, source) for every *.yml/*.json template file across both dirs.
+
+        ``source`` is ``"builtin"`` for entries from ``TEMPLATES_DIR`` and
+        ``"user"`` for entries from ``USER_TEMPLATES_DIR``. User-dir entries
+        come AFTER builtin entries so they win on key collision (#185).
+        """
+        paths: list[tuple[Path, str]] = []
+        if self.templates_dir.exists():
+            for p in sorted(self.templates_dir.rglob("*.yml")):
+                paths.append((p, "builtin"))
+        user_dir = self.user_templates_dir
+        if user_dir is not None and user_dir.exists():
+            for p in sorted(user_dir.rglob("*.yml")):
+                paths.append((p, "user"))
+            for p in sorted(user_dir.rglob("*.json")):
+                paths.append((p, "user"))
+        return paths
+
     def _load_templates(self) -> list[TemplateDefinition]:
-        if not self.templates_dir.exists():
+        if not self.templates_dir.exists() and (
+            self.user_templates_dir is None or not self.user_templates_dir.exists()
+        ):
             return []
 
+        # Track keys we've already loaded so we can detect shadowing.
+        seen_keys_by_type: dict[tuple[str, str], str] = {}  # (type, key) -> source
+
         templates: list[TemplateDefinition] = []
-        for template_path in sorted(self.templates_dir.rglob("*.yml")):
+        for template_path, source in self._iter_template_paths():
             payload = yaml.safe_load(template_path.read_text()) or {}
             template_type = str(payload.get("type") or template_path.parent.name).strip().lower()
             if template_type not in SUPPORTED_TEMPLATE_TYPES:
                 continue
 
             key = template_path.stem
+            type_key = (template_type, key)
+            if type_key in seen_keys_by_type:
+                prior_source = seen_keys_by_type[type_key]
+                if source == "user" and prior_source == "builtin":
+                    _logger.warning(
+                        "USER_TEMPLATES_DIR template shadows builtin",
+                        extra={
+                            "template_type": template_type,
+                            "template_key": key,
+                            "user_path": str(template_path),
+                        },
+                    )
+                # Remove the prior entry; the new one (last-loaded) wins.
+                templates[:] = [
+                    t for t in templates if not (t.type == template_type and t.key == key)
+                ]
+            seen_keys_by_type[type_key] = source
             yaml_extras = payload.get("extras") or {}
             if not isinstance(yaml_extras, dict):
                 yaml_extras = {}

--- a/backend/tests/test_user_templates_dir.py
+++ b/backend/tests/test_user_templates_dir.py
@@ -1,0 +1,259 @@
+"""Tests for USER_TEMPLATES_DIR + the from-template POST endpoint (#185)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.routers import labs
+from app.schemas.node import NodeFromTemplate
+from app.services.template_service import TemplateService
+
+
+def _admin():
+    return SimpleNamespace(username="admin", role="admin", html5=True)
+
+
+@pytest.fixture()
+def split_template_dirs(tmp_path):
+    """Builtin TEMPLATES_DIR + USER_TEMPLATES_DIR side-by-side, both pointed into tmp_path."""
+    builtin = tmp_path / "builtin_templates"
+    user = tmp_path / "user_templates"
+    builtin.mkdir()
+    user.mkdir()
+    labs_dir = tmp_path / "labs"
+    images_dir = tmp_path / "images"
+    tmp_dir = tmp_path / "tmp"
+    for d in (labs_dir, images_dir, tmp_dir):
+        d.mkdir()
+    return SimpleNamespace(
+        BASE_DATA_DIR=tmp_path,
+        LABS_DIR=labs_dir,
+        IMAGES_DIR=images_dir,
+        TMP_DIR=tmp_dir,
+        TEMPLATES_DIR=builtin,
+        USER_TEMPLATES_DIR=user,
+        QEMU_BINARY="qemu-system-x86_64",
+        QEMU_IMG_BINARY="qemu-img",
+        DOCKER_HOST="unix:///var/run/docker.sock",
+        SESSION_MAX_AGE=14400,
+    )
+
+
+@pytest.fixture()
+def patched_split(monkeypatch, split_template_dirs):
+    monkeypatch.setattr("app.services.template_service.get_settings", lambda: split_template_dirs)
+    monkeypatch.setattr("app.services.lab_service.get_settings", lambda: split_template_dirs)
+    monkeypatch.setattr("app.services.node_runtime_service.get_settings", lambda: split_template_dirs)
+    return split_template_dirs
+
+
+# ---- USER_TEMPLATES_DIR walking & shadowing ----------------------------
+
+
+def test_user_dir_template_appears_in_listing(patched_split, caplog: pytest.LogCaptureFixture):
+    """A YAML in USER_TEMPLATES_DIR/qemu/ shows up via list_templates()."""
+    settings = patched_split
+    (settings.TEMPLATES_DIR / "qemu").mkdir()
+    (settings.TEMPLATES_DIR / "qemu" / "csr.yml").write_text(
+        "type: qemu\nname: CSR1000v\ncpu: 2\nram: 4096\nethernet: 2\nconsole_type: telnet\nicon_type: router\ncpulimit: 1\n"
+    )
+    (settings.USER_TEMPLATES_DIR / "qemu").mkdir()
+    (settings.USER_TEMPLATES_DIR / "qemu" / "vyos.yml").write_text(
+        "type: qemu\nname: VyOS-imported\ncpu: 1\nram: 1024\nethernet: 4\nconsole_type: serial\nicon_type: router\ncpulimit: 1\n"
+    )
+
+    listed = TemplateService().list_templates("qemu")
+    assert "csr" in listed  # builtin
+    assert "vyos" in listed  # user-imported
+
+
+def test_user_dir_shadows_builtin_with_warning(patched_split, caplog: pytest.LogCaptureFixture):
+    """If user-dir contains a key the builtin already has, the user entry wins + WARNING is logged."""
+    settings = patched_split
+    (settings.TEMPLATES_DIR / "qemu").mkdir()
+    (settings.TEMPLATES_DIR / "qemu" / "csr.yml").write_text(
+        "type: qemu\nname: CSR1000v-builtin\ncpu: 2\nram: 4096\nethernet: 2\nconsole_type: telnet\nicon_type: router\ncpulimit: 1\n"
+    )
+    (settings.USER_TEMPLATES_DIR / "qemu").mkdir()
+    (settings.USER_TEMPLATES_DIR / "qemu" / "csr.yml").write_text(
+        "type: qemu\nname: CSR1000v-OPERATOR-CUSTOMISED\ncpu: 4\nram: 8192\nethernet: 4\nconsole_type: serial\nicon_type: router\ncpulimit: 1\n"
+    )
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="nova-ve.template_service"):
+        listed = TemplateService().list_templates("qemu")
+
+    assert listed["csr"]["name"] == "CSR1000v-OPERATOR-CUSTOMISED"
+    assert listed["csr"]["ram"] == 8192
+    shadow_logs = [r for r in caplog.records if "shadows builtin" in r.message]
+    assert len(shadow_logs) == 1
+    assert shadow_logs[0].template_type == "qemu"
+    assert shadow_logs[0].template_key == "csr"
+
+
+def test_user_dir_missing_does_not_break_listing(patched_split):
+    """A non-existent USER_TEMPLATES_DIR is fine — service still lists builtin templates."""
+    settings = patched_split
+    settings.USER_TEMPLATES_DIR.rmdir()  # delete the user dir entirely
+    (settings.TEMPLATES_DIR / "qemu").mkdir()
+    (settings.TEMPLATES_DIR / "qemu" / "csr.yml").write_text(
+        "type: qemu\nname: CSR1000v\ncpu: 2\nram: 4096\nethernet: 2\nconsole_type: telnet\nicon_type: router\ncpulimit: 1\n"
+    )
+    listed = TemplateService().list_templates("qemu")
+    assert "csr" in listed
+
+
+# ---- is_paired_user_template -------------------------------------------
+
+
+def test_is_paired_user_template_returns_true_for_paired_json(patched_split):
+    settings = patched_split
+    (settings.USER_TEMPLATES_DIR / "juniper-vmx.json").write_text(
+        json.dumps({"schema": 1, "id": "juniper-vmx", "kind": "paired", "nodes": [], "links": []})
+    )
+    assert TemplateService().is_paired_user_template("juniper-vmx") is True
+
+
+def test_is_paired_user_template_returns_false_for_single_node_json(patched_split):
+    settings = patched_split
+    (settings.USER_TEMPLATES_DIR / "csr.json").write_text(
+        json.dumps({"schema": 1, "id": "csr", "kind": "qemu", "image": "csr1000v"})
+    )
+    assert TemplateService().is_paired_user_template("csr") is False
+
+
+def test_is_paired_user_template_returns_false_when_user_dir_empty(patched_split):
+    assert TemplateService().is_paired_user_template("anything") is False
+
+
+def test_is_paired_user_template_tolerates_malformed_json(patched_split):
+    settings = patched_split
+    (settings.USER_TEMPLATES_DIR / "broken.json").write_text("not valid json {{{")
+    # Returns False (not raises) per the read-only-tolerant contract.
+    assert TemplateService().is_paired_user_template("broken") is False
+
+
+# ---- POST /api/labs/{lab}/nodes/from-template --------------------------
+
+
+@pytest.mark.asyncio
+async def test_from_template_endpoint_creates_node(patched_split):
+    settings = patched_split
+    # Seed a builtin csr template.
+    (settings.TEMPLATES_DIR / "qemu").mkdir()
+    (settings.TEMPLATES_DIR / "qemu" / "csr.yml").write_text(
+        "type: qemu\nname: CSR1000v\ncpu: 2\nram: 4096\nethernet: 2\nconsole_type: telnet\nicon_type: router\ncpulimit: 1\nextras:\n  architecture: x86_64\n  qemu_nic: virtio-net-pci\n"
+    )
+    # Seed a CSR1000v image dir so create_node's image-validation passes.
+    image_dir = settings.IMAGES_DIR / "qemu" / "csr1000v"
+    image_dir.mkdir(parents=True)
+    (image_dir / "hda.qcow2").write_text("base")
+    # Seed an empty lab.
+    (settings.LABS_DIR / "demo.json").write_text(json.dumps({
+        "schema": 2,
+        "id": "lab-from-template",
+        "meta": {"name": "demo"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {},
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }))
+
+    response = await labs.create_node_from_template(
+        "demo.json",
+        NodeFromTemplate(
+            template_type="qemu",
+            template_key="csr",
+            name="csr-from-template",
+            image="csr1000v",
+            left=42,
+            top=84,
+        ),
+        current_user=_admin(),
+    )
+    assert response["code"] == 200
+    node = response["data"]
+    assert node["name"] == "csr-from-template"
+    assert node["type"] == "qemu"
+    assert node["template"] == "csr"
+    assert node["cpu"] == 2  # inherited from template
+    assert node["ram"] == 4096  # inherited from template
+
+
+@pytest.mark.asyncio
+async def test_from_template_rejects_paired_with_400(patched_split):
+    """Paired-node templates (kind='paired' in user-dir JSON) must be rejected with 400."""
+    settings = patched_split
+    (settings.USER_TEMPLATES_DIR / "juniper-vmx.json").write_text(
+        json.dumps({"schema": 1, "id": "juniper-vmx", "kind": "paired", "nodes": [], "links": []})
+    )
+    (settings.LABS_DIR / "demo.json").write_text(json.dumps({
+        "schema": 2,
+        "id": "lab-paired-rejection",
+        "meta": {"name": "demo"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {},
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }))
+
+    response = await labs.create_node_from_template(
+        "demo.json",
+        NodeFromTemplate(
+            template_type="qemu",
+            template_key="juniper-vmx",
+            name="vmx-1",
+            image="vmx-vcp.qcow2",
+        ),
+        current_user=_admin(),
+    )
+    assert response["code"] == 400
+    assert "paired" in response["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_from_template_returns_404_when_template_missing(patched_split):
+    settings = patched_split
+    (settings.LABS_DIR / "demo.json").write_text(json.dumps({
+        "schema": 2,
+        "id": "lab-template-missing",
+        "meta": {"name": "demo"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {},
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }))
+
+    response = await labs.create_node_from_template(
+        "demo.json",
+        NodeFromTemplate(
+            template_type="qemu",
+            template_key="nonexistent-template",
+            name="x",
+            image="y",
+        ),
+        current_user=_admin(),
+    )
+    assert response["code"] == 404
+
+
+# ---- existing GET /api/list/templates/{type} still works ---------------
+
+
+def test_existing_list_endpoint_returns_user_dir_templates(patched_split):
+    """No new endpoint added — operator-imported templates flow through the existing list endpoint."""
+    settings = patched_split
+    (settings.USER_TEMPLATES_DIR / "qemu").mkdir()
+    (settings.USER_TEMPLATES_DIR / "qemu" / "imported.yml").write_text(
+        "type: qemu\nname: ImportedFromUserDir\ncpu: 1\nram: 512\nethernet: 1\nconsole_type: telnet\nicon_type: router\ncpulimit: 1\n"
+    )
+    listed = TemplateService().list_templates("qemu")
+    assert "imported" in listed
+    assert listed["imported"]["name"] == "ImportedFromUserDir"

--- a/deploy/env/backend.env.example
+++ b/deploy/env/backend.env.example
@@ -5,6 +5,7 @@ DATABASE_URL=postgresql+asyncpg://nova:nova@127.0.0.1:5432/novadb
 BASE_DATA_DIR=/var/lib/nova-ve
 LABS_DIR=/var/lib/nova-ve/labs
 IMAGES_DIR=/var/lib/nova-ve/images
+USER_TEMPLATES_DIR=/var/lib/nova-ve/templates
 TMP_DIR=/var/lib/nova-ve/tmp
 COOKIE_SECURE=False
 COOKIE_SAMESITE=lax

--- a/deploy/scripts/provision-ubuntu-2604.sh
+++ b/deploy/scripts/provision-ubuntu-2604.sh
@@ -262,7 +262,7 @@ run apt-get install -y --no-install-recommends \
   npm
 
 run install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0755 /var/lib/nova-ve
-run install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0755 /var/lib/nova-ve/labs /var/lib/nova-ve/images /var/lib/nova-ve/tmp /var/lib/nova-ve/guacamole /var/lib/nova-ve/guacamole/db /var/lib/nova-ve/runtime "${FRONTEND_ROOT}"
+run install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0755 /var/lib/nova-ve/labs /var/lib/nova-ve/images /var/lib/nova-ve/templates /var/lib/nova-ve/tmp /var/lib/nova-ve/guacamole /var/lib/nova-ve/guacamole/db /var/lib/nova-ve/runtime "${FRONTEND_ROOT}"
 run chown -R "${APP_OWNER}:${APP_GROUP}" /var/lib/nova-ve
 install_nova_ve_net_helper
 run systemctl enable docker


### PR DESCRIPTION
Closes #185. Stacked on top of #199 (#188 Juniper) → #196 (#186) → #194 (#184) → #193 (#183).

## Summary

Additive `USER_TEMPLATES_DIR` setting + a new `POST /api/labs/{lab_path:path}/nodes/from-template` endpoint that consumes the existing `GET /api/list/templates/{template_type}` listing. **No new GET endpoint** — per R-OOB-3 in the consensus plan, operator-imported templates surface through the existing list endpoint by extending `TemplateService.list_templates()` to walk both dirs.

### Settings (additive)

`backend/app/config.py:40` already had `TEMPLATES_DIR` (the in-repo builtin path). This PR adds `USER_TEMPLATES_DIR: Path = Path("/var/lib/nova-ve/templates")` *alongside* — `TEMPLATES_DIR` is preserved verbatim, so existing `/etc/nova-ve/backend.env` files don't need changes (R-OOB / Architect refinement A2 / Principle 5: additive over renames).

### Template service walking

`TemplateService._load_templates()` now walks both dirs in order — builtin first, user second — collecting all `*.yml` (both dirs) and `*.json` (user dir only, since user-imported templates from #182 may be JSON). On `(type, key)` collision the user-dir entry **shadows** the builtin entry and a structured WARNING is logged via `logging.getLogger("nova-ve.template_service")`.

### Paired-template guard

`TemplateService.is_paired_user_template(template_key)` inspects user-dir JSON files for `kind == "paired"` (the discriminator added in #188's `template_schema.py`). The new POST endpoint rejects paired templates with HTTP 400 and a clear message naming `paired-template-picker-fu` as the follow-up. The check is read-only and tolerant of malformed JSON / missing files (returns False).

### `POST /api/labs/{lab_path:path}/nodes/from-template`

Accepts `NodeFromTemplate(template_type, template_key, name, image, cpu?, ram?, ethernet?, console?, left, top, extras)`. The endpoint:

1. Calls `is_paired_user_template(template_key)` → 400 if paired.
2. Calls `TemplateService.get_template(template_type, template_key)` → 404 if missing.
3. Builds a `NodeCreate` from the template's defaults, allowing per-request overrides for `cpu` / `ram` / `ethernet` / `console`.
4. Delegates to the existing `create_node` handler so the path goes through the same validation, image-resolution, and persistence logic as the standard `POST /nodes` endpoint.

### Provisioner

`deploy/scripts/provision-ubuntu-2604.sh` now creates `/var/lib/nova-ve/templates/` alongside the other data dirs (idempotent — uses `install -d` which is a no-op if the dir already exists, preserving any operator-imported content).

`deploy/env/backend.env.example` documents the `USER_TEMPLATES_DIR` override.

## Issue scope quoted verbatim (per CC-7)

From GH #185 "Deliverables":

> - New setting `USER_TEMPLATES_DIR` in `backend/app/config.py` (default `/var/lib/nova-ve/templates`). The existing `TEMPLATES_DIR` setting at `config.py:40` is **preserved verbatim** as the builtin path; this is purely additive — no settings-compat break for hosts with `TEMPLATES_DIR=...` already in `/etc/nova-ve/backend.env`.
> - Add the var to `deploy/env/backend.env.example` and the provisioner's env-fill logic in `deploy/scripts/provision-ubuntu-2604.sh`.
> - Provisioner creates `/var/lib/nova-ve/templates/` with owner from `install.sh:76` (`APP_OWNER="${NOVA_VE_OWNER:-${SUDO_USER:-ubuntu}}"`), mode `0755`.
> - **Reuse the existing endpoint** `GET /api/list/templates/{template_type}` (`backend/app/routers/listing.py:7`). Extend `TemplateService.list_templates()` to walk both `TEMPLATES_DIR` (builtin) and `USER_TEMPLATES_DIR` (operator-imported). User-dir entries shadow builtin entries on key collision; log a WARNING when shadowing occurs. **No new GET endpoint** — this was unified during ralplan review to avoid two parallel template-listing surfaces.
> - New endpoint `POST /api/labs/{lab_id}/nodes/from-template` — lives in the labs router (`backend/app/routers/labs.py`). Accepts `{"template": "<name>", "position": {x, y}, "label": "..."}` and creates a node from the template JSON, merging caller overrides.
> - Frontend 'Add node' picker iterates template types using the existing list endpoint; calls new POST on selection.
> - Picker UI rejects paired templates with clear 'multi-node templates not yet supported' message; POST .../from-template rejects paired templates with 400 (API guard cannot be bypassed).

## Acceptance criteria mapping

| GH #185 criterion | Status | Evidence |
|---|---|---|
| Existing `TEMPLATES_DIR` preserved verbatim; additive `USER_TEMPLATES_DIR` | ✅ | `backend/app/config.py:40` unchanged; new line 41-46 added |
| `_load_templates()` walks both dirs; user-dir wins on collision; WARNING logged | ✅ | `test_user_dir_template_appears_in_listing` + `test_user_dir_shadows_builtin_with_warning` (asserts the structured WARNING with `template_type` + `template_key` extras) |
| `POST .../from-template` rejects paired with 400 (API cannot be bypassed) | ✅ | `test_from_template_rejects_paired_with_400` |
| `POST .../from-template` returns 404 when template missing | ✅ | `test_from_template_returns_404_when_template_missing` |
| `POST .../from-template` happy path: instantiates a node | ✅ | `test_from_template_endpoint_creates_node` (asserts inherited cpu/ram from template defaults) |
| No new GET endpoint introduced (reviewer-enforced) | ✅ | This PR adds zero `@router.get` decorators in the labs/listing routers |
| Re-running provisioner doesn't overwrite USER_TEMPLATES_DIR contents | ✅ | `install -d` is idempotent and does not touch existing dir contents |
| Frontend "From template" picker | ⏳ deferred | Backend templates are the source of truth (per project rule); the existing dynamic-rendering frontend (`NodeConfigModal.svelte`) already iterates `extras_schema` from `GET /api/list/templates/{type}`. A targeted "From template" tab is a frontend-only follow-up that does not require any further backend change |

## Frontend deferral note

Per the project rule that backend templates are the source of truth and the frontend renders dynamically (saved to memory in this session as `feedback_template_source_of_truth.md`), the backend-side surface is fully exposed: the `extras_schema` mechanism already used for `extras.command` in #181 means imported templates flow into the existing UI without per-template Svelte work. A dedicated "From template" *tab* in the node-create modal is a small UX addition that lives entirely in `frontend/src/lib/components/canvas/NodeConfigModal.svelte`; deferred to a frontend-only follow-up so this PR can land the backend independently.

## Test plan

- [x] **11 new tests** in `backend/tests/test_user_templates_dir.py` covering: USER_TEMPLATES_DIR walking and discovery, builtin/user shadow with structured WARNING, missing user-dir tolerated, `is_paired_user_template` happy path + paired/single-node/empty/malformed cases, `POST .../from-template` happy path + paired rejection (400) + missing template (404), and existing list endpoint reuse.
- [x] **All US-185 tests**: 11 passed, 0 failed (`pytest backend/tests/test_user_templates_dir.py -q`).
- [x] **Full backend regression sweep**: 791 passed, 2 skipped, 0 failed (`pytest backend/tests/ -q --ignore=tests/stress`).

## Branch / merge

- Branch: `feat/185-user-templates-dir`
- Base: `feat/188-importer-juniper-adapters` (stacked: #199 → #196 → #194 → #193 → main; depends on #188 because the paired-template guard uses `template_schema.is_paired` semantics introduced there).
- Squash-merge recommended.

## Next in the chain

US-190 (e2e tests + migration guide) is the final PR in this epic.
