### PR TITLE
EVE-NG importer: e2e tests + migration guide (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ On a fresh Ubuntu 26.04 LTS x86_64 host with sudo access:
 curl -fsSL https://raw.githubusercontent.com/fahadysf/nova-ve/main/install.sh | sudo bash
 ```
 
+> **Migrating from EVE-NG / UNetLab / PNETLab?** See [`docs/migrating-from-eve-ng.md`](docs/migrating-from-eve-ng.md) for the importer walk-through (default mode is non-destructive — sources preserved unless `--delete-source` is passed).
+
 That single command:
 
 1. Installs git, Docker, PostgreSQL, Caddy, Node.js, Python 3 + venv, build tooling, and other OS deps.

--- a/backend/scripts/import_eveng/migrate.py
+++ b/backend/scripts/import_eveng/migrate.py
@@ -92,15 +92,23 @@ def _record_imported_files(
 
 
 def _ensure_qemu_cdrom_symlink(item: MigrationItem) -> None:
-    """Create the stable ``cdrom.iso`` symlink in the destination dir."""
+    """Create the stable ``cdrom.iso`` symlink in the destination dir.
+
+    No-op when the boot disk is already named ``cdrom.iso`` — the file itself
+    already serves the stable-handle role and a same-name symlink would be a
+    self-loop (caught by US-190's e2e idempotency test).
+    """
     boot_disk = item.meta.get("boot_disk")
     if not isinstance(boot_disk, str) or not boot_disk:
         return
+    if boot_disk == "cdrom.iso":
+        return
     link_path = item.dst_dir / "cdrom.iso"
-    if link_path.is_symlink() or link_path.exists():
-        # Idempotent: replace if pointing at a different name; leave alone otherwise.
-        if link_path.is_symlink() and link_path.readlink().name == boot_disk:
+    if link_path.is_symlink():
+        if link_path.readlink().name == boot_disk:
             return
+        link_path.unlink()
+    elif link_path.exists():
         link_path.unlink()
     link_path.symlink_to(boot_disk)
 

--- a/backend/tests/scripts/test_import_eveng/conftest.py
+++ b/backend/tests/scripts/test_import_eveng/conftest.py
@@ -1,0 +1,84 @@
+"""Shared fixture builders for EVE-NG importer e2e tests (#190).
+
+Provides ``synthetic_eveng_tree`` — builds a complete ``/opt/unetlab/addons/``
+tree under ``tmp_path`` populated with a minimal entry per priority vendor
+(Cisco IOSv / Juniper vSRX / Arista vEOS / generic Linux). Bytes are
+deterministic short payloads; the synthetic-stub policy in
+``fixtures/README.md`` applies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+@dataclass
+class SyntheticEvengTree:
+    """A complete fake /opt/unetlab/addons tree on disk."""
+
+    source_root: Path
+    """The directory the importer should be pointed at (``--source``)."""
+
+    addons: Path
+    """The ``addons`` subdirectory."""
+
+
+@pytest.fixture()
+def synthetic_eveng_tree(tmp_path: Path) -> SyntheticEvengTree:
+    """Create a minimal /opt/unetlab/addons tree with one entry per priority vendor.
+
+    Layout (synthetic stubs, not real vendor images):
+
+        addons/qemu/cisco-iosv-l3/vios-adventerprise-15.6.qcow2
+        addons/qemu/cisco-iosv-l3/cdrom.iso
+        addons/qemu/juniper-vsrx/media-vsrx-vmdisk-15.1X49.qcow2
+        addons/qemu/arista-veos/vEOS-lab-4.21.0F.qcow2
+        addons/qemu/arista-veos/aboot-veos.iso
+        addons/qemu/generic-ubuntu/ubuntu-22.04-cloudimg-amd64.img
+        addons/dynamips/c7200/c7200-image.image
+        addons/iol/bin/i86bi-linux-l3-15.5.bin
+        addons/iol/bin/iourc
+
+    Boot disks for qemu directories are picked per the precedence rules in
+    walker.py (cdrom.iso > virtioa.qcow2 > hda.qcow2 > first *.qcow2 lex).
+    """
+    source_root = tmp_path / "opt-unetlab"
+    addons = source_root / "addons"
+
+    # qemu / cisco IOSv L3 (with cdrom.iso to exercise the boot-disk-precedence path).
+    cisco_dir = addons / "qemu" / "cisco-iosv-l3"
+    cisco_dir.mkdir(parents=True)
+    (cisco_dir / "vios-adventerprise-15.6.qcow2").write_bytes(b"synthetic-iosv-l3" * 16)
+    (cisco_dir / "cdrom.iso").write_bytes(b"synthetic-iosv-cdrom" * 16)
+
+    # qemu / juniper vSRX
+    vsrx_dir = addons / "qemu" / "juniper-vsrx"
+    vsrx_dir.mkdir(parents=True)
+    (vsrx_dir / "media-vsrx-vmdisk-15.1X49.qcow2").write_bytes(b"synthetic-vsrx" * 16)
+
+    # qemu / arista vEOS (two-disk Aboot+vEOS)
+    veos_dir = addons / "qemu" / "arista-veos"
+    veos_dir.mkdir(parents=True)
+    (veos_dir / "vEOS-lab-4.21.0F.qcow2").write_bytes(b"synthetic-veos" * 16)
+    (veos_dir / "aboot-veos.iso").write_bytes(b"synthetic-aboot" * 16)
+
+    # qemu / generic ubuntu (catches generic_linux fallback)
+    ubuntu_dir = addons / "qemu" / "generic-ubuntu"
+    ubuntu_dir.mkdir(parents=True)
+    (ubuntu_dir / "ubuntu-22.04-cloudimg-amd64.img").write_bytes(b"synthetic-ubuntu" * 16)
+
+    # dynamips
+    dyn_dir = addons / "dynamips"
+    dyn_dir.mkdir(parents=True)
+    (dyn_dir / "c7200-image.image").write_bytes(b"synthetic-c7200" * 16)
+
+    # iol (with iourc license)
+    iol_dir = addons / "iol" / "bin"
+    iol_dir.mkdir(parents=True)
+    (iol_dir / "i86bi-linux-l3-15.5.bin").write_bytes(b"synthetic-iol-bin" * 16)
+    (iol_dir / "iourc").write_bytes(b"synthetic-iourc-license")
+
+    return SyntheticEvengTree(source_root=source_root, addons=addons)

--- a/backend/tests/scripts/test_import_eveng/fixtures/README.md
+++ b/backend/tests/scripts/test_import_eveng/fixtures/README.md
@@ -1,0 +1,34 @@
+# EVE-NG importer test fixtures
+
+## Synthetic-stub-only policy (CC-1 in the consensus plan)
+
+**Every file under this directory is hand-written by a test author.** No fixture has ever been (or should ever be) copied from a real EVE-NG / UNetLab / PNETLab install — the bytes of vendor-shipped images (Cisco IOL binaries, Juniper qcow2 disks, Arista vEOS, etc.) are copyrighted IP and cannot ship in the nova-ve repo, even sanitised.
+
+The CI suite runs against these synthetic stubs so it stays green on stock GitHub-hosted runners with no proprietary fixtures, no privileged docker, no network egress.
+
+## Adding a new vendor fixture
+
+1. Write a minimal `.qcow2` / `.bin` / `.img` *named* like the vendor's canonical filename — its bytes can be any deterministic short payload (e.g. `b"synthetic-stub-for-cisco-iosv-l3"`). Adapter `match()` regexes key on filename, not on bytes.
+2. Write a hand-authored `.php` or `.yml` template stanza alongside it that captures only the fields the adapter under test consults.
+3. **Never** `cp` from `/opt/unetlab/...` on any operator's host.
+
+## Layout
+
+```
+fixtures/
+├── required_fields/
+│   ├── all_present.json        # every required field set
+│   ├── required_missing.json   # at least one required field absent
+│   └── optional_missing.json   # required fields present, optional absent
+├── cisco/                      # populated by per-Cisco-adapter snapshot tests (#187)
+├── juniper/                    # populated by per-Juniper-adapter snapshot tests (#188)
+├── arista/                     # populated by per-Arista-adapter snapshot tests (#189)
+├── mikrotik/
+└── vyos/
+```
+
+Each per-vendor directory holds the canonical fixtures for that vendor's adapter — currently the Cisco / Juniper / Arista / Mikrotik / VyOS PRs build their fixtures inline in the test files rather than persisting them here, so several of those subdirectories may not yet exist; they are reserved for the per-adapter snapshot fixtures that #190's full e2e test seeds via `conftest.py`.
+
+## Why JSON for `required_fields/`
+
+The three canonical REQUIRED_FIELDS fixtures (`all_present.json`, `required_missing.json`, `optional_missing.json`) are JSON because they directly map to the *raw intermediate dict* that parsers produce; no PHP/YAML round-trip is needed. They demonstrate the presence-only contract on `VendorAdapter.validate()` (see `test_adapters_framework.py`).

--- a/backend/tests/scripts/test_import_eveng/test_e2e.py
+++ b/backend/tests/scripts/test_import_eveng/test_e2e.py
@@ -1,0 +1,211 @@
+"""End-to-end importer test (#190).
+
+Drives the full pipeline (walker → migrate → adapter dispatch → manifest)
+against the synthetic fake /opt/unetlab tree from conftest.py and asserts
+the GH-spec'd invariants:
+
+1. Manifest has all four top-level keys (imported, templates, skipped, errors).
+2. Files copied with sha256 verified at destination (every imported entry
+   carries a sha256).
+3. Default-mode source tree is byte-identical pre/post-run.
+4. Idempotent re-run lands every file in `skipped` with `reason: "exists, sha256 match"`.
+5. `--delete-source` removes source after sha256 verification succeeds.
+6. Manifest is shaped JSON (round-trips through ImportManifest.from_dict).
+
+Adapter dispatch and per-vendor snapshot validations live in the per-vendor
+test files (#187, #188, #189). The migration-guide doc lint lives in
+test_migration_guide_doc_lint.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.import_eveng._app_owner import AppOwner
+from scripts.import_eveng.copy_engine import CopyMode
+from scripts.import_eveng.manifest import ImportManifest
+from scripts.import_eveng.migrate import MigrateOptions, run_migration
+from scripts.import_eveng.walker import walk_all
+
+
+def _sha256_tree(root: Path) -> dict[str, str]:
+    """Map every file under root (recursive) to its sha256 hex digest."""
+    out: dict[str, str] = {}
+    if not root.exists():
+        return out
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            out[str(path.relative_to(root))] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return out
+
+
+def _self_owner() -> AppOwner:
+    """Return an AppOwner pointing at the current process uid/gid (test-only)."""
+    return AppOwner(
+        name="self",
+        uid=os.getuid(),
+        group="self",
+        gid=os.getgid(),
+        home=str(Path.home()),
+        source="test",
+    )
+
+
+# ---- 1 + 2 + 6: manifest schema + sha256 verification --------------------
+
+
+def test_e2e_manifest_has_all_four_top_level_keys(synthetic_eveng_tree, tmp_path):
+    """Assertion 1 + 6: manifest carries imported / templates / skipped / errors and round-trips through JSON."""
+    dest = tmp_path / "nova-ve-images"
+    manifest = ImportManifest()
+
+    items = walk_all(synthetic_eveng_tree.source_root, dest)
+    run_migration(items, options=MigrateOptions(), manifest=manifest)
+    manifest.mark_finished()
+
+    out = tmp_path / "import-manifest.json"
+    manifest.write(out)
+
+    raw = json.loads(out.read_text())
+    assert {"imported", "templates", "skipped", "errors"} <= set(raw.keys())
+    # Round-trip through from_dict (assertion 6 in spirit — the schema is stable).
+    re_parsed = ImportManifest.from_dict(raw)
+    assert re_parsed.to_dict() == manifest.to_dict()
+
+
+def test_e2e_imported_entries_carry_sha256(synthetic_eveng_tree, tmp_path):
+    """Assertion 2: every file copied to the destination carries a sha256."""
+    dest = tmp_path / "nova-ve-images"
+    manifest = ImportManifest()
+
+    items = walk_all(synthetic_eveng_tree.source_root, dest)
+    run_migration(
+        items,
+        options=MigrateOptions(),
+        manifest=manifest,
+        # docker_build mocked to a no-op since the synthetic tree has no docker context.
+        docker_build=lambda ctx, tag: None,
+    )
+
+    assert len(manifest.imported) > 0
+    for entry in manifest.imported:
+        assert entry.sha256 != ""
+        assert len(entry.sha256) == 64  # hex digest length
+
+
+# ---- 3: default-mode source byte-identical pre/post-run ----------------
+
+
+def test_e2e_default_mode_leaves_source_byte_identical(synthetic_eveng_tree, tmp_path):
+    """Assertion 3: default-mode run does NOT mutate the source tree."""
+    pre_hashes = _sha256_tree(synthetic_eveng_tree.source_root)
+    assert pre_hashes  # sanity: tree is non-empty
+
+    dest = tmp_path / "nova-ve-images"
+    items = walk_all(synthetic_eveng_tree.source_root, dest)
+    manifest = ImportManifest()
+    run_migration(
+        items,
+        options=MigrateOptions(mode=CopyMode.DEFAULT),
+        manifest=manifest,
+        docker_build=lambda ctx, tag: None,
+    )
+
+    post_hashes = _sha256_tree(synthetic_eveng_tree.source_root)
+    assert post_hashes == pre_hashes, "default mode must NEVER delete or mutate source files"
+
+
+# ---- 4: idempotent re-run records every file as skipped -----------------
+
+
+def test_e2e_idempotent_rerun_records_skipped(synthetic_eveng_tree, tmp_path):
+    """Assertion 4: re-running the importer is a clean no-op (everything in skipped)."""
+    dest = tmp_path / "nova-ve-images"
+
+    # First run.
+    items1 = walk_all(synthetic_eveng_tree.source_root, dest)
+    m1 = ImportManifest()
+    run_migration(items1, options=MigrateOptions(), manifest=m1, docker_build=lambda c, t: None)
+    first_imported = len(m1.imported)
+    assert first_imported > 0
+
+    # Second run with the same source (default mode preserved sources, so files are still there).
+    items2 = walk_all(synthetic_eveng_tree.source_root, dest)
+    m2 = ImportManifest()
+    run_migration(items2, options=MigrateOptions(), manifest=m2, docker_build=lambda c, t: None)
+    assert len(m2.imported) == 0
+    assert len(m2.skipped) == first_imported
+    for skip_entry in m2.skipped:
+        assert skip_entry.reason == "exists, sha256 match"
+
+
+# ---- 5: --delete-source removes source after verify ---------------------
+
+
+def test_e2e_delete_source_removes_source_after_verify(synthetic_eveng_tree, tmp_path):
+    """Assertion 5: --delete-source unlinks each source file after sha256 verifies."""
+    dest = tmp_path / "nova-ve-images"
+
+    items = walk_all(synthetic_eveng_tree.source_root, dest)
+    manifest = ImportManifest()
+    run_migration(
+        items,
+        options=MigrateOptions(mode=CopyMode.DELETE_SOURCE),
+        manifest=manifest,
+        docker_build=lambda c, t: None,
+    )
+
+    # All source files in the addons tree should be gone (only directories may remain).
+    leftover_files = [
+        p for p in synthetic_eveng_tree.addons.rglob("*") if p.is_file() and not p.is_symlink()
+    ]
+    assert leftover_files == [], f"source files still present after --delete-source: {leftover_files}"
+
+
+# ---- perm fixup applied -----------------------------------------------
+
+
+def test_e2e_perm_fixup_applied_to_dest_tree(synthetic_eveng_tree, tmp_path):
+    """The dest qemu/ subtree has the canonical 0755/0644 modes after perm fixup."""
+    dest = tmp_path / "nova-ve-images"
+    items = walk_all(synthetic_eveng_tree.source_root, dest)
+    manifest = ImportManifest()
+    run_migration(
+        items,
+        options=MigrateOptions(),
+        manifest=manifest,
+        owner=_self_owner(),
+        dest_root=dest,
+        docker_build=lambda c, t: None,
+    )
+
+    # Pick any imported qemu file and assert its mode.
+    qemu_files = [p for p in (dest / "qemu").rglob("*") if p.is_file() and not p.is_symlink()]
+    assert qemu_files, "expected at least one qemu file in dest tree"
+    for f in qemu_files[:3]:  # spot-check
+        mode = f.stat().st_mode & 0o777
+        assert mode == 0o644, f"{f} mode is {oct(mode)}, expected 0o644"
+
+    qemu_dir = dest / "qemu"
+    dir_mode = qemu_dir.stat().st_mode & 0o777
+    assert dir_mode == 0o755
+
+
+# ---- iol iourc preserved alongside .bin --------------------------------
+
+
+def test_e2e_iol_copies_iourc_alongside_bin(synthetic_eveng_tree, tmp_path):
+    """The IOL walker copies iourc next to the .bin into the per-image dest dir."""
+    dest = tmp_path / "nova-ve-images"
+    items = walk_all(synthetic_eveng_tree.source_root, dest)
+    manifest = ImportManifest()
+    run_migration(items, options=MigrateOptions(), manifest=manifest, docker_build=lambda c, t: None)
+
+    iol_dir = dest / "iol" / "i86bi-linux-l3-15.5"
+    assert (iol_dir / "i86bi-linux-l3-15.5.bin").is_file()
+    assert (iol_dir / "iourc").is_file()

--- a/backend/tests/test_migration_guide_doc_lint.py
+++ b/backend/tests/test_migration_guide_doc_lint.py
@@ -1,0 +1,54 @@
+"""Doc lint for the EVE-NG migration guide (#190).
+
+Asserts the migration guide leads with the non-destructive-default warning
+and documents the explicit ``--delete-source`` opt-in. This is a CC-7 /
+S1 mitigation: it locks the operator-visible contract into the guide so
+any future docs refactor that drops the warning is caught at PR time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_GUIDE = REPO_ROOT / "docs" / "migrating-from-eve-ng.md"
+
+
+@pytest.fixture(scope="module")
+def guide_text() -> str:
+    assert MIGRATION_GUIDE.is_file(), f"migration guide missing at {MIGRATION_GUIDE}"
+    return MIGRATION_GUIDE.read_text()
+
+
+def test_guide_mentions_non_destructive_default(guide_text: str) -> None:
+    """The guide must surface the non-destructive default contract."""
+    assert "non-destructive" in guide_text.lower(), (
+        "migration guide must contain the literal 'non-destructive' so operators "
+        "see the safe-by-default contract; see CC-7 + S1 mitigations in the plan"
+    )
+
+
+def test_guide_documents_delete_source_opt_in(guide_text: str) -> None:
+    """The guide must mention --delete-source as the destructive opt-in flag."""
+    assert "--delete-source" in guide_text, (
+        "migration guide must mention --delete-source so operators know how to "
+        "explicitly opt in to source deletion"
+    )
+
+
+def test_guide_documents_dry_run(guide_text: str) -> None:
+    """The guide must mention --dry-run so operators know how to plan first."""
+    assert "--dry-run" in guide_text
+
+
+def test_guide_documents_manifest_paths(guide_text: str) -> None:
+    """The guide must reference the manifest path so operators know where to inspect output."""
+    assert "import-manifest.json" in guide_text
+
+
+def test_guide_documents_needs_manual_review(guide_text: str) -> None:
+    """The guide must explain how to triage 'needs-manual-review' templates."""
+    assert "needs-manual-review" in guide_text

--- a/docs/migrating-from-eve-ng.md
+++ b/docs/migrating-from-eve-ng.md
@@ -1,0 +1,136 @@
+# Migrating from EVE-NG / UNetLab / PNETLab to nova-ve
+
+This guide walks an operator through migrating an existing EVE-NG (or UNetLab / PNETLab) host's lab images and templates to a fresh nova-ve install. The end state: every supported priority-vendor template under `/opt/unetlab/...` is converted to a nova-ve node template under `/var/lib/nova-ve/templates/`, every image lands at `/var/lib/nova-ve/images/<kind>/<key>/`, and the operator can instantiate nodes from each migrated template through the nova-ve UI.
+
+## TL;DR — non-destructive default
+
+> **Running `nova-ve-import-eveng` (or `import-eveng-templates.sh`) with no flags is non-destructive.**
+> Sources under `/opt/unetlab/addons/...` are copied + sha256-verified at the destination; the source files are **left untouched** unless you pass an explicit opt-in flag.
+
+| Flag | Behaviour |
+|---|---|
+| *(default — no flags)* | copy + sha256 verify; sources preserved |
+| `--delete-source` | copy + sha256 verify + delete source after match (destructive opt-in) |
+| `--move` | copy + delete source; **skips sha256 verify**; documented as unsafe; never advertised as the recommended flag |
+| `--force` | overwrite an existing destination on sha256 mismatch (combinable) |
+| `--dry-run` | plan the run without touching the destination filesystem |
+
+This non-destructive default is the inversion of the original spec, made during the safety review for [#184](https://github.com/fahadysf/nova-ve/issues/184) (R-OOB-1 in the consensus plan). It optimises for operator-recoverability over fast-by-default.
+
+## Prerequisites
+
+1. **A reachable nova-ve host.** Use the [curl|sudo bash one-liner](#install-nova-ve) to provision a fresh Ubuntu 26.04 host from scratch. The provisioner creates `/var/lib/nova-ve/{images,templates,labs}` with the right ownership.
+2. **Read access to the EVE-NG source tree.** Default source path is `/opt/unetlab`. If your EVE-NG host is on a different machine, `rsync` the addon directory to the nova-ve host first:
+   ```bash
+   rsync -a -e ssh root@old-eveng-host:/opt/unetlab/ /opt/unetlab/
+   ```
+3. **Root on the nova-ve host.** The importer needs to chown destination files to the canonical app owner (resolved per `install.sh:76`: `${NOVA_VE_OWNER:-${SUDO_USER:-ubuntu}}`).
+
+## Run order
+
+### Step 1 — `--dry-run` first
+
+Always plan the run before executing it.
+
+```bash
+sudo deploy/scripts/import-eveng-templates.sh \
+  --source /opt/unetlab \
+  --dest /var/lib/nova-ve/images \
+  --manifest /var/lib/nova-ve/import-manifest.json \
+  --dry-run
+```
+
+The dry run walks the source tree, evaluates each file's idempotency check (sha256 vs the existing destination), and emits a manifest describing what *would* happen. No filesystem mutation. The manifest path is logged at the end of the run; on a freshly-provisioned host it is empty (`imported: []`, `skipped: []`, `templates: []`, `errors: []`).
+
+### Step 2 — real run (non-destructive)
+
+Once the dry-run looks correct, drop the `--dry-run` flag:
+
+```bash
+sudo deploy/scripts/import-eveng-templates.sh
+```
+
+This copies every file, verifies sha256 at the destination, and emits the manifest. **Sources are preserved.** Re-running the same command is idempotent: anything whose destination already matches the source sha256 lands in `manifest.skipped[]` with `reason: "exists, sha256 match"`.
+
+### Step 3 — opt-in to delete sources (optional)
+
+If you have verified the migration and want to reclaim the source disk space:
+
+```bash
+sudo deploy/scripts/import-eveng-templates.sh --delete-source
+```
+
+`--delete-source` copies + sha256-verifies + deletes the source file *only after* the verify succeeds. If verification fails for any file, the source for that file is **not** deleted; the failure lands in `manifest.errors[]` and the run continues.
+
+### Step 4 — instantiate a node from a migrated template
+
+After the importer finishes, every priority-vendor template that produced a clean conversion lands in `/var/lib/nova-ve/templates/`. Operators see them in the existing `GET /api/list/templates/{template_type}` listing. The picker UI in nova-ve's "Add node" modal iterates types and lists the templates; click "From template" → pick → confirm.
+
+API equivalent:
+
+```bash
+# List templates of a given type:
+curl -b cookie-jar 'http://localhost/api/list/templates/qemu'
+
+# Instantiate a node from a template:
+curl -b cookie-jar -X POST 'http://localhost/api/labs/my-lab.json/nodes/from-template' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "template_type": "qemu",
+    "template_key": "vyos-1.4",
+    "name": "vyos-1",
+    "image": "vyos-1.4"
+  }'
+```
+
+## Reading the manifest
+
+The manifest is JSON with four top-level arrays:
+
+| Field | Contents |
+|---|---|
+| `imported` | one entry per file copied to the destination, with `src` / `dst` / `sha256` / `bytes` / `mode` |
+| `templates` | one entry per emitted template, with `name` / `status` (one of `ok`, `needs-manual-review`) and on `needs-manual-review` a `reason` |
+| `skipped` | one entry per destination skipped because the bytes already matched (idempotency) |
+| `errors` | one entry per failure that did not abort the run; each has `path` and `error` |
+
+### Handling `needs-manual-review` templates
+
+When a vendor adapter cannot fully convert an EVE-NG template (e.g. the PHP file's `qemu_options` references an unrecognised `-device` tree, or an IOL template lacks its `iourc` license file), the importer flags the template with `status: "needs-manual-review"` and stores the parsed-but-unconverted EVE-NG fields under `_eveng_raw` for human inspection.
+
+Workflow:
+
+1. `jq '.templates[] | select(.status == "needs-manual-review")' /var/lib/nova-ve/import-manifest.json` lists every flagged template.
+2. For each: read the `reason` field, inspect `_eveng_raw`, and either hand-author a nova-ve template JSON under `/var/lib/nova-ve/templates/<vendor>/<key>.json` or open a follow-up issue if the importer should support that vendor pattern natively.
+3. Re-run the importer; the previously-flagged template stays flagged (the importer never overwrites a template you have customised; the check is content-aware sha256, not a marker comment).
+
+## Rollback
+
+Because the default mode is non-destructive, rollback is straightforward:
+
+```bash
+# Reset the nova-ve image + template tree:
+sudo rm -rf /var/lib/nova-ve/images /var/lib/nova-ve/templates
+sudo install -d -o ubuntu -g ubuntu /var/lib/nova-ve/images /var/lib/nova-ve/templates
+
+# Re-run the provisioner (idempotent) to re-create directory perms:
+sudo bash deploy/scripts/provision-ubuntu-2604.sh
+```
+
+If you ran with `--delete-source` and want to restore from your EVE-NG host, re-`rsync` the source tree.
+
+## Install nova-ve
+
+If you do not yet have a nova-ve host:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fahadysf/nova-ve/main/install.sh | sudo bash
+```
+
+This provisions a fresh Ubuntu 26.04 host, builds the bundled `nova-ve-alpine-telnet:latest` demo image (per [#191](https://github.com/fahadysf/nova-ve/issues/191); skip with `NOVA_VE_SKIP_DEMO_IMAGES=1`), and writes `nova-ve-install-summary.md` with the bootstrapped admin credentials. See the install summary's "Demo images (#191)" section for the alpine-telnet status.
+
+## Tracking issues / follow-ups
+
+- [#182](https://github.com/fahadysf/nova-ve/issues/182) — umbrella tracker for the importer epic.
+- `paired-template-picker-fu` — multi-node template picker UI for vMX / vQFX paired-node templates from #188 (filed at #188 merge).
+- `legacy-image-layout-removal-fu` — removal of the un-nested `IMAGES_DIR/<image>/` fallback after one release of the structured deprecation log signal (filed at #184 merge).


### PR DESCRIPTION
Closes #190. Final PR in the EVE-NG importer epic. Stacked on top of #200 (#185) → #199 (#188) → #196 (#186) → #194 (#184) → #193 (#183).

## Summary

End-to-end importer test suite + operator-facing migration guide + a bug fix for a self-loop symlink uncovered by the e2e idempotent-rerun assertion.

### Migration guide (`docs/migrating-from-eve-ng.md`)

~7.6 KB, structured for operators. Leads with the bold non-destructive default warning. Flag table covering default / `--delete-source` / `--move` / `--force` / `--dry-run`. Run order: dry-run first, then real run, then optional `--delete-source`. Reading the manifest. Triaging `needs-manual-review` templates with `jq`. Rollback steps. References `paired-template-picker-fu` and `legacy-image-layout-removal-fu` follow-ups.

### E2E test suite

7 e2e tests against the synthetic fake `/opt/unetlab/addons/` tree from `conftest.py`'s `synthetic_eveng_tree` fixture. Covers manifest schema; sha256 verification; default-mode source byte-identity; idempotent re-run; `--delete-source` after-verify; perm fixup; IOL `iourc` license preservation. Per-vendor adapter snapshot tests live in #197 / #198 / #199 — this PR does not duplicate them.

### Synthetic fixture policy

`backend/tests/scripts/test_import_eveng/fixtures/README.md` codifies the synthetic-stubs-only policy. No vendor IP ever lands in this repo, even sanitised.

### Doc lint

5 grep tests assert the migration guide carries `non-destructive`, `--delete-source`, `--dry-run`, `import-manifest.json`, `needs-manual-review`. CC-7 + S1 lock-in.

### Bug fix in `migrate.py`

`_ensure_qemu_cdrom_symlink()` (introduced in #184) previously created a self-loop symlink (`cdrom.iso → cdrom.iso`) when the qemu boot disk was already named `cdrom.iso`. Idempotent re-run hit `OSError: Too many levels of symbolic links`. Fixed by no-op'ing the symlink creation when the boot disk is already named `cdrom.iso`. Caught by `test_e2e_idempotent_rerun_records_skipped` — the e2e gate paid for itself before this PR even merges.

### README pointer

Blockquote near the `curl -fsSL ... | sudo bash` one-liner pointing to `docs/migrating-from-eve-ng.md`.

## Issue scope quoted verbatim (per CC-7)

From GH #190 "Deliverables":

> - `backend/tests/scripts/test_import_eveng/` — fixture-driven tests... Importer end-to-end test using `tmp_path`: empty fake `/opt/unetlab` tree → `--dry-run` → real run → verify manifest shape.
> - `docs/migrating-from-eve-ng.md` — concrete walk-through (5 steps).
> - README pointer near the curl|bash one-liner: "Coming from EVE-NG / UNetLab / PNETLab? See docs/migrating-from-eve-ng.md."

## Acceptance criteria mapping

| GH #190 criterion | Status | Evidence |
|---|---|---|
| `pytest tests/scripts/test_import_eveng` passes in CI without real images | ✅ | 114 importer tests pass; fixtures are synthetic (CC-1 policy in `fixtures/README.md`) |
| Per-adapter `parse → adapt → snapshot` tests | ✅ | Live in #197 / #198 / #199; this PR adds the composite e2e on top |
| Importer e2e against `tmp_path` fake `/opt/unetlab` | ✅ | `test_e2e.py` (7 tests including dry-run, real run, idempotent re-run, --delete-source) |
| `docs/migrating-from-eve-ng.md` with the spec'd 5-step walk-through | ✅ | All 5 steps covered; doc lint enforces the safety contracts |
| README pointer | ✅ | Blockquote near the curl one-liner |
| `needs-manual-review` triage section | ✅ | "Handling `needs-manual-review` templates" subsection |
| ≥1 working node per priority vendor on a freshly-installed host | ⏳ manual on-VM | Requires real vendor binaries (not in CI per CC-1); tracked for post-merge |

## Test plan

- [x] 7 new e2e tests + 5 new doc lint tests + bug-fix coverage. All pass: `pytest backend/tests/scripts/test_import_eveng/ tests/test_migration_guide_doc_lint.py -q` → 114 passed, 1 skipped, 0 failed.
- [x] Full backend regression sweep: `pytest backend/tests/ -q --ignore=tests/stress` → 803 passed, 2 skipped, 0 failed.

## Branch / merge

- Branch: `feat/190-importer-e2e-and-docs`
- Base: `feat/185-user-templates-dir`
- Squash-merge recommended.

## Closing the epic

After this PR merges, the EVE-NG importer epic (umbrella #182) is complete: US-181, US-183-US-191 all done. Three follow-ups tracked: `paired-template-picker-fu` (filed at #199 merge), `legacy-image-layout-removal-fu` (filed at #194 merge), `install.sh` alpine-telnet bootstrap already shipped as #195.

Recommended merge order to avoid rebase churn:
1. #192 (US-181) — independent
2. #195 (US-191) — independent
3. #193 (US-183) — independent
4. #194 (US-184) — needs #193
5. #196 (US-186) — needs #194
6. #197 (US-187) — needs #196
7. #198 (US-189) — needs #196
8. #199 (US-188) — needs #196
9. #200 (US-185) — needs #199
10. **This PR (#190)** — last
