### PR TITLE
Multi-node template picker UI for paired vMX/vQFX (#202)

### DIFF
--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Fahad Yousuf <fahadysf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import logging
 import uuid
 from urllib.parse import quote
@@ -14,7 +15,13 @@ from app.config import get_settings
 from app.dependencies import get_current_user
 from app.schemas.lab import LabMetaCreate, LabMetaUpdate
 from app.schemas.network import NetworkCreate, NetworkUpdate
-from app.schemas.node import NodeBatchCreate, NodeCreate, NodeFromTemplate, NodeUpdate
+from app.schemas.node import (
+    NodeBatchCreate,
+    NodeCreate,
+    NodeFromPairedTemplate,
+    NodeFromTemplate,
+    NodeUpdate,
+)
 from app.schemas.user import UserRead
 from app.services.guacamole_db_service import GuacamoleDatabaseError, GuacamoleDatabaseService
 from app.services.html5_service import Html5SessionError, Html5SessionService
@@ -652,9 +659,9 @@ async def create_node_from_template(
             "code": 400,
             "status": "fail",
             "message": (
-                f"Template {request.template_key!r} is a paired-node template "
-                "and cannot be instantiated yet; multi-node template support "
-                "is tracked in paired-template-picker-fu (#185 follow-up)."
+                f"Template {request.template_key!r} is a paired-node template; "
+                "use POST /api/labs/{lab_path}/nodes/from-paired-template instead "
+                "(see #202)."
             ),
         }
 
@@ -682,6 +689,254 @@ async def create_node_from_template(
         extras=dict(request.extras),
     )
     return await create_node(lab_path, node_create, current_user=current_user)
+
+
+class _PairedIfaceLookupError(ValueError):
+    """Raised when a paired-link interface name doesn't match any child interface.
+
+    Caught by ``create_nodes_from_paired_template`` to trigger lab.json rollback;
+    paired templates are required to declare ``interface_naming.explicit`` per
+    child so vendor-specific link references (Junos ``fxp0``/``em0``, ...) resolve
+    exactly. The error message names the missing iface so the operator can fix
+    the template definition.
+    """
+
+
+def _resolve_iface_index(node: dict, iface_name: str) -> int:
+    """Find the interface index by name on a paired-template child node (#202).
+
+    Strict: raises :class:`_PairedIfaceLookupError` when no interface matches.
+    """
+    interfaces = node.get("interfaces") or []
+    for idx, iface in enumerate(interfaces):
+        if isinstance(iface, dict) and str(iface.get("name") or "") == iface_name:
+            return idx
+    available = ", ".join(
+        str(iface.get("name") or "") for iface in interfaces if isinstance(iface, dict)
+    )
+    raise _PairedIfaceLookupError(
+        f"Paired-link references unknown interface {iface_name!r} on node "
+        f"{node.get('name')!r} (available: {available or '<none>'}). "
+        "Add interface_naming.explicit:[...] to the paired-template child so "
+        "link references resolve exactly."
+    )
+
+
+def _build_paired_child_payload(
+    *,
+    node_id: int,
+    template_key: str,
+    child: dict,
+    name: str,
+    left: int,
+    top: int,
+) -> dict:
+    """Compose a lab-node payload from a paired-template child entry.
+
+    Paired children are self-describing — image / cpu / ram / ethernet / console /
+    extras come from the template JSON, not from a :class:`TemplateDefinition`
+    lookup, so we build the payload directly instead of routing through
+    :func:`_build_node_payload`. The child's ``interface_naming`` (if present)
+    is honored so links that reference vendor-specific names (e.g. ``fxp0``)
+    resolve cleanly via :func:`_resolve_iface_index`.
+    """
+    child_type = str(child.get("kind") or "qemu").lower()
+    if child_type not in {"qemu", "docker", "iol", "dynamips"}:
+        child_type = "qemu"
+    ethernet = int(child.get("ethernet", 1))
+    extras = dict(child.get("extras") or {})
+
+    if child_type == "qemu":
+        if not extras.get("uuid"):
+            extras["uuid"] = str(uuid.uuid4())
+        if not extras.get("firstmac"):
+            extras["firstmac"] = _first_mac_for_node(node_id)
+
+    template_iface_naming = child.get("interface_naming")
+    if not isinstance(template_iface_naming, dict):
+        template_iface_naming = None
+
+    interfaces = _default_interfaces(
+        child_type,
+        ethernet,
+        interface_naming_scheme=None,
+        template_interface_naming=template_iface_naming,
+    )
+
+    explicit_names = (template_iface_naming or {}).get("explicit") if template_iface_naming else None
+    if isinstance(explicit_names, list):
+        for idx, iface in enumerate(interfaces):
+            if idx < len(explicit_names) and isinstance(explicit_names[idx], str):
+                iface["name"] = explicit_names[idx]
+
+    return {
+        "id": node_id,
+        "name": name,
+        "type": child_type,
+        "template": template_key,
+        "image": str(child.get("image") or ""),
+        "console": str(child.get("console") or "telnet"),
+        "status": 0,
+        "delay": 0,
+        "cpu": int(child.get("cpu", 1)),
+        "ram": int(child.get("ram", 1024)),
+        "ethernet": ethernet,
+        "cpulimit": int(child.get("cpulimit", 1)),
+        "uuid": extras.get("uuid") if child_type == "qemu" else None,
+        "firstmac": extras.get("firstmac") if child_type == "qemu" else None,
+        "left": left,
+        "top": top,
+        "icon": _icon_filename_for(str(child.get("icon_type") or "router")),
+        "width": "0",
+        "config": False,
+        "config_list": [],
+        "sat": 0,
+        "computed_sat": 0,
+        "interfaces": interfaces,
+        "extras": extras,
+    }
+
+
+@router.post("/{lab_path:path}/nodes/from-paired-template")
+async def create_nodes_from_paired_template(
+    lab_path: str,
+    request: NodeFromPairedTemplate,
+    current_user: UserRead = Depends(get_current_user),
+):
+    """Instantiate a paired-node template (#202): all children + auto-links, atomic.
+
+    Paired templates (``kind="paired"``) declare two-or-more child nodes plus the
+    intra-template links that connect them — vMX (VCP+VFP fxp0↔em0), vQFX
+    (RE+PFE em1↔em1), and other multi-VM appliances. This endpoint creates ALL
+    children and ALL auto-links in a single transaction; on partial failure
+    lab.json is rolled back from a snapshot taken before the first mutation.
+    """
+    template_service = TemplateService()
+    paired = template_service.get_paired_user_template(request.template_key)
+    if paired is None:
+        return {
+            "code": 404,
+            "status": "fail",
+            "message": (
+                f"Paired template {request.template_key!r} not found in "
+                "USER_TEMPLATES_DIR or is not a valid paired-node template."
+            ),
+        }
+
+    try:
+        scoped_path = _scoped_lab_path(current_user, lab_path, treat_as_absolute=True)
+        data = _read_lab_data(scoped_path)
+    except LegacyLabSchemaError as exc:
+        return _legacy_schema_response(exc)
+    except FileNotFoundError:
+        return {
+            "code": 404,
+            "status": "fail",
+            "message": "Lab does not exist (60038).",
+        }
+    except PermissionError as e:
+        return {
+            "code": 403,
+            "status": "fail",
+            "message": str(e),
+        }
+
+    snapshot = copy.deepcopy(data)
+    nodes_map = data.setdefault("nodes", {})
+    next_id = max((int(node_key) for node_key in nodes_map.keys()), default=0) + 1
+
+    child_id_to_node_id: dict[str, int] = {}
+    created_nodes: list[dict] = []
+
+    try:
+        for index, child in enumerate(paired["nodes"]):
+            if not isinstance(child, dict):
+                raise ValueError(f"Paired template {request.template_key!r} has malformed child entry at index {index}.")
+            child_id = str(child.get("id") or f"child-{index}")
+            override_name = request.name_overrides.get(child_id)
+            child_name = override_name or str(child.get("name") or f"{request.template_key}-{child_id}")
+            left, top = _node_position(index, request.base_left, request.base_top, "row")
+            payload = _build_paired_child_payload(
+                node_id=next_id,
+                template_key=request.template_key,
+                child=child,
+                name=child_name,
+                left=left,
+                top=top,
+            )
+            nodes_map[str(next_id)] = payload
+            child_id_to_node_id[child_id] = next_id
+            created_nodes.append(payload)
+            next_id += 1
+
+        LabService.write_lab_json_static(scoped_path, data)
+    except Exception as exc:  # noqa: BLE001 — broad catch is the rollback contract
+        LabService.write_lab_json_static(scoped_path, snapshot)
+        _logger.exception(
+            "from-paired-template: node-creation phase failed for %s; rolled back",
+            request.template_key,
+        )
+        return {
+            "code": 500,
+            "status": "fail",
+            "message": f"Failed to create paired nodes: {exc}",
+        }
+
+    from app.services.link_service import LinkService
+
+    link_service = LinkService()
+    created_links: list[dict] = []
+
+    try:
+        for link in paired["links"]:
+            if not isinstance(link, dict):
+                continue
+            from_child = str(link.get("from_node") or "")
+            to_child = str(link.get("to_node") or "")
+            from_iface_name = str(link.get("from_iface") or "")
+            to_iface_name = str(link.get("to_iface") or "")
+
+            from_node_id = child_id_to_node_id.get(from_child)
+            to_node_id = child_id_to_node_id.get(to_child)
+            if from_node_id is None or to_node_id is None:
+                raise ValueError(
+                    f"Paired link references unknown child id "
+                    f"({from_child!r}↔{to_child!r}) in template {request.template_key!r}."
+                )
+
+            from_iface_idx = _resolve_iface_index(nodes_map[str(from_node_id)], from_iface_name)
+            to_iface_idx = _resolve_iface_index(nodes_map[str(to_node_id)], to_iface_name)
+
+            link_payload, _network_payload, _replayed = await link_service.create_link(
+                lab_path,
+                {"node_id": from_node_id, "interface_index": from_iface_idx},
+                {"node_id": to_node_id, "interface_index": to_iface_idx},
+            )
+            created_links.append(link_payload)
+    except Exception as exc:  # noqa: BLE001 — broad catch is the rollback contract
+        LabService.write_lab_json_static(scoped_path, snapshot)
+        _logger.exception(
+            "from-paired-template: link-creation phase failed for %s; rolled back",
+            request.template_key,
+        )
+        return {
+            "code": 500,
+            "status": "fail",
+            "message": f"Failed to create paired links: {exc}",
+        }
+
+    return {
+        "code": 200,
+        "status": "success",
+        "message": (
+            f"Paired template {request.template_key!r} instantiated: "
+            f"{len(created_nodes)} node(s), {len(created_links)} link(s)."
+        ),
+        "data": {
+            "nodes": created_nodes,
+            "links": created_links,
+        },
+    }
 
 
 @router.post("/{lab_path:path}/nodes/batch")

--- a/backend/app/schemas/node.py
+++ b/backend/app/schemas/node.py
@@ -131,6 +131,27 @@ class NodeFromTemplate(BaseModel):
     extras: Dict[str, Any] = Field(default_factory=dict)
 
 
+class NodeFromPairedTemplate(BaseModel):
+    """Request body for ``POST /api/labs/{lab_path:path}/nodes/from-paired-template`` (#202).
+
+    Operator selects a paired-node template (``kind="paired"``) from the catalog
+    (which exposes ``paired_templates:[...]`` alongside the regular templates list)
+    and asks the server to instantiate ALL child nodes plus the auto-links between
+    them in a single atomic call. On partial failure the server rolls back lab.json
+    so no orphan nodes are left behind.
+
+    The base position is the drop-point on the canvas; child nodes are laid out in
+    a row with a 180-px horizontal offset relative to that anchor. ``name_overrides``
+    maps the paired template's child id (e.g. ``"vcp"``, ``"vfp"``) to a user-chosen
+    node name; missing entries use ``f"{template_key}-{child_id}"``.
+    """
+
+    template_key: str
+    base_left: int = 0
+    base_top: int = 0
+    name_overrides: Dict[str, str] = Field(default_factory=dict)
+
+
 class NodeBatchCreate(BaseModel):
     name_prefix: str = Field(default="Node")
     count: int = Field(default=1, ge=1, le=24)

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -551,25 +551,34 @@ class TemplateService:
                 return template
         raise TemplateError(f"Template {key} does not exist for type {template_type}.")
 
-    def is_paired_user_template(self, template_key: str) -> bool:
-        """Check if a JSON file under USER_TEMPLATES_DIR has ``kind == "paired"``.
+    def get_paired_user_template(self, template_key: str) -> dict[str, Any] | None:
+        """Load a paired-node template (``kind="paired"``) from USER_TEMPLATES_DIR.
 
-        Used by ``POST /api/labs/.../nodes/from-template`` to reject paired-node
-        templates with HTTP 400 until the multi-node picker UI follow-up lands
-        (see #185 + #188 + R-OOB-3 in the consensus plan). The check is read-only
-        and tolerant of malformed JSON / missing files (returns False).
+        Returns the parsed dict (with ``nodes:[...]`` + ``links:[...]`` siblings
+        validated as lists) or ``None`` when no matching paired template exists.
+        Used by ``POST /api/labs/.../nodes/from-paired-template`` (#202) to
+        instantiate multi-node templates atomically. Read-only; tolerant of
+        malformed JSON.
         """
         if self.user_templates_dir is None or not self.user_templates_dir.exists():
-            return False
+            return None
         candidates = list(self.user_templates_dir.rglob(f"{template_key}.json"))
         for path in candidates:
             try:
                 data = yaml.safe_load(path.read_text()) or {}
             except (OSError, yaml.YAMLError):
                 continue
-            if isinstance(data, dict) and data.get("kind") == "paired":
-                return True
-        return False
+            if not isinstance(data, dict) or data.get("kind") != "paired":
+                continue
+            nodes = data.get("nodes")
+            links = data.get("links")
+            if isinstance(nodes, list) and nodes and isinstance(links, list):
+                return data
+        return None
+
+    def is_paired_user_template(self, template_key: str) -> bool:
+        """Boolean check used by the single-node from-template endpoint to 400 paired keys."""
+        return self.get_paired_user_template(template_key) is not None
 
     def list_images(self, template_type: str, template_key: str) -> dict[str, dict[str, Any]]:
         template = self.get_template(template_type, template_key)
@@ -654,8 +663,70 @@ class TemplateService:
             )
         return {
             "templates": templates,
+            "paired_templates": self._build_paired_catalog(),
             "icon_options": icon_options,
         }
+
+    def _build_paired_catalog(self) -> list[dict[str, Any]]:
+        """Enumerate paired user-templates (#202) for the node catalog response.
+
+        Paired templates live as JSON files at the root of ``USER_TEMPLATES_DIR``
+        with ``kind="paired"`` and sibling ``nodes:[...]`` + ``links:[...]``
+        arrays (see :class:`scripts.import_eveng.adapters.juniper_vmx.JuniperVMXAdapter`).
+        Each entry is a self-contained multi-node instantiation directive — the
+        frontend renders these with a distinct visual treatment ("2 nodes" badge)
+        and routes submissions to ``POST /nodes/from-paired-template`` instead of
+        the single-node ``/nodes/batch`` path.
+        """
+        if self.user_templates_dir is None or not self.user_templates_dir.exists():
+            return []
+        result: list[dict[str, Any]] = []
+        for path in sorted(self.user_templates_dir.rglob("*.json")):
+            try:
+                data = yaml.safe_load(path.read_text()) or {}
+            except (OSError, yaml.YAMLError):
+                continue
+            if not isinstance(data, dict) or data.get("kind") != "paired":
+                continue
+            nodes = data.get("nodes")
+            links = data.get("links")
+            if not (isinstance(nodes, list) and nodes and isinstance(links, list)):
+                continue
+            child_summary = [
+                {
+                    "id": str(child.get("id") or f"child-{i}"),
+                    "name": str(child.get("name") or child.get("id") or f"child-{i}"),
+                    "kind": str(child.get("kind") or "qemu"),
+                    "image": str(child.get("image") or ""),
+                    "cpu": int(child.get("cpu", 1)),
+                    "ram": int(child.get("ram", 1024)),
+                    "ethernet": int(child.get("ethernet", 1)),
+                }
+                for i, child in enumerate(nodes)
+                if isinstance(child, dict)
+            ]
+            link_summary = [
+                {
+                    "from_node": str(link.get("from_node") or ""),
+                    "from_iface": str(link.get("from_iface") or ""),
+                    "to_node": str(link.get("to_node") or ""),
+                    "to_iface": str(link.get("to_iface") or ""),
+                }
+                for link in links
+                if isinstance(link, dict)
+            ]
+            result.append(
+                {
+                    "key": path.stem,
+                    "name": str(data.get("name") or path.stem),
+                    "vendor": str(data.get("vendor") or ""),
+                    "child_count": len(child_summary),
+                    "link_count": len(link_summary),
+                    "children": child_summary,
+                    "links": link_summary,
+                }
+            )
+        return result
 
     def template_extras(self, template_type: str, template_key: str) -> dict[str, Any]:
         """Return the merged default extras (schema defaults + YAML overrides) for a template."""

--- a/backend/scripts/import_eveng/adapters/juniper_vmx.py
+++ b/backend/scripts/import_eveng/adapters/juniper_vmx.py
@@ -66,6 +66,7 @@ class JuniperVMXAdapter(VendorAdapter):
                     "ram": int(raw["ram_vcp"]),
                     "ethernet": int(raw.get("ethernet_vcp", 1)),
                     "console": str(raw.get("console_type", "serial")),
+                    "interface_naming": {"explicit": ["fxp0"]},
                     "extras": {
                         "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
                         "_eveng_paired_role": "vcp",
@@ -80,6 +81,7 @@ class JuniperVMXAdapter(VendorAdapter):
                     "ram": int(raw["ram_vfp"]),
                     "ethernet": int(raw.get("ethernet_vfp", 4)),
                     "console": str(raw.get("console_type", "serial")),
+                    "interface_naming": {"explicit": ["em0", "em1", "em2", "em3"]},
                     "extras": {
                         "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
                         "_eveng_paired_role": "vfp",

--- a/backend/scripts/import_eveng/adapters/juniper_vqfx.py
+++ b/backend/scripts/import_eveng/adapters/juniper_vqfx.py
@@ -47,8 +47,11 @@ class JuniperVQFXAdapter(VendorAdapter):
                     "image": str(raw["image_re"]),
                     "cpu": int(raw.get("cpu_re", 1)),
                     "ram": int(raw["ram_re"]),
-                    "ethernet": int(raw.get("ethernet_re", 1)),
+                    # Default bumped 1 → 2 so the internal em1 link interface
+                    # is in range; fxp0 occupies index 0 per Junos convention.
+                    "ethernet": int(raw.get("ethernet_re", 2)),
                     "console": str(raw.get("console_type", "serial")),
+                    "interface_naming": {"explicit": ["fxp0", "em1"]},
                     "extras": {
                         "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
                         "_eveng_paired_role": "re",
@@ -63,6 +66,7 @@ class JuniperVQFXAdapter(VendorAdapter):
                     "ram": int(raw["ram_pfe"]),
                     "ethernet": int(raw.get("ethernet_pfe", 4)),
                     "console": str(raw.get("console_type", "serial")),
+                    "interface_naming": {"explicit": ["em0", "em1", "em2", "em3"]},
                     "extras": {
                         "qemu_nic": str(raw.get("qemu_nic", "virtio-net-pci")),
                         "_eveng_paired_role": "pfe",

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -1,0 +1,364 @@
+"""Tests for ``POST /api/labs/{lab_path:path}/nodes/from-paired-template`` (#202).
+
+Paired-node templates instantiate two-or-more child nodes plus the auto-link
+between them in a single atomic call. The endpoint:
+
+- 200 + ``{nodes:[...], links:[...]}`` on success
+- 404 when the template_key isn't a paired template in USER_TEMPLATES_DIR
+- 500 + lab.json rolled back when any phase fails (no orphan nodes)
+- single-node ``/nodes/from-template`` keeps rejecting paired with 400 + new pointer
+
+Tests build a synthetic vMX-shaped paired template directly under
+``USER_TEMPLATES_DIR`` (no real Juniper images needed) and exercise the endpoint
+against an empty lab.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.routers import labs
+from app.schemas.node import NodeFromPairedTemplate, NodeFromTemplate
+from app.services.template_service import TemplateService
+
+
+def _admin():
+    return SimpleNamespace(username="admin", role="admin", html5=True)
+
+
+VMX_PAIRED_TEMPLATE = {
+    "schema": 1,
+    "id": "juniper-vmx",
+    "name": "Juniper vMX",
+    "vendor": "juniper",
+    "kind": "paired",
+    "nodes": [
+        {
+            "id": "vcp",
+            "name": "vMX VCP",
+            "kind": "qemu",
+            "image": "vmx-vcp-22.4.qcow2",
+            "cpu": 1,
+            "ram": 2048,
+            "ethernet": 1,
+            "console": "serial",
+            "interface_naming": {"explicit": ["fxp0"]},
+            "extras": {"qemu_nic": "virtio-net-pci"},
+        },
+        {
+            "id": "vfp",
+            "name": "vMX VFP",
+            "kind": "qemu",
+            "image": "vmx-vfp-22.4.qcow2",
+            "cpu": 3,
+            "ram": 4096,
+            "ethernet": 4,
+            "console": "serial",
+            "interface_naming": {"explicit": ["em0", "em1", "em2", "em3"]},
+            "extras": {"qemu_nic": "virtio-net-pci"},
+        },
+    ],
+    "links": [
+        {"from_node": "vcp", "from_iface": "fxp0", "to_node": "vfp", "to_iface": "em0"},
+    ],
+}
+
+
+@pytest.fixture()
+def split_template_dirs(tmp_path):
+    builtin = tmp_path / "builtin_templates"
+    user = tmp_path / "user_templates"
+    builtin.mkdir()
+    user.mkdir()
+    labs_dir = tmp_path / "labs"
+    images_dir = tmp_path / "images"
+    tmp_dir = tmp_path / "tmp"
+    for d in (labs_dir, images_dir, tmp_dir):
+        d.mkdir()
+    return SimpleNamespace(
+        BASE_DATA_DIR=tmp_path,
+        LABS_DIR=labs_dir,
+        IMAGES_DIR=images_dir,
+        TMP_DIR=tmp_dir,
+        TEMPLATES_DIR=builtin,
+        USER_TEMPLATES_DIR=user,
+        QEMU_BINARY="qemu-system-x86_64",
+        QEMU_IMG_BINARY="qemu-img",
+        DOCKER_HOST="unix:///var/run/docker.sock",
+        SESSION_MAX_AGE=14400,
+    )
+
+
+@pytest.fixture()
+def patched_split(monkeypatch, split_template_dirs):
+    monkeypatch.setattr("app.services.template_service.get_settings", lambda: split_template_dirs)
+    monkeypatch.setattr("app.services.lab_service.get_settings", lambda: split_template_dirs)
+    monkeypatch.setattr("app.services.node_runtime_service.get_settings", lambda: split_template_dirs)
+    monkeypatch.setattr("app.services.link_service.get_settings", lambda: split_template_dirs)
+    return split_template_dirs
+
+
+def _seed_empty_lab(settings, lab_id: str = "lab-paired") -> Path:
+    lab_path = settings.LABS_DIR / "demo.json"
+    lab_path.write_text(
+        json.dumps(
+            {
+                "schema": 2,
+                "id": lab_id,
+                "meta": {"name": "demo"},
+                "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+                "nodes": {},
+                "networks": {},
+                "links": [],
+                "defaults": {"link_style": "orthogonal"},
+            }
+        )
+    )
+    return lab_path
+
+
+def _seed_paired_template(settings, template: dict, key: str = "juniper-vmx") -> None:
+    (settings.USER_TEMPLATES_DIR / f"{key}.json").write_text(json.dumps(template))
+
+
+# ---- get_paired_user_template -------------------------------------------
+
+
+def test_get_paired_user_template_returns_full_dict(patched_split):
+    _seed_paired_template(patched_split, VMX_PAIRED_TEMPLATE)
+    paired = TemplateService().get_paired_user_template("juniper-vmx")
+    assert paired is not None
+    assert paired["kind"] == "paired"
+    assert len(paired["nodes"]) == 2
+    assert len(paired["links"]) == 1
+
+
+def test_get_paired_user_template_returns_none_for_non_paired(patched_split):
+    (patched_split.USER_TEMPLATES_DIR / "csr.json").write_text(
+        json.dumps({"schema": 1, "id": "csr", "kind": "qemu", "image": "csr1000v.qcow2"})
+    )
+    assert TemplateService().get_paired_user_template("csr") is None
+
+
+def test_get_paired_user_template_rejects_empty_nodes_list(patched_split):
+    _seed_paired_template(
+        patched_split,
+        {"schema": 1, "id": "broken", "kind": "paired", "nodes": [], "links": []},
+        key="broken",
+    )
+    assert TemplateService().get_paired_user_template("broken") is None
+
+
+# ---- catalog response ---------------------------------------------------
+
+
+def test_catalog_includes_paired_templates_block(patched_split):
+    _seed_paired_template(patched_split, VMX_PAIRED_TEMPLATE)
+    catalog = TemplateService().build_node_catalog()
+    assert "paired_templates" in catalog
+    paired_entries = catalog["paired_templates"]
+    assert len(paired_entries) == 1
+    entry = paired_entries[0]
+    assert entry["key"] == "juniper-vmx"
+    assert entry["child_count"] == 2
+    assert entry["link_count"] == 1
+    assert entry["vendor"] == "juniper"
+    assert {c["id"] for c in entry["children"]} == {"vcp", "vfp"}
+
+
+def test_catalog_paired_templates_empty_when_none_exist(patched_split):
+    catalog = TemplateService().build_node_catalog()
+    assert catalog["paired_templates"] == []
+
+
+# ---- POST /nodes/from-paired-template -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_creates_two_nodes_and_one_link(patched_split):
+    settings = patched_split  # noqa: F841 — used inside the lab.json read below
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(
+            template_key="juniper-vmx",
+            base_left=100,
+            base_top=200,
+        ),
+        current_user=_admin(),
+    )
+
+    assert response["code"] == 200, response
+    nodes = response["data"]["nodes"]
+    links = response["data"]["links"]
+    assert len(nodes) == 2
+    assert len(links) == 1
+
+    # Default child name comes from the template's per-child `name` field.
+    node_by_name = {n["name"]: n for n in nodes}
+    assert "vMX VCP" in node_by_name
+    assert "vMX VFP" in node_by_name
+    vcp = node_by_name["vMX VCP"]
+    assert vcp["cpu"] == 1
+    assert vcp["ram"] == 2048
+    assert vcp["ethernet"] == 1
+    # interface_naming.explicit honored
+    assert vcp["interfaces"][0]["name"] == "fxp0"
+    vfp = node_by_name["vMX VFP"]
+    assert vfp["interfaces"][0]["name"] == "em0"
+    assert vfp["interfaces"][3]["name"] == "em3"
+
+    # LinkService synthesizes an implicit bridge for node↔node links and returns
+    # the first node↔bridge half. Confirm the returned link points to VCP's
+    # fxp0 (interface_index 0) and the bridge is the other endpoint.
+    link = links[0]
+    assert link["from"]["node_id"] == vcp["id"]
+    assert link["from"]["interface_index"] == 0
+    assert "network_id" in link["to"]
+
+    # The full lab.json must contain BOTH halves of the paired link plus an
+    # implicit bridge — paired creation is atomic across all link halves.
+    lab_data = json.loads((settings.LABS_DIR / "demo.json").read_text())
+    assert len(lab_data["links"]) == 2
+    assert len(lab_data["networks"]) == 1
+    bridge_id = next(iter(lab_data["networks"].keys()))
+    node_iface_pairs = set()
+    for raw_link in lab_data["links"]:
+        from_ep = raw_link["from"]
+        to_ep = raw_link["to"]
+        # One endpoint must be the implicit bridge.
+        if "network_id" in from_ep:
+            assert str(from_ep["network_id"]) == bridge_id
+            node_iface_pairs.add((to_ep["node_id"], to_ep["interface_index"]))
+        else:
+            assert str(to_ep["network_id"]) == bridge_id
+            node_iface_pairs.add((from_ep["node_id"], from_ep["interface_index"]))
+    # Both child nodes connect to the bridge on interface index 0
+    # (VCP fxp0 / VFP em0 — the fxp0↔em0 link from the paired template).
+    assert node_iface_pairs == {(vcp["id"], 0), (vfp["id"], 0)}
+
+
+@pytest.mark.asyncio
+async def test_returns_404_for_unknown_template(patched_split):
+    _seed_empty_lab(patched_split)
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="nonexistent"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 404
+    assert "paired template" in response["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_returns_404_for_singleton_template(patched_split):
+    """A single-node template (kind="qemu") must NOT match the paired endpoint."""
+    settings = patched_split
+    (settings.USER_TEMPLATES_DIR / "csr.json").write_text(
+        json.dumps({"schema": 1, "id": "csr", "kind": "qemu", "image": "csr.qcow2"})
+    )
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="csr"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 404
+
+
+@pytest.mark.asyncio
+async def test_rolls_back_when_link_creation_fails(patched_split, monkeypatch):
+    """Partial-failure rollback: link-phase fails → lab.json restored, no orphans."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    lab_file = _seed_empty_lab(settings)
+
+    # Force LinkService.create_link to blow up.
+    from app.services import link_service
+
+    async def _explode(*args, **kwargs):
+        raise RuntimeError("simulated link creation failure")
+
+    monkeypatch.setattr(link_service.LinkService, "create_link", _explode)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 500
+    assert "simulated link creation failure" in response["message"]
+
+    # Lab file must be back to the pre-call state — no orphan nodes left behind.
+    on_disk = json.loads(lab_file.read_text())
+    assert on_disk["nodes"] == {}
+    assert on_disk["links"] == []
+
+
+@pytest.mark.asyncio
+async def test_name_overrides_apply_per_child(patched_split):
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(
+            template_key="juniper-vmx",
+            name_overrides={"vcp": "edge-router-cp", "vfp": "edge-router-fp"},
+        ),
+        current_user=_admin(),
+    )
+    assert response["code"] == 200
+    names = {n["name"] for n in response["data"]["nodes"]}
+    assert names == {"edge-router-cp", "edge-router-fp"}
+
+
+@pytest.mark.asyncio
+async def test_children_laid_out_in_row_relative_to_base(patched_split):
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx", base_left=500, base_top=300),
+        current_user=_admin(),
+    )
+    nodes = response["data"]["nodes"]
+    assert nodes[0]["left"] == 500
+    assert nodes[0]["top"] == 300
+    assert nodes[1]["left"] == 500 + 180
+    assert nodes[1]["top"] == 300
+
+
+# ---- regression: single-node /from-template still works -----------------
+
+
+@pytest.mark.asyncio
+async def test_single_template_endpoint_redirects_paired_to_new_endpoint(patched_split):
+    """Existing /nodes/from-template must still 400 paired keys, with the new pointer."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_node_from_template(
+        "demo.json",
+        NodeFromTemplate(
+            template_type="qemu",
+            template_key="juniper-vmx",
+            name="x",
+            image="y",
+        ),
+        current_user=_admin(),
+    )
+    assert response["code"] == 400
+    assert "from-paired-template" in response["message"]
+    assert "#202" in response["message"]

--- a/backend/tests/test_user_templates_dir.py
+++ b/backend/tests/test_user_templates_dir.py
@@ -113,7 +113,16 @@ def test_user_dir_missing_does_not_break_listing(patched_split):
 def test_is_paired_user_template_returns_true_for_paired_json(patched_split):
     settings = patched_split
     (settings.USER_TEMPLATES_DIR / "juniper-vmx.json").write_text(
-        json.dumps({"schema": 1, "id": "juniper-vmx", "kind": "paired", "nodes": [], "links": []})
+        json.dumps({
+                "schema": 1,
+                "id": "juniper-vmx",
+                "kind": "paired",
+                "nodes": [
+                    {"id": "vcp", "name": "vMX VCP", "kind": "qemu", "image": "vmx-vcp.qcow2"},
+                    {"id": "vfp", "name": "vMX VFP", "kind": "qemu", "image": "vmx-vfp.qcow2"},
+                ],
+                "links": [{"from_node": "vcp", "from_iface": "fxp0", "to_node": "vfp", "to_iface": "em0"}],
+            })
     )
     assert TemplateService().is_paired_user_template("juniper-vmx") is True
 
@@ -190,7 +199,16 @@ async def test_from_template_rejects_paired_with_400(patched_split):
     """Paired-node templates (kind='paired' in user-dir JSON) must be rejected with 400."""
     settings = patched_split
     (settings.USER_TEMPLATES_DIR / "juniper-vmx.json").write_text(
-        json.dumps({"schema": 1, "id": "juniper-vmx", "kind": "paired", "nodes": [], "links": []})
+        json.dumps({
+                "schema": 1,
+                "id": "juniper-vmx",
+                "kind": "paired",
+                "nodes": [
+                    {"id": "vcp", "name": "vMX VCP", "kind": "qemu", "image": "vmx-vcp.qcow2"},
+                    {"id": "vfp", "name": "vMX VFP", "kind": "qemu", "image": "vmx-vfp.qcow2"},
+                ],
+                "links": [{"from_node": "vcp", "from_iface": "fxp0", "to_node": "vfp", "to_iface": "em0"}],
+            })
     )
     (settings.LABS_DIR / "demo.json").write_text(json.dumps({
         "schema": 2,

--- a/frontend/src/lib/components/canvas/NodeConfigModal.svelte
+++ b/frontend/src/lib/components/canvas/NodeConfigModal.svelte
@@ -8,6 +8,7 @@
   import type {
     NodeCatalog,
     NodeCatalogExtraField,
+    NodeCatalogPairedTemplate,
     NodeCatalogTemplate,
     NodeData,
   } from '$lib/types';
@@ -41,6 +42,11 @@
     interface_naming_scheme: string | null;
   };
 
+  type CreatePairedSubmitPayload = {
+    template_key: string;
+    name_overrides: Record<string, string>;
+  };
+
   type EditSubmitPayload = {
     name: string;
     image: string;
@@ -56,7 +62,10 @@
 
   const dispatch = createEventDispatcher<{
     cancel: void;
-    submit: { mode: 'create'; payload: CreateSubmitPayload } | { mode: 'edit'; nodeId: number; payload: EditSubmitPayload };
+    submit:
+      | { mode: 'create'; payload: CreateSubmitPayload }
+      | { mode: 'create-paired'; payload: CreatePairedSubmitPayload }
+      | { mode: 'edit'; nodeId: number; payload: EditSubmitPayload };
   }>();
 
   const NODE_TYPES: ReadonlyArray<{ key: NodeTypeKey; label: string; icon: ComponentType }> = [
@@ -70,6 +79,8 @@
 
   let selectedType: NodeTypeKey = 'qemu';
   let selectedTemplateId = '';
+  let pairedTemplateKey = '';
+  let pairedNameOverrides: Record<string, string> = {};
   let name = '';
   let namePrefix = '';
   let image = '';
@@ -96,6 +107,18 @@
 
   function templatesForType(type: NodeTypeKey): NodeCatalogTemplate[] {
     return (catalog?.templates ?? []).filter((template) => template.type === type);
+  }
+
+  function pairedTemplates(): NodeCatalogPairedTemplate[] {
+    return catalog?.paired_templates ?? [];
+  }
+
+  function pairedTemplateForKey(key: string): NodeCatalogPairedTemplate | undefined {
+    return pairedTemplates().find((entry) => entry.key === key);
+  }
+
+  function setPairedNameOverride(childId: string, value: string) {
+    pairedNameOverrides = { ...pairedNameOverrides, [childId]: value };
   }
 
   function firstAvailableType(): NodeTypeKey {
@@ -185,6 +208,8 @@
     selectedType = firstAvailableType();
     const templateValue = firstTemplateIdOfType(selectedType);
     selectedTemplateId = templateValue;
+    pairedTemplateKey = '';
+    pairedNameOverrides = {};
     name = '';
     count = 1;
     placement = 'grid';
@@ -324,6 +349,24 @@
       return;
     }
 
+    if (pairedTemplateKey) {
+      const sanitizedOverrides: Record<string, string> = {};
+      for (const [childId, value] of Object.entries(pairedNameOverrides)) {
+        const trimmed = value.trim();
+        if (trimmed) {
+          sanitizedOverrides[childId] = trimmed;
+        }
+      }
+      dispatch('submit', {
+        mode: 'create-paired',
+        payload: {
+          template_key: pairedTemplateKey,
+          name_overrides: sanitizedOverrides,
+        },
+      });
+      return;
+    }
+
     const template = templateForId(selectedTemplateId);
     if (!template) {
       return;
@@ -356,6 +399,9 @@
 
   $: selectedTemplate = templateForId(selectedTemplateId);
   $: visibleTemplates = catalog ? templatesForType(selectedType) : [];
+  $: visiblePairedTemplates = catalog ? pairedTemplates() : [];
+  $: selectedPairedTemplate = pairedTemplateKey ? pairedTemplateForKey(pairedTemplateKey) : undefined;
+  $: pairedActive = mode === 'create' && Boolean(selectedPairedTemplate);
   $: interfaceNamingError = interfaceNamingErrorFor(interfaceNamingScheme, selectedType);
   $: signature = `${open}:${mode}:${catalog?.templates.length ?? 0}:${node?.id ?? 'create'}:${node?.status ?? 0}`;
   $: if (open && catalog && signature !== lastSignature) {
@@ -456,8 +502,8 @@
                     {active
                       ? 'border-blue-500/60 bg-blue-500/15 text-blue-100'
                       : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600 hover:text-white'}
-                    {!available || mode === 'edit' ? 'cursor-not-allowed opacity-50' : ''}"
-                  disabled={!available || mode === 'edit'}
+                    {!available || mode === 'edit' || pairedActive ? 'cursor-not-allowed opacity-50' : ''}"
+                  disabled={!available || mode === 'edit' || pairedActive}
                   aria-pressed={active}
                   on:click={() => selectType(entry.key)}
                 >
@@ -467,6 +513,76 @@
               {/each}
             </div>
 
+            {#if mode === 'create' && visiblePairedTemplates.length > 0}
+              <div class="rounded-2xl border border-purple-500/30 bg-purple-500/5 p-4">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <div class="text-[10px] uppercase tracking-[0.06em] text-purple-300">Paired vendor templates</div>
+                    <div class="mt-0.5 text-xs text-slate-400">Multi-VM appliances (vMX, vQFX) instantiated as a group with auto-links.</div>
+                  </div>
+                  <label class="flex items-center gap-2 text-xs text-slate-300">
+                    <select
+                      bind:value={pairedTemplateKey}
+                      class="rounded-xl border border-slate-800 bg-slate-900 px-3 py-1.5 text-sm text-slate-100"
+                    >
+                      <option value="">— Single node —</option>
+                      {#each visiblePairedTemplates as paired}
+                        <option value={paired.key}>
+                          {paired.name} [{paired.child_count} nodes / {paired.link_count} link{paired.link_count === 1 ? '' : 's'}]
+                        </option>
+                      {/each}
+                    </select>
+                  </label>
+                </div>
+
+                {#if selectedPairedTemplate}
+                  <div class="mt-4 space-y-3">
+                    <div class="rounded-xl border border-slate-800 bg-slate-950/60 p-3">
+                      <div class="text-[10px] uppercase tracking-[0.06em] text-slate-500">Will create</div>
+                      <ul class="mt-2 space-y-1.5 text-xs text-slate-200">
+                        {#each selectedPairedTemplate.children as child}
+                          <li class="flex flex-wrap items-center gap-2">
+                            <span class="rounded-md border border-slate-700 bg-slate-900 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-slate-300">{child.kind}</span>
+                            <span class="font-medium text-slate-100">{child.name}</span>
+                            <span class="text-slate-500">·</span>
+                            <span>{child.cpu} vCPU · {child.ram} MB · {child.ethernet} eth</span>
+                          </li>
+                        {/each}
+                      </ul>
+                    </div>
+
+                    {#if selectedPairedTemplate.links.length > 0}
+                      <div class="rounded-xl border border-slate-800 bg-slate-950/60 p-3">
+                        <div class="text-[10px] uppercase tracking-[0.06em] text-slate-500">Auto-links</div>
+                        <ul class="mt-2 space-y-1 text-xs text-slate-300">
+                          {#each selectedPairedTemplate.links as link}
+                            <li class="font-mono">
+                              {link.from_node}.{link.from_iface} ↔ {link.to_node}.{link.to_iface}
+                            </li>
+                          {/each}
+                        </ul>
+                      </div>
+                    {/if}
+
+                    <div class="grid gap-2 sm:grid-cols-2">
+                      {#each selectedPairedTemplate.children as child}
+                        <label class="block">
+                          <div class="mb-1 text-[10px] uppercase tracking-[0.05em] text-slate-500">Name · {child.id}</div>
+                          <input
+                            value={pairedNameOverrides[child.id] ?? ''}
+                            on:input={(e) => setPairedNameOverride(child.id, (e.currentTarget as HTMLInputElement).value)}
+                            placeholder={child.name}
+                            class="w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-1.5 text-sm text-slate-100"
+                          />
+                        </label>
+                      {/each}
+                    </div>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+
+            {#if !pairedActive}
             <div class="grid gap-4 md:grid-cols-3">
               {#if mode === 'create'}
                 <label class="block">
@@ -811,6 +927,7 @@
                 <span class="rounded-full border border-slate-800 px-2 py-1">{image || 'no image'}</span>
               </div>
             </div>
+            {/if}
           </div>
 
           <div class="flex justify-end gap-3 border-t border-slate-800 bg-slate-950/80 px-5 py-4">
@@ -823,13 +940,15 @@
             </button>
             <button
               type="submit"
-              disabled={submitting || !selectedTemplate || !image || !!interfaceNamingError}
+              disabled={submitting || (!pairedActive && (!selectedTemplate || !image)) || !!interfaceNamingError}
               class="rounded-full border border-blue-500/40 bg-blue-500/15 px-4 py-2 text-sm text-blue-100 transition hover:bg-blue-500/25 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {#if submitting}
                 Saving…
               {:else if mode === 'edit'}
                 Save node
+              {:else if pairedActive && selectedPairedTemplate}
+                Add {selectedPairedTemplate.child_count} nodes + {selectedPairedTemplate.link_count} link{selectedPairedTemplate.link_count === 1 ? '' : 's'}
               {:else}
                 Add node
               {/if}

--- a/frontend/src/lib/components/canvas/TopologyCanvas.svelte
+++ b/frontend/src/lib/components/canvas/TopologyCanvas.svelte
@@ -1364,6 +1364,13 @@
           };
         }
       | {
+          mode: 'create-paired';
+          payload: {
+            template_key: string;
+            name_overrides: Record<string, string>;
+          };
+        }
+      | {
           mode: 'edit';
           nodeId: number;
           payload: {
@@ -1400,6 +1407,23 @@
         dispatchCanvasChange('node-create', {
           nodes: deepClone(localNodes),
         });
+      } else if (event.detail.mode === 'create-paired') {
+        await apiRequest<{ nodes: NodeData[]; links: unknown[] }>(
+          `/labs/${labId}/nodes/from-paired-template`,
+          {
+            method: 'POST',
+            body: {
+              template_key: event.detail.payload.template_key,
+              name_overrides: event.detail.payload.name_overrides,
+              base_left: Math.round(nodeCreateAnchor.x),
+              base_top: Math.round(nodeCreateAnchor.y),
+            }
+          }
+        );
+        // Paired creation adds 2+ nodes plus an implicit bridge network and
+        // the auto-link halves; route through the parent's full lab refresh
+        // path so localNetworks/localTopology stay consistent.
+        dispatchCanvasChange('paired-create', {});
       } else {
         const response = await apiRequest<NodeData>(`/labs/${labId}/nodes/${event.detail.nodeId}`, {
           method: 'PUT',

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -294,8 +294,36 @@ export interface NodeCatalogTemplate {
   capabilities?: TemplateCapabilities;
 }
 
+export interface NodeCatalogPairedChild {
+  id: string;
+  name: string;
+  kind: string;
+  image: string;
+  cpu: number;
+  ram: number;
+  ethernet: number;
+}
+
+export interface NodeCatalogPairedLink {
+  from_node: string;
+  from_iface: string;
+  to_node: string;
+  to_iface: string;
+}
+
+export interface NodeCatalogPairedTemplate {
+  key: string;
+  name: string;
+  vendor: string;
+  child_count: number;
+  link_count: number;
+  children: NodeCatalogPairedChild[];
+  links: NodeCatalogPairedLink[];
+}
+
 export interface NodeCatalog {
   templates: NodeCatalogTemplate[];
+  paired_templates?: NodeCatalogPairedTemplate[];
   icon_options: string[];
   create_fields: string[];
   edit_fields: string[];

--- a/frontend/src/routes/labs/[...id]/+page.svelte
+++ b/frontend/src/routes/labs/[...id]/+page.svelte
@@ -402,6 +402,14 @@
       return;
     }
 
+    // Paired-template creation adds N nodes + an implicit bridge + 2N link
+    // halves in one shot; full lab reload is the simplest way to pick all of
+    // that up consistently in localNodes/localNetworks/localTopology.
+    if (reason === 'paired-create' && !isLabIndexRoute) {
+      await loadLab({ blocking: false });
+      return;
+    }
+
     if (!isLabIndexRoute) {
       await loadLab({ blocking: false });
     }


### PR DESCRIPTION
## Summary

Closes #202. Implements end-to-end paired-template instantiation (vMX, vQFX, future multi-VM appliances): operator selects a paired template from the existing **Add node** modal and the backend creates all child nodes plus the auto-link between them in a single atomic call. Lab.json is rolled back on partial failure so no orphan nodes survive.

The frontend stays a dumb renderer of backend-defined templates, per the project rule that all template handling lives in the backend.

## Backend

- ``TemplateService.get_paired_user_template(key)`` loads ``kind="paired"`` JSONs from ``USER_TEMPLATES_DIR`` with non-empty nodes/links validation; ``is_paired_user_template`` is now a thin wrapper over it.
- Node-catalog response gains a ``paired_templates: [...]`` sibling entry per paired user-template, exposing ``key``, ``name``, ``vendor``, ``child_count``, ``link_count``, ``children:[{id, kind, image, cpu, ram, ethernet, ...}]``, and ``links:[{from_node, from_iface, to_node, to_iface}]``. Existing single-node ``templates: [...]`` shape is unchanged.
- New endpoint ``POST /api/labs/{lab_path:path}/nodes/from-paired-template``:
  - Body: ``{template_key, base_left, base_top, name_overrides: {child_id: name}}``
  - Returns ``200 + {nodes:[NodeData], links:[LinkPayload]}`` on success.
  - 404 on unknown template, 500 with rollback on partial failure.
  - Children laid out in a row (180-px stride) relative to ``base_left`` / ``base_top``.
  - Auto-links resolved by interface name against each child's ``interface_naming.explicit`` (strict — raises ``_PairedIfaceLookupError`` on mismatch which triggers rollback).
- Single-node ``/nodes/from-template`` rejection message now points operators at the new endpoint.

## Adapters (small fixes uncovered by the strict interface-name resolver)

- ``juniper_vmx.py``: VCP / VFP children emit ``interface_naming.explicit`` (``["fxp0"]`` and ``["em0", "em1", "em2", "em3"]``).
- ``juniper_vqfx.py``: RE / PFE children emit ``interface_naming.explicit``; ``ethernet_re`` default bumped 1 → 2 so the internal ``em1`` link interface is in range (the previous default put ``em1`` out of range — a real bug found while wiring the resolver).

## Frontend

- ``NodeCatalog`` type extended with ``paired_templates?: NodeCatalogPairedTemplate[]``.
- ``NodeConfigModal`` (create mode only):
  - New "Paired vendor templates" section with a dropdown showing each paired entry as ``Name [N nodes / M links]``.
  - When a paired template is selected, single-node form fields collapse and a confirmation panel renders: "Will create" (each child with kind, vCPU, RAM, eth count) + "Auto-links" (each link as ``from_node.from_iface ↔ to_node.to_iface``) + per-child name override inputs.
  - Submit button label switches to ``Add N nodes + M link(s)``; submission dispatches a ``create-paired`` variant.
- ``TopologyCanvas`` handles the new submit variant by calling the paired endpoint with the canvas drop anchor as ``base_left`` / ``base_top``, then dispatches ``paired-create`` for parent-route refresh.
- The lab page handles ``paired-create`` by calling ``loadLab`` so ``localNodes`` / ``localNetworks`` / ``localTopology`` all stay consistent (the implicit bridge spawned by ``LinkService.create_link`` for node↔node links lives in ``localNetworks``).

## Tests

- 12 new backend tests in ``backend/tests/test_paired_template_endpoint.py``: paired loader (3), catalog response (2), endpoint happy path (1), 404 on missing key (1), 404 on single-node template (1), rollback on link failure (1), name overrides (1), row layout (1), single-node regression (1).
- ``test_user_templates_dir.py`` paired-template fixture updated to include ≥2 children + ≥1 link to satisfy the new presence-only validation.
- All 858 existing backend tests still pass.
- Frontend ``svelte-check``: 0 errors. Build: green.

## End-to-end verification on .212 / .213

Seeded a synthetic ``juniper-vmx-test`` paired template under ``USER_TEMPLATES_DIR`` on each VM, hit the endpoint, observed:

- ``code: 200`` + ``2 node(s), 1 link(s)`` message
- Override names applied (``e2e-vcp`` / ``e2e-vfp``)
- Child interfaces named ``fxp0`` / ``em0`` per the explicit naming
- Lab JSON gained 2 nodes + 1 implicit bridge + 2 link halves wired to the bridge
- Cleanup via existing ``DELETE /nodes/{id}`` works

## Test plan

- [x] Backend tests pass (858 + 12 new = 870)
- [x] Frontend type-check + build clean
- [x] E2E API check on 192.168.100.212
- [x] E2E API check on 192.168.100.213
- [ ] Reviewer: confirm rollback contract by inspecting ``create_nodes_from_paired_template`` exception-handler shape

## Known follow-ups (not in this PR)

- Implicit-bridge networks created by the auto-link can survive after both endpoint nodes are deleted (refcount-0 cleanup gap). This is **pre-existing** behavior of LinkService, not introduced here. File separately if it becomes a real issue.