### PR TITLE
Per-port naming: accept format as YAML list + UI vendor presets (#179)

### DIFF
--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -440,9 +440,18 @@ def render_interface_name(fmt: str, index: int) -> str:
 def _validate_interface_naming(payload: dict[str, Any], source: str) -> dict[str, Any]:
     """Validate the optional ``interface_naming`` block on a template YAML.
 
-    Either ``format: <str>`` (a pattern containing one of {n}|{slot}|{port})
-    OR ``explicit: [<str>, ...]`` may be supplied — exactly one. Any other
-    combination raises :class:`TemplateError`.
+    Either ``format`` OR ``explicit: [<str>, ...]`` may be supplied — exactly
+    one. Any other combination raises :class:`TemplateError`.
+
+    ``format`` may be either:
+
+    * a single string carrying a placeholder (``{n}``, ``{slot}``, or
+      ``{port}``), e.g. ``"eth{n}"`` — the historical shape; or
+    * a non-empty ``list[str]`` of fixed names with a trailing placeholder
+      entry (#179), e.g. ``["fxp0", "ge-0/0/{n}"]``. Earlier entries are
+      fixed; only the last entry may carry a placeholder. The list is
+      normalized to a comma-separated string for downstream consumers
+      (``render_interface_name`` already understands that form).
     """
 
     if not isinstance(payload, dict):
@@ -464,9 +473,33 @@ def _validate_interface_naming(payload: dict[str, Any], source: str) -> dict[str
 
     if has_format:
         fmt = payload["format"]
+        if isinstance(fmt, list):
+            if not fmt:
+                raise TemplateError(
+                    f"interface_naming.format on {source} must be a non-empty list when given as a list."
+                )
+            for i, item in enumerate(fmt):
+                if not isinstance(item, str) or not item.strip():
+                    raise TemplateError(
+                        f"interface_naming.format on {source} list entries must be non-empty strings."
+                    )
+                has_placeholder = any(t in item for t in _INTERFACE_NAMING_FORMAT_PLACEHOLDERS)
+                if i < len(fmt) - 1 and has_placeholder:
+                    raise TemplateError(
+                        f"interface_naming.format on {source}: only the last list entry "
+                        f"may contain {', '.join(_INTERFACE_NAMING_FORMAT_PLACEHOLDERS)} (got placeholder in entry {i!r})."
+                    )
+            last_has_placeholder = any(t in fmt[-1] for t in _INTERFACE_NAMING_FORMAT_PLACEHOLDERS)
+            if not last_has_placeholder:
+                raise TemplateError(
+                    f"interface_naming.format on {source}: last list entry must contain "
+                    f"{', '.join(_INTERFACE_NAMING_FORMAT_PLACEHOLDERS)} "
+                    f"(use 'explicit: [...]' for a fixed-only list)."
+                )
+            return {"format": ",".join(item.strip() for item in fmt)}
         if not isinstance(fmt, str) or not fmt.strip():
             raise TemplateError(
-                f"interface_naming.format on {source} must be a non-empty string."
+                f"interface_naming.format on {source} must be a non-empty string or list of strings."
             )
         if not any(token in fmt for token in _INTERFACE_NAMING_FORMAT_PLACEHOLDERS):
             raise TemplateError(

--- a/backend/tests/test_node_schema_naming.py
+++ b/backend/tests/test_node_schema_naming.py
@@ -8,7 +8,11 @@ from pydantic import ValidationError
 
 from app.routers.labs import _default_interfaces
 from app.schemas.node import NodeBase, NodeCreate, NodeBatchCreate
-from app.services.template_service import render_interface_name
+from app.services.template_service import (
+    TemplateError,
+    _validate_interface_naming,
+    render_interface_name,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -195,3 +199,83 @@ class TestNodeBatchCreateValidator:
             interface_naming_scheme="eth{n}",
         )
         assert nb.interface_naming_scheme == "eth{n}"
+
+
+# ---------------------------------------------------------------------------
+# _validate_interface_naming — list-form 'format' (#179)
+# ---------------------------------------------------------------------------
+
+class TestValidateInterfaceNamingFormatList:
+    """The YAML ``format`` field accepts either a string (historical shape)
+    or a list of fixed names ending in a placeholder entry (#179). Lists
+    normalize to a comma-separated string so downstream consumers
+    (``render_interface_name``) stay unchanged."""
+
+    def test_string_format_accepted_unchanged(self):
+        result = _validate_interface_naming({"format": "eth{n}"}, source="vyos.yml")
+        assert result == {"format": "eth{n}"}
+
+    def test_list_format_accepted_and_normalized_to_comma_string(self):
+        result = _validate_interface_naming(
+            {"format": ["fxp0", "ge-0/0/{n}"]}, source="juniper-vmx.yml"
+        )
+        assert result == {"format": "fxp0,ge-0/0/{n}"}
+
+    def test_list_format_three_fixed_then_template(self):
+        result = _validate_interface_naming(
+            {"format": ["mgmt0", "mgmt1", "ge-0/0/{port}"]},
+            source="multi-mgmt.yml",
+        )
+        assert result == {"format": "mgmt0,mgmt1,ge-0/0/{port}"}
+
+    def test_list_format_strips_whitespace_in_items(self):
+        result = _validate_interface_naming(
+            {"format": [" fxp0 ", "  ge-0/0/{n}  "]}, source="ws.yml"
+        )
+        assert result == {"format": "fxp0,ge-0/0/{n}"}
+
+    def test_list_format_round_trip_via_render(self):
+        normalized = _validate_interface_naming(
+            {"format": ["fxp0", "ge-0/0/{n}"]}, source="vmx.yml"
+        )["format"]
+        assert render_interface_name(normalized, 0) == "fxp0"
+        assert render_interface_name(normalized, 1) == "ge-0/0/0"
+        assert render_interface_name(normalized, 4) == "ge-0/0/3"
+
+    def test_list_format_empty_list_rejected(self):
+        with pytest.raises(TemplateError, match="non-empty list"):
+            _validate_interface_naming({"format": []}, source="empty.yml")
+
+    def test_list_format_no_placeholder_anywhere_rejected(self):
+        with pytest.raises(TemplateError, match="last list entry must contain"):
+            _validate_interface_naming(
+                {"format": ["fxp0", "fxp1"]}, source="explicit-only.yml"
+            )
+
+    def test_list_format_placeholder_in_non_last_entry_rejected(self):
+        with pytest.raises(TemplateError, match="only the last list entry"):
+            _validate_interface_naming(
+                {"format": ["ge-0/0/{n}", "extra"]}, source="bad-mid.yml"
+            )
+
+    def test_list_format_placeholder_in_middle_three_entries_rejected(self):
+        with pytest.raises(TemplateError, match="only the last list entry"):
+            _validate_interface_naming(
+                {"format": ["fxp0", "mgmt{n}", "ge-0/0/{n}"]}, source="bad-mid3.yml"
+            )
+
+    def test_list_format_non_string_item_rejected(self):
+        with pytest.raises(TemplateError, match="non-empty strings"):
+            _validate_interface_naming(
+                {"format": ["fxp0", 42]}, source="non-str.yml"
+            )
+
+    def test_list_format_blank_item_rejected(self):
+        with pytest.raises(TemplateError, match="non-empty strings"):
+            _validate_interface_naming(
+                {"format": ["fxp0", "   ", "ge-0/0/{n}"]}, source="blank.yml"
+            )
+
+    def test_string_format_without_placeholder_rejected(self):
+        with pytest.raises(TemplateError, match="must contain at least one of"):
+            _validate_interface_naming({"format": "loopback"}, source="bad-str.yml")

--- a/frontend/src/lib/components/canvas/NodeConfigModal.svelte
+++ b/frontend/src/lib/components/canvas/NodeConfigModal.svelte
@@ -77,6 +77,25 @@
   const DEFAULT_INTERFACE_NAMING = '';
   const DOCKER_INTERFACE_NAMING_FIXED = 'eth{n}';
 
+  // #179 — vendor presets for the interface-naming scheme. Each preset
+  // value is a comma-separated list (last entry carries the placeholder).
+  // Empty value = (template default); 'custom' = whatever the operator
+  // typed by hand. Presets just populate the freeform input — the input
+  // remains the source of truth and is independently validated.
+  type InterfaceNamingPreset = { label: string; value: string };
+  const INTERFACE_NAMING_PRESETS: ReadonlyArray<InterfaceNamingPreset> = [
+    { label: '(template default)', value: '' },
+    { label: 'Linux — eth{n}', value: 'eth{n}' },
+    { label: 'Cisco IOS — Gi{port}', value: 'Gi{port}' },
+    { label: 'Cisco IOS-XE — GigabitEthernet0/0/{n}', value: 'GigabitEthernet0/0/{n}' },
+    { label: 'Arista — Ethernet{port}', value: 'Ethernet{port}' },
+    { label: 'Linux + mgmt0 — mgmt0,eth{n}', value: 'mgmt0,eth{n}' },
+    { label: 'Juniper vMX — fxp0,ge-0/0/{n}', value: 'fxp0,ge-0/0/{n}' },
+    { label: 'Arista + Management1', value: 'Management1,Ethernet{port}' },
+    { label: 'Cisco IOSv-L2', value: 'Management0/0,GigabitEthernet0/{n}' },
+  ];
+  const INTERFACE_NAMING_CUSTOM = '__custom__';
+
   let selectedType: NodeTypeKey = 'qemu';
   let selectedTemplateId = '';
   let pairedTemplateKey = '';
@@ -153,6 +172,20 @@
   function normalizedInterfaceNamingScheme(): string | null {
     const trimmed = interfaceNamingScheme.trim();
     return trimmed || null;
+  }
+
+  function presetValueFor(scheme: string): string {
+    const trimmed = scheme.trim();
+    const match = INTERFACE_NAMING_PRESETS.find((preset) => preset.value === trimmed);
+    return match ? match.value : INTERFACE_NAMING_CUSTOM;
+  }
+
+  function applyInterfaceNamingPreset(presetValue: string) {
+    if (presetValue === INTERFACE_NAMING_CUSTOM) {
+      return;
+    }
+    interfaceNamingScheme = presetValue;
+    markDirty('interfaceNamingScheme');
   }
 
   function defaultExtrasFromTemplate(template: NodeCatalogTemplate | undefined): ExtrasMap {
@@ -403,6 +436,7 @@
   $: selectedPairedTemplate = pairedTemplateKey ? pairedTemplateForKey(pairedTemplateKey) : undefined;
   $: pairedActive = mode === 'create' && Boolean(selectedPairedTemplate);
   $: interfaceNamingError = interfaceNamingErrorFor(interfaceNamingScheme, selectedType);
+  $: selectedInterfaceNamingPreset = presetValueFor(interfaceNamingScheme);
   $: signature = `${open}:${mode}:${catalog?.templates.length ?? 0}:${node?.id ?? 'create'}:${node?.status ?? 0}`;
   $: if (open && catalog && signature !== lastSignature) {
     lastSignature = signature;
@@ -729,6 +763,17 @@
               </label>
               <label class="block">
                 <div class="mb-1 text-[10px] uppercase tracking-[0.05em] text-slate-500">Interface naming</div>
+                <select
+                  value={selectedInterfaceNamingPreset}
+                  on:change={(event) => applyInterfaceNamingPreset((event.currentTarget as HTMLSelectElement).value)}
+                  class="mb-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-1.5 text-sm text-slate-100"
+                  aria-label="Interface naming preset"
+                >
+                  {#each INTERFACE_NAMING_PRESETS as preset}
+                    <option value={preset.value}>{preset.label}</option>
+                  {/each}
+                  <option value={INTERFACE_NAMING_CUSTOM}>Custom…</option>
+                </select>
                 <input
                   bind:value={interfaceNamingScheme}
                   on:input={() => markDirty('interfaceNamingScheme')}


### PR DESCRIPTION
## Summary

Closes #179. The comma-separated string convention for per-port interface naming was already shipped end-to-end (US-105 / #179 references in `template_service.render_interface_name` and `interfaceNaming.formatInterfaceName`). This PR closes the two remaining gaps from the issue:

1. **YAML list-form `format`** — `interface_naming.format` now accepts either a string (existing) or a `list[str]` of fixed names ending in a placeholder entry, e.g.

   ```yaml
   interface_naming:
     format:
       - fxp0
       - "ge-0/0/{n}"
   ```

   Lists are validated (only-last-entry placeholder, all entries non-empty strings) then normalized to the comma-separated form (`"fxp0,ge-0/0/{n}"`) so `render_interface_name` and the frontend renderer stay unchanged.

2. **UI vendor presets** — `NodeConfigModal` grows a small preset `<select>` next to the existing freeform interface-naming input. Picking a preset populates the input; ``Custom…`` leaves whatever the operator typed alone.

## Backend

- `_validate_interface_naming` (template_service.py): when `format` is a list:
  - non-empty list of non-empty strings;
  - placeholders only allowed in the last entry — mid-list placeholder is rejected;
  - last entry must contain `{n}`/`{slot}`/`{port}` (use `explicit:` for a fixed-only list);
  - normalize to `",".join(items)` and return `{"format": joined_string}`.
- String form: behavior unchanged.

## Frontend

- `NodeConfigModal.svelte`:
  - new `INTERFACE_NAMING_PRESETS` constant with 9 entries: ``(template default)``, ``Linux eth{n}``, ``Cisco IOS Gi{port}``, ``Cisco IOS-XE GigabitEthernet0/0/{n}``, ``Arista Ethernet{port}``, ``Linux + mgmt0``, ``Juniper vMX (fxp0,ge-0/0/{n})``, ``Arista + Management1``, ``Cisco IOSv-L2``;
  - reactive ``selectedInterfaceNamingPreset`` derives the dropdown selection from whatever's in the input (matches a preset value or falls back to ``Custom…``);
  - selecting a preset populates the input via ``applyInterfaceNamingPreset``;
  - existing comma-string + placeholder validation still gates submission.

## Tests

12 new cases in ``backend/tests/test_node_schema_naming.py::TestValidateInterfaceNamingFormatList`` covering:
- string form regression (accepted unchanged, rejected without placeholder)
- list form: 2-entry / 3-entry accepted + normalized
- whitespace stripping inside list items
- round-trip through ``render_interface_name`` (``fxp0`` then ``ge-0/0/0`` etc.)
- empty list rejected
- list with no placeholder anywhere rejected
- placeholder in non-last entry rejected (2 cases: 2-entry and 3-entry)
- non-string item rejected
- blank/whitespace-only item rejected

## Test plan

- [x] `pytest tests/test_node_schema_naming.py tests/test_user_templates_dir.py tests/test_template_management.py tests/test_template_capabilities.py` — 72 passed
- [x] `npx svelte-check` — 0 errors / 0 warnings (1929 files)
- [ ] Manual on `192.168.100.140`: drop a YAML template under USER_TEMPLATES_DIR that uses `format: ["fxp0", "ge-0/0/{n}"]`; confirm catalog API returns it normalized to the comma-string; create a node and verify ports render `fxp0`, `ge-0/0/0`, `ge-0/0/1`, ...

## Out of scope (per issue)

- Auto-detecting management vs data ports from template type — templates declare names explicitly.
- Renaming persisted `interfaces[].name` strings on a scheme change — display-layer override only (matches US-105).
- Migrating real builtin templates (`csr.yml`, `vyos.yml`) to the list shape — left as-is; product call.