### PR TITLE
Paired-template Codex follow-ups: synthetic identity + pre-flight + lock + error mapping (#206 #207 #208)

### DIFF
--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -727,6 +727,7 @@ def _build_paired_child_payload(
     node_id: int,
     template_key: str,
     child: dict,
+    child_id: str,
     name: str,
     left: int,
     top: int,
@@ -739,6 +740,10 @@ def _build_paired_child_payload(
     :func:`_build_node_payload`. The child's ``interface_naming`` (if present)
     is honored so links that reference vendor-specific names (e.g. ``fxp0``)
     resolve cleanly via :func:`_resolve_iface_index`.
+
+    #206: ``template`` is the synthetic per-child key
+    ``<paired_key>__<child_id>`` so node.template lookups by edit-mode (image
+    validation, capability gates, frontend modal resolution) succeed.
     """
     child_type = str(child.get("kind") or "qemu").lower()
     if child_type not in {"qemu", "docker", "iol", "dynamips"}:
@@ -769,11 +774,13 @@ def _build_paired_child_payload(
             if idx < len(explicit_names) and isinstance(explicit_names[idx], str):
                 iface["name"] = explicit_names[idx]
 
+    from app.services.template_service import synthetic_paired_child_key
+
     return {
         "id": node_id,
         "name": name,
         "type": child_type,
-        "template": template_key,
+        "template": synthetic_paired_child_key(template_key, child_id),
         "image": str(child.get("image") or ""),
         "console": str(child.get("console") or "telnet"),
         "status": 0,
@@ -811,6 +818,8 @@ async def create_nodes_from_paired_template(
     children and ALL auto-links in a single transaction; on partial failure
     lab.json is rolled back from a snapshot taken before the first mutation.
     """
+    from app.services.template_service import validate_paired_template
+
     template_service = TemplateService()
     paired = template_service.get_paired_user_template(request.template_key)
     if paired is None:
@@ -823,17 +832,23 @@ async def create_nodes_from_paired_template(
             ),
         }
 
+    # #207 — pre-flight before any mutation. Catches old (#202-pre) imports
+    # whose link refs reference interfaces no child will expose (e.g. paired
+    # JSONs without ``interface_naming.explicit``). Surface as 422 so the UI
+    # can render a fix-the-template message instead of a generic 500.
+    pre_flight_reason = validate_paired_template(paired)
+    if pre_flight_reason is not None:
+        return {
+            "code": 422,
+            "status": "fail",
+            "message": (
+                f"Paired template {request.template_key!r} cannot be instantiated: "
+                f"{pre_flight_reason}"
+            ),
+        }
+
     try:
         scoped_path = _scoped_lab_path(current_user, lab_path, treat_as_absolute=True)
-        data = _read_lab_data(scoped_path)
-    except LegacyLabSchemaError as exc:
-        return _legacy_schema_response(exc)
-    except FileNotFoundError:
-        return {
-            "code": 404,
-            "status": "fail",
-            "message": "Lab does not exist (60038).",
-        }
     except PermissionError as e:
         return {
             "code": 403,
@@ -841,89 +856,168 @@ async def create_nodes_from_paired_template(
             "message": str(e),
         }
 
-    snapshot = copy.deepcopy(data)
-    nodes_map = data.setdefault("nodes", {})
-    next_id = max((int(node_key) for node_key in nodes_map.keys()), default=0) + 1
-
-    child_id_to_node_id: dict[str, int] = {}
-    created_nodes: list[dict] = []
-
-    try:
-        for index, child in enumerate(paired["nodes"]):
-            if not isinstance(child, dict):
-                raise ValueError(f"Paired template {request.template_key!r} has malformed child entry at index {index}.")
-            child_id = str(child.get("id") or f"child-{index}")
-            override_name = request.name_overrides.get(child_id)
-            child_name = override_name or str(child.get("name") or f"{request.template_key}-{child_id}")
-            left, top = _node_position(index, request.base_left, request.base_top, "row")
-            payload = _build_paired_child_payload(
-                node_id=next_id,
-                template_key=request.template_key,
-                child=child,
-                name=child_name,
-                left=left,
-                top=top,
-            )
-            nodes_map[str(next_id)] = payload
-            child_id_to_node_id[child_id] = next_id
-            created_nodes.append(payload)
-            next_id += 1
-
-        LabService.write_lab_json_static(scoped_path, data)
-    except Exception as exc:  # noqa: BLE001 — broad catch is the rollback contract
-        LabService.write_lab_json_static(scoped_path, snapshot)
-        _logger.exception(
-            "from-paired-template: node-creation phase failed for %s; rolled back",
-            request.template_key,
-        )
-        return {
-            "code": 500,
-            "status": "fail",
-            "message": f"Failed to create paired nodes: {exc}",
-        }
+    settings = get_settings()
+    normalized = _normalize_relative_lab_path(scoped_path)
 
     from app.services.link_service import LinkService
 
     link_service = LinkService()
+    created_nodes: list[dict] = []
     created_links: list[dict] = []
 
-    try:
-        for link in paired["links"]:
-            if not isinstance(link, dict):
-                continue
-            from_child = str(link.get("from_node") or "")
-            to_child = str(link.get("to_node") or "")
-            from_iface_name = str(link.get("from_iface") or "")
-            to_iface_name = str(link.get("to_iface") or "")
+    # #208a — hold lab_lock across snapshot+phase1+phase2+restore so a
+    # concurrent writer cannot slip in between snapshot and restore (which
+    # would silently clobber their work). LinkService.create_link normally
+    # acquires its own lab_lock; we pass _lab_lock_held=True so the inner
+    # call uses a nullcontext (fcntl flock is not reentrant on Linux).
+    with lab_lock(normalized, settings.LABS_DIR):
+        try:
+            data = _read_lab_data(scoped_path)
+        except LegacyLabSchemaError as exc:
+            return _legacy_schema_response(exc)
+        except FileNotFoundError:
+            return {
+                "code": 404,
+                "status": "fail",
+                "message": "Lab does not exist (60038).",
+            }
 
-            from_node_id = child_id_to_node_id.get(from_child)
-            to_node_id = child_id_to_node_id.get(to_child)
-            if from_node_id is None or to_node_id is None:
-                raise ValueError(
-                    f"Paired link references unknown child id "
-                    f"({from_child!r}↔{to_child!r}) in template {request.template_key!r}."
+        snapshot = copy.deepcopy(data)
+        nodes_map = data.setdefault("nodes", {})
+        next_id = max((int(node_key) for node_key in nodes_map.keys()), default=0) + 1
+
+        child_id_to_node_id: dict[str, int] = {}
+
+        try:
+            for index, child in enumerate(paired["nodes"]):
+                if not isinstance(child, dict):
+                    raise ValueError(
+                        f"Paired template {request.template_key!r} has malformed "
+                        f"child entry at index {index}."
+                    )
+                child_id = str(child.get("id") or f"child-{index}")
+                override_name = request.name_overrides.get(child_id)
+                child_name = override_name or str(
+                    child.get("name") or f"{request.template_key}-{child_id}"
+                )
+                left, top = _node_position(
+                    index, request.base_left, request.base_top, "row"
+                )
+                payload = _build_paired_child_payload(
+                    node_id=next_id,
+                    template_key=request.template_key,
+                    child=child,
+                    child_id=child_id,
+                    name=child_name,
+                    left=left,
+                    top=top,
+                )
+                nodes_map[str(next_id)] = payload
+                child_id_to_node_id[child_id] = next_id
+                created_nodes.append(payload)
+                next_id += 1
+
+            LabService.write_lab_json_static(scoped_path, data)
+        except Exception as exc:  # noqa: BLE001 — broad catch is the rollback contract
+            LabService.write_lab_json_static(scoped_path, snapshot)
+            _logger.exception(
+                "from-paired-template: node-creation phase failed for %s; rolled back",
+                request.template_key,
+            )
+            return {
+                "code": 500,
+                "status": "fail",
+                "message": f"Failed to create paired nodes: {exc}",
+            }
+
+        try:
+            for link in paired["links"]:
+                if not isinstance(link, dict):
+                    continue
+                from_child = str(link.get("from_node") or "")
+                to_child = str(link.get("to_node") or "")
+                from_iface_name = str(link.get("from_iface") or "")
+                to_iface_name = str(link.get("to_iface") or "")
+
+                from_node_id = child_id_to_node_id.get(from_child)
+                to_node_id = child_id_to_node_id.get(to_child)
+                if from_node_id is None or to_node_id is None:
+                    raise ValueError(
+                        f"Paired link references unknown child id "
+                        f"({from_child!r}↔{to_child!r}) in template {request.template_key!r}."
+                    )
+
+                from_iface_idx = _resolve_iface_index(
+                    nodes_map[str(from_node_id)], from_iface_name
+                )
+                to_iface_idx = _resolve_iface_index(
+                    nodes_map[str(to_node_id)], to_iface_name
                 )
 
-            from_iface_idx = _resolve_iface_index(nodes_map[str(from_node_id)], from_iface_name)
-            to_iface_idx = _resolve_iface_index(nodes_map[str(to_node_id)], to_iface_name)
-
-            link_payload, _network_payload, _replayed = await link_service.create_link(
-                lab_path,
-                {"node_id": from_node_id, "interface_index": from_iface_idx},
-                {"node_id": to_node_id, "interface_index": to_iface_idx},
+                link_payload, _network_payload, _replayed = await link_service.create_link(
+                    lab_path,
+                    {"node_id": from_node_id, "interface_index": from_iface_idx},
+                    {"node_id": to_node_id, "interface_index": to_iface_idx},
+                    _lab_lock_held=True,
+                )
+                created_links.append(link_payload)
+        except Exception as exc:  # noqa: BLE001 — broad catch is the rollback contract
+            # #208b — compensate already-created links before snapshot restore
+            # so host-side attach work, implicit bridges, and runtime stamps
+            # are torn down (snapshot restore only reverts lab.json content;
+            # kernel state survives without delete_link). Order: reverse of
+            # creation. Errors during compensation are logged but do not
+            # prevent snapshot restore — we want to leave the lab in the
+            # cleanest state we can.
+            for done in reversed(created_links):
+                try:
+                    await link_service.delete_link(
+                        lab_path, str(done.get("id", "")), _lab_lock_held=True
+                    )
+                except Exception as comp_exc:  # noqa: BLE001 — best-effort cleanup
+                    _logger.warning(
+                        "from-paired-template: compensation delete_link(%s) "
+                        "failed during rollback: %s",
+                        done.get("id"),
+                        comp_exc,
+                    )
+            LabService.write_lab_json_static(scoped_path, snapshot)
+            _logger.exception(
+                "from-paired-template: link-creation phase failed for %s; rolled back",
+                request.template_key,
             )
-            created_links.append(link_payload)
-    except Exception as exc:  # noqa: BLE001 — broad catch is the rollback contract
-        LabService.write_lab_json_static(scoped_path, snapshot)
-        _logger.exception(
-            "from-paired-template: link-creation phase failed for %s; rolled back",
-            request.template_key,
-        )
-        return {
-            "code": 500,
-            "status": "fail",
-            "message": f"Failed to create paired links: {exc}",
-        }
+            # #208e — map exception classes to operator-meaningful HTTP codes.
+            # _PairedIfaceLookupError = template defect → 422 (operator can
+            # fix the template); LinkService DuplicateLinkError/LinkContention
+            # = retryable / racy → 409; everything else stays 500.
+            from app.services.link_service import (
+                DuplicateLinkError,
+                LinkContentionError,
+            )
+
+            if isinstance(exc, _PairedIfaceLookupError):
+                return {
+                    "code": 422,
+                    "status": "fail",
+                    "message": f"Paired link interface lookup failed: {exc}",
+                }
+            if isinstance(exc, DuplicateLinkError):
+                return {
+                    "code": 409,
+                    "status": "fail",
+                    "message": f"Paired link conflicts with an existing link: {exc}",
+                }
+            if isinstance(exc, LinkContentionError):
+                return {
+                    "code": 409,
+                    "status": "fail",
+                    "message": f"Paired link blocked by concurrent attach/detach: {exc}",
+                }
+            return {
+                "code": 500,
+                "status": "fail",
+                "message": f"Failed to create paired links: {exc}",
+            }
 
     return {
         "code": 200,

--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -674,6 +674,24 @@ async def create_node_from_template(
             "message": str(exc),
         }
 
+    # #206 codex-iter2: synthetic per-child template entries (paired_parent set,
+    # e.g. ``juniper-vmx__vcp``) must NOT be instantiable via the single-node
+    # route. They live in the catalog only so node.template lookups in edit
+    # mode + capability gates resolve; their console_type can violate
+    # ``NodeCreate.console`` Literal (Juniper children declare ``serial``),
+    # raising an uncaught Pydantic ValidationError. Reject explicitly.
+    if template_def.paired_parent is not None:
+        return {
+            "code": 400,
+            "status": "fail",
+            "message": (
+                f"Template {request.template_key!r} is a synthetic per-child entry "
+                f"of paired template {template_def.paired_parent!r}; "
+                "use POST /api/labs/{lab_path}/nodes/from-paired-template with "
+                f"template_key={template_def.paired_parent!r} instead (see #206)."
+            ),
+        }
+
     # Build a NodeCreate from the template defaults, allowing per-request overrides.
     node_create = NodeCreate(
         name=request.name,

--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -936,6 +936,27 @@ async def create_nodes_from_paired_template(
                 next_id += 1
 
             LabService.write_lab_json_static(scoped_path, data)
+        except (ValueError, TemplateError) as exc:
+            # #208-MEDIUM — bad child scalars (e.g. ``ethernet: "not-an-int"``)
+            # and malformed-child entries are template defects, not server
+            # bugs. Surface as 422 so the operator sees a fix-the-template
+            # message instead of a generic 500. Pre-flight already catches
+            # link/iface defects; this catches the scalar shape that pre-flight
+            # doesn't (and shouldn't, to keep validator scope tight).
+            LabService.write_lab_json_static(scoped_path, snapshot)
+            _logger.exception(
+                "from-paired-template: node-creation phase failed for %s "
+                "(template defect); rolled back",
+                request.template_key,
+            )
+            return {
+                "code": 422,
+                "status": "fail",
+                "message": (
+                    f"Paired template {request.template_key!r} has malformed "
+                    f"child data: {exc}"
+                ),
+            }
         except Exception as exc:  # noqa: BLE001 — broad catch is the rollback contract
             LabService.write_lab_json_static(scoped_path, snapshot)
             _logger.exception(

--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -1028,11 +1028,16 @@ async def create_nodes_from_paired_template(
             # #208e — map exception classes to operator-meaningful HTTP codes.
             # _PairedIfaceLookupError = template defect → 422 (operator can
             # fix the template); LinkService DuplicateLinkError/LinkContention
-            # = retryable / racy → 409; everything else stays 500.
+            # = retryable / racy → 409; NodeRuntimeError / host_net.HostNetError
+            # = hot-attach / kernel-side failure → 422 (mirrors the /links route
+            # at routers/links.py:146,198,236, added in #208 codex-iter3 to
+            # close the drift Codex flagged); everything else stays 500.
+            from app.services import host_net
             from app.services.link_service import (
                 DuplicateLinkError,
                 LinkContentionError,
             )
+            from app.services.node_runtime_service import NodeRuntimeError
 
             if isinstance(exc, _PairedIfaceLookupError):
                 return {
@@ -1051,6 +1056,12 @@ async def create_nodes_from_paired_template(
                     "code": 409,
                     "status": "fail",
                     "message": f"Paired link blocked by concurrent attach/detach: {exc}",
+                }
+            if isinstance(exc, (NodeRuntimeError, host_net.HostNetError)):
+                return {
+                    "code": 422,
+                    "status": "fail",
+                    "message": f"Paired link hot-attach/host-net failure: {exc}",
                 }
             return {
                 "code": 500,

--- a/backend/app/schemas/node.py
+++ b/backend/app/schemas/node.py
@@ -42,7 +42,10 @@ class NodeBase(BaseModel):
     type: Literal["qemu", "docker", "iol", "dynamips"] = "qemu"
     template: str = Field(default="")
     image: str = Field(default="")
-    console: Literal["telnet", "vnc", "rdp"] = "telnet"
+    # ``serial`` is a paired-template-only console type (Juniper VCP/VFP).
+    # Single-node create flows still default to ``telnet``; the value only
+    # appears on lab.json entries that came from /from-paired-template.
+    console: Literal["telnet", "vnc", "rdp", "serial"] = "telnet"
     status: Literal[0, 2] = 0
     delay: int = 0
     cpu: int = 1
@@ -183,7 +186,12 @@ class NodeUpdate(BaseModel):
     ram: Optional[int] = None
     ethernet: Optional[int] = None
     image: Optional[str] = None
-    console: Optional[Literal["telnet", "vnc", "rdp"]] = None
+    # ``serial`` accepted so paired-template children (Juniper VCP/VFP) can
+    # round-trip through the edit modal — the modal always re-submits
+    # ``console`` and the existing value is whatever the paired template
+    # declared. Without ``serial`` here, saving an unchanged paired child
+    # would 422 on schema validation (#206 codex-iter3).
+    console: Optional[Literal["telnet", "vnc", "rdp", "serial"]] = None
     delay: Optional[int] = None
     left: Optional[int] = None
     top: Optional[int] = None

--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -16,7 +16,7 @@ import logging
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple
 
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, nullcontext
 
 from app.config import get_settings
 from app.services import host_net
@@ -256,12 +256,20 @@ class LinkService:
         *,
         style_override: Optional[str] = None,
         idempotency_key: Optional[str] = None,
+        _lab_lock_held: bool = False,
     ) -> Tuple[dict, Optional[dict], bool]:
         """Create a link, applying the implicit-bridge state machine.
 
         Returns ``(link_payload, network_payload_or_none, replayed)``. When
         ``replayed`` is True the caller should respond 200 (not 201) and skip
         WebSocket publishing.
+
+        ``_lab_lock_held`` (#208a): set True when the caller already holds
+        ``lab_lock(normalized, labs_dir)`` so the inner ``_create_link_locked``
+        skips its own re-acquisition (fcntl.flock would deadlock). This is
+        used by paired-create which holds one outer lab_lock spanning
+        snapshot + node-creation + multi-link creation + (rollback or
+        success). Default False keeps the historical contract intact.
         """
         normalized = _normalize_relative_lab_path(lab_path)
 
@@ -323,6 +331,7 @@ class LinkService:
                     idempotency_key=idempotency_key,
                     ws_events=ws_events,
                     mutex_lab_id=mutex_lab_id,
+                    _lab_lock_held=_lab_lock_held,
                 )
         except RuntimeMutexContention as exc:
             # US-303 codex iter1 MEDIUM: bounded-wait timeout → 409.
@@ -339,14 +348,23 @@ class LinkService:
         idempotency_key: Optional[str],
         ws_events: List[Tuple[str, dict]],
         mutex_lab_id: str,
+        _lab_lock_held: bool = False,
     ) -> Tuple[dict, Optional[dict], bool]:
         """Per-iface mutex(es) ARE held by the caller (US-204b). This
         helper does the lab_lock-bounded mutation + hot-attach work.
+
+        ``_lab_lock_held`` (#208a): when True the caller already holds
+        ``lab_lock(normalized, labs_dir)``; we skip re-acquisition (fcntl
+        flock is not reentrant on Linux even within the same process).
         """
         link_payload: dict
         network_payload: Optional[dict] = None
 
-        with lab_lock(normalized, labs_dir):
+        lab_lock_cm = (
+            nullcontext() if _lab_lock_held else lab_lock(normalized, labs_dir)
+        )
+
+        with lab_lock_cm:
             data = LabService.read_lab_json_static(normalized)
             networks = data.setdefault("networks", {})
             links = data.setdefault("links", [])
@@ -944,8 +962,20 @@ class LinkService:
                 return bridge
         return host_net.bridge_name(lab_id, network_id)
 
-    async def delete_link(self, lab_path: str, link_id: str) -> Tuple[bool, Optional[dict]]:
+    async def delete_link(
+        self,
+        lab_path: str,
+        link_id: str,
+        *,
+        _lab_lock_held: bool = False,
+    ) -> Tuple[bool, Optional[dict]]:
         """Delete a link. Idempotent: missing link returns ``(True, None)``.
+
+        ``_lab_lock_held`` (#208a/b): set True when the caller already holds
+        ``lab_lock(normalized, labs_dir)`` so the inner lab_lock acquisition
+        is skipped (fcntl flock is not reentrant on Linux). Used by
+        paired-create's link-rollback compensation to undo previously-attached
+        links inside the outer lab_lock window.
 
         Returns ``(already_deleted_or_succeeded, deleted_implicit_network)``.
         ``deleted_implicit_network`` is None unless an implicit network's
@@ -1005,6 +1035,7 @@ class LinkService:
                     labs_dir=labs_dir,
                     link_id=link_id,
                     mutex_lab_id=mutex_lab_id,
+                    _lab_lock_held=_lab_lock_held,
                 )
         except RuntimeMutexContention as exc:
             # US-303 codex iter1 MEDIUM: bounded-wait timeout → 409.
@@ -1017,6 +1048,7 @@ class LinkService:
         labs_dir,
         link_id: str,
         mutex_lab_id: str,
+        _lab_lock_held: bool = False,
     ) -> Tuple[bool, Optional[dict]]:
         """Per-iface mutex(es) ARE held by the caller (US-205 / US-204b).
 
@@ -1210,7 +1242,16 @@ class LinkService:
         ):
             from app.services.network_service import NetworkService  # noqa: WPS433
 
-            NetworkService()._release_ip(normalized, int(paired_net_id), removed_ip)
+            # #208a/b architect-iter1: thread _lab_lock_held so paired-create
+            # compensation (which holds the outer lab_lock) does not deadlock
+            # on the inner per-lab fcntl flock when releasing IPAM-bearing
+            # links. Default-path delete_link callers pass False here.
+            NetworkService()._release_ip(
+                normalized,
+                int(paired_net_id),
+                removed_ip,
+                _lab_lock_held=_lab_lock_held,
+            )
 
         # ------------------------------------------------------------------
         # Phase 4 — under ``lab_lock``: remove the link from lab.json + GC
@@ -1219,7 +1260,10 @@ class LinkService:
         # changed by ``_release_ip`` so the original ``target_link`` is
         # still findable by id.
         # ------------------------------------------------------------------
-        with lab_lock(normalized, labs_dir):
+        delete_lab_lock_cm = (
+            nullcontext() if _lab_lock_held else lab_lock(normalized, labs_dir)
+        )
+        with delete_lab_lock_cm:
             data = LabService.read_lab_json_static(normalized)
             links = data.get("links", []) or []
             networks = data.get("networks", {}) or {}

--- a/backend/app/services/network_service.py
+++ b/backend/app/services/network_service.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import ipaddress
 import json
 import logging
+from contextlib import nullcontext
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -614,16 +615,33 @@ class NetworkService:
 
         return str(chosen)
 
-    def _release_ip(self, lab_path: str, network_id: int, ip: str) -> bool:
+    def _release_ip(
+        self,
+        lab_path: str,
+        network_id: int,
+        ip: str,
+        *,
+        _lab_lock_held: bool = False,
+    ) -> bool:
         """Remove ``ip`` from ``runtime.used_ips``; return True if removed.
 
         No-op (returns False) when the network or IP is absent —
         idempotent so detach paths can call this without a pre-check.
+
+        ``_lab_lock_held`` (#208a/b architect-iter1): set True when the
+        caller already holds ``lab_lock(normalized, labs_dir)`` so the
+        inner acquisition is skipped. Used by paired-create's compensation
+        path (delete_link from inside the outer paired lab_lock); fcntl
+        flock LOCK_EX is not reentrant within the same Linux process.
         """
         normalized = _normalize_relative_lab_path(lab_path)
         labs_dir = get_settings().LABS_DIR
 
-        with lab_lock(normalized, labs_dir):
+        release_lab_lock_cm = (
+            nullcontext() if _lab_lock_held else lab_lock(normalized, labs_dir)
+        )
+
+        with release_lab_lock_cm:
             data = LabService.read_lab_json_static(normalized)
             networks = data.get("networks", {}) or {}
             network = networks.get(str(network_id))

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -122,7 +122,17 @@ def validate_paired_template(data: dict[str, Any]) -> str | None:
             child = children_by_id.get(child_id)
             if child is None:
                 return f"link references unknown child id {child_id!r}"
-            available = _paired_child_iface_names(child)
+            # #208-MEDIUM — predictor casts ``ethernet`` to int. A child with
+            # ``ethernet: "not-an-int"`` would otherwise propagate ValueError
+            # uncaught out of pre-flight back to the FastAPI handler → 500.
+            # Surface as a reason string so the endpoint returns 422.
+            try:
+                available = _paired_child_iface_names(child)
+            except (ValueError, TypeError) as exc:
+                return (
+                    f"child {child_id!r} has malformed scalar field "
+                    f"(ethernet must be an int): {exc}"
+                )
             if iface_name not in available:
                 return (
                     f"child {child_id!r} interface {iface_name!r} not in available "

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -30,42 +30,73 @@ def synthetic_paired_child_key(paired_key: str, child_id: str) -> str:
     return f"{paired_key}{SYNTHETIC_PAIRED_CHILD_SEP}{child_id}"
 
 
+def _kind_default_iface_names(kind: str, ethernet: int) -> list[str]:
+    """Hardcoded fallback interface names by node kind. Mirrors the qemu
+    branch and ``eth{n}`` else-branch in ``_default_interfaces``."""
+    if kind == "qemu":
+        return [f"Gi{i + 1}" for i in range(ethernet)]
+    return [f"eth{i}" for i in range(ethernet)]
+
+
 def _paired_child_iface_names(child: dict[str, Any]) -> list[str]:
     """Predict the interface names a paired child will have at creation
     time. Used by :func:`validate_paired_template` to pre-flight link
     resolution at catalog-load time so old (#202-pre) imports surface as
     invalid in the catalog rather than failing only at instantiation.
 
-    Must mirror the runtime priority order in
-    ``backend/app/routers/labs.py::_default_interfaces``:
+    Must mirror the runtime overlay sequence in
+    ``backend/app/routers/labs.py::_build_paired_child_payload``:
 
-    1. ``interface_naming.explicit:[...]`` — fixed list of names
-    2. ``interface_naming.format`` — comma-separated string or list[str]
-       (post-#179 normalization), rendered per-index via
-       :func:`render_interface_name`
-    3. Hardcoded fallback by kind (qemu→Gi{n+1}, others→eth{n})
+    1. Build the base interface list:
+       a. ``interface_naming.format`` (string or list[str]) → per-index
+          via :func:`render_interface_name`, OR
+       b. Hardcoded fallback by kind (qemu→``Gi{n+1}``, others→``eth{n}``).
+    2. Overlay ``interface_naming.explicit:[name0, name1, ...]`` onto
+       positions ``0..len(explicit)-1`` of the base.
+
+    Codex-iter2 fix: previously this returned the explicit list verbatim,
+    so a child with ``ethernet=2, explicit=["mgmt0"]`` was predicted as
+    ``["mgmt0"]`` and any link to the second interface (``Gi2``/``eth1``)
+    was wrongly flagged invalid. The runtime overlays explicit onto a
+    full-length base, so the predictor must too.
     """
     ethernet = int(child.get("ethernet", 1))
-    iface_naming = child.get("interface_naming")
-    if isinstance(iface_naming, dict):
-        explicit = iface_naming.get("explicit")
-        if isinstance(explicit, list) and all(isinstance(x, str) for x in explicit):
-            return list(explicit)
+    kind = str(child.get("kind") or "qemu").strip().lower()
+    iface_naming = child.get("interface_naming") if isinstance(child.get("interface_naming"), dict) else None
+
+    # Step 1 — base list (format if present, else kind-default).
+    base: list[str]
+    if iface_naming is not None:
         fmt = iface_naming.get("format")
         if isinstance(fmt, str) and fmt.strip():
-            return [render_interface_name(fmt, i) for i in range(ethernet)]
-        if isinstance(fmt, list) and fmt:
+            base = [render_interface_name(fmt, i) for i in range(ethernet)]
+        elif isinstance(fmt, list) and fmt:
             # Pre-validation list shape (#179) — _validate_interface_naming
             # would normalize this to a comma-string before reaching the
-            # runtime, but the predictor sees raw template JSON so handle
-            # both shapes by joining and rendering.
+            # runtime; the predictor sees raw template JSON so normalize
+            # here too.
             normalized = ",".join(str(item).strip() for item in fmt if str(item).strip())
-            if normalized:
-                return [render_interface_name(normalized, i) for i in range(ethernet)]
-    kind = str(child.get("kind") or "qemu").strip().lower()
-    if kind == "qemu":
-        return [f"Gi{i + 1}" for i in range(ethernet)]
-    return [f"eth{i}" for i in range(ethernet)]
+            base = (
+                [render_interface_name(normalized, i) for i in range(ethernet)]
+                if normalized
+                else _kind_default_iface_names(kind, ethernet)
+            )
+        else:
+            base = _kind_default_iface_names(kind, ethernet)
+    else:
+        base = _kind_default_iface_names(kind, ethernet)
+
+    # Step 2 — overlay explicit names onto the front of the base list.
+    if iface_naming is not None:
+        explicit = iface_naming.get("explicit")
+        if isinstance(explicit, list):
+            for idx, name in enumerate(explicit):
+                if idx >= len(base):
+                    break
+                if isinstance(name, str):
+                    base[idx] = name
+
+    return base
 
 
 def validate_paired_template(data: dict[str, Any]) -> str | None:

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shutil
 import subprocess
-from typing import Any
+from typing import Any, Iterator
 
 import yaml
 
@@ -19,6 +19,87 @@ SUPPORTED_TEMPLATE_TYPES = {"qemu", "docker", "iol", "dynamips"}
 QEMU_MACHINE_OPTIONS = {"q35", "pc"}
 _QEMU_MAX_NICS_HARD_CAP = 8
 _DOCKER_MAX_NICS_DEFAULT = 99
+
+# #206 — synthetic per-child template key separator. A paired template's child
+# is exposed in the catalog as ``<paired_key>__<child_id>`` so node.template
+# lookups (edit, capability, image validation) resolve to a real entry.
+SYNTHETIC_PAIRED_CHILD_SEP = "__"
+
+
+def synthetic_paired_child_key(paired_key: str, child_id: str) -> str:
+    return f"{paired_key}{SYNTHETIC_PAIRED_CHILD_SEP}{child_id}"
+
+
+def _paired_child_iface_names(child: dict[str, Any]) -> list[str]:
+    """Predict the interface names a paired child will have at creation
+    time. Used by :func:`validate_paired_template` to pre-flight link
+    resolution at catalog-load time so old (#202-pre) imports surface as
+    invalid in the catalog rather than failing only at instantiation.
+
+    Must mirror the runtime priority order in
+    ``backend/app/routers/labs.py::_default_interfaces``:
+
+    1. ``interface_naming.explicit:[...]`` — fixed list of names
+    2. ``interface_naming.format`` — comma-separated string or list[str]
+       (post-#179 normalization), rendered per-index via
+       :func:`render_interface_name`
+    3. Hardcoded fallback by kind (qemu→Gi{n+1}, others→eth{n})
+    """
+    ethernet = int(child.get("ethernet", 1))
+    iface_naming = child.get("interface_naming")
+    if isinstance(iface_naming, dict):
+        explicit = iface_naming.get("explicit")
+        if isinstance(explicit, list) and all(isinstance(x, str) for x in explicit):
+            return list(explicit)
+        fmt = iface_naming.get("format")
+        if isinstance(fmt, str) and fmt.strip():
+            return [render_interface_name(fmt, i) for i in range(ethernet)]
+        if isinstance(fmt, list) and fmt:
+            # Pre-validation list shape (#179) — _validate_interface_naming
+            # would normalize this to a comma-string before reaching the
+            # runtime, but the predictor sees raw template JSON so handle
+            # both shapes by joining and rendering.
+            normalized = ",".join(str(item).strip() for item in fmt if str(item).strip())
+            if normalized:
+                return [render_interface_name(normalized, i) for i in range(ethernet)]
+    kind = str(child.get("kind") or "qemu").strip().lower()
+    if kind == "qemu":
+        return [f"Gi{i + 1}" for i in range(ethernet)]
+    return [f"eth{i}" for i in range(ethernet)]
+
+
+def validate_paired_template(data: dict[str, Any]) -> str | None:
+    """Pre-flight a paired template (#207). Returns ``None`` when the template
+    can be instantiated end-to-end, or a human-readable reason string when a
+    link references an interface name that no child will expose. Used by the
+    catalog builder to flag old imports + by the from-paired-template endpoint
+    to return 422 instead of 500.
+    """
+    nodes = data.get("nodes") or []
+    links = data.get("links") or []
+    children_by_id: dict[str, dict[str, Any]] = {}
+    for child in nodes:
+        if isinstance(child, dict):
+            children_by_id[str(child.get("id") or "")] = child
+
+    for link in links:
+        if not isinstance(link, dict):
+            continue
+        for endpoint_key, iface_key in (("from_node", "from_iface"), ("to_node", "to_iface")):
+            child_id = str(link.get(endpoint_key) or "")
+            iface_name = str(link.get(iface_key) or "")
+            child = children_by_id.get(child_id)
+            if child is None:
+                return f"link references unknown child id {child_id!r}"
+            available = _paired_child_iface_names(child)
+            if iface_name not in available:
+                return (
+                    f"child {child_id!r} interface {iface_name!r} not in available "
+                    f"set [{', '.join(available) or '<empty>'}]. Add "
+                    f"interface_naming.explicit:[...] to the child block so "
+                    f"the link resolves at instantiation time."
+                )
+    return None
 
 
 def _default_capabilities(template_type: str) -> dict[str, Any]:
@@ -536,6 +617,12 @@ class TemplateDefinition:
     raw: dict[str, Any] = field(default_factory=dict)
     interface_naming: dict[str, Any] | None = None
     capabilities: dict[str, Any] = field(default_factory=dict)
+    # #206 — when this entry was synthesized from a paired-template child block
+    # (vs loaded from a per-type YAML), ``paired_parent`` is the originating
+    # paired template key. Surfaced in the catalog response so the frontend can
+    # exclude these from the standalone "Add node" type-tab picker while still
+    # resolving them by key for edit-mode lookups and capability gates.
+    paired_parent: str | None = None
 
     def as_response(self) -> dict[str, Any]:
         return {
@@ -584,6 +671,28 @@ class TemplateService:
                 return template
         raise TemplateError(f"Template {key} does not exist for type {template_type}.")
 
+    def _iter_paired_user_templates(self) -> Iterator[tuple[Path, dict[str, Any]]]:
+        """Yield (path, payload) for every well-formed ``kind="paired"`` JSON
+        under ``USER_TEMPLATES_DIR``. Tolerates I/O + parse errors, skips
+        non-paired files, and enforces the minimal structural invariant
+        (non-empty ``nodes`` list + ``links`` list). Shared by the loader,
+        the catalog builder, and the per-key lookup so they cannot drift.
+        """
+        if self.user_templates_dir is None or not self.user_templates_dir.exists():
+            return
+        for path in sorted(self.user_templates_dir.rglob("*.json")):
+            try:
+                data = yaml.safe_load(path.read_text()) or {}
+            except (OSError, yaml.YAMLError):
+                continue
+            if not isinstance(data, dict) or data.get("kind") != "paired":
+                continue
+            nodes = data.get("nodes")
+            links = data.get("links")
+            if not (isinstance(nodes, list) and nodes and isinstance(links, list)):
+                continue
+            yield path, data
+
     def get_paired_user_template(self, template_key: str) -> dict[str, Any] | None:
         """Load a paired-node template (``kind="paired"``) from USER_TEMPLATES_DIR.
 
@@ -593,19 +702,8 @@ class TemplateService:
         instantiate multi-node templates atomically. Read-only; tolerant of
         malformed JSON.
         """
-        if self.user_templates_dir is None or not self.user_templates_dir.exists():
-            return None
-        candidates = list(self.user_templates_dir.rglob(f"{template_key}.json"))
-        for path in candidates:
-            try:
-                data = yaml.safe_load(path.read_text()) or {}
-            except (OSError, yaml.YAMLError):
-                continue
-            if not isinstance(data, dict) or data.get("kind") != "paired":
-                continue
-            nodes = data.get("nodes")
-            links = data.get("links")
-            if isinstance(nodes, list) and nodes and isinstance(links, list):
+        for path, data in self._iter_paired_user_templates():
+            if path.stem == template_key:
                 return data
         return None
 
@@ -615,6 +713,16 @@ class TemplateService:
 
     def list_images(self, template_type: str, template_key: str) -> dict[str, dict[str, Any]]:
         template = self.get_template(template_type, template_key)
+
+        # #206 — synthetic paired children declare their image explicitly in
+        # the paired template JSON. Surface only that image so validation in
+        # validate_node_request matches what the paired-create endpoint uses.
+        if template.paired_parent is not None:
+            declared = str(template.raw.get("image") or "").strip()
+            if declared:
+                return {declared: {"image": declared, "source": "paired-child-declared"}}
+            return {}
+
         images: dict[str, dict[str, Any]] = {}
 
         if template_type == "docker":
@@ -692,6 +800,10 @@ class TemplateService:
                     "icon_options": icon_options,
                     "extras_schema": extras_schema,
                     "capabilities": dict(template.capabilities),
+                    # #206 — set on synthetic per-child entries; frontends should
+                    # filter these out of the standalone create-flow type tabs
+                    # but still resolve them by key for edit + capability lookups.
+                    "paired_parent": template.paired_parent,
                 }
             )
         return {
@@ -711,20 +823,11 @@ class TemplateService:
         and routes submissions to ``POST /nodes/from-paired-template`` instead of
         the single-node ``/nodes/batch`` path.
         """
-        if self.user_templates_dir is None or not self.user_templates_dir.exists():
-            return []
         result: list[dict[str, Any]] = []
-        for path in sorted(self.user_templates_dir.rglob("*.json")):
-            try:
-                data = yaml.safe_load(path.read_text()) or {}
-            except (OSError, yaml.YAMLError):
-                continue
-            if not isinstance(data, dict) or data.get("kind") != "paired":
-                continue
-            nodes = data.get("nodes")
-            links = data.get("links")
-            if not (isinstance(nodes, list) and nodes and isinstance(links, list)):
-                continue
+        for path, data in self._iter_paired_user_templates():
+            nodes = data["nodes"]
+            links = data["links"]
+            paired_key = path.stem
             child_summary = [
                 {
                     "id": str(child.get("id") or f"child-{i}"),
@@ -734,6 +837,13 @@ class TemplateService:
                     "cpu": int(child.get("cpu", 1)),
                     "ram": int(child.get("ram", 1024)),
                     "ethernet": int(child.get("ethernet", 1)),
+                    # #206 — synthetic template key the child node carries on
+                    # its ``template`` field once instantiated; lets the frontend
+                    # cross-reference the matching catalog entry for capabilities,
+                    # extras schema, etc.
+                    "template_key": synthetic_paired_child_key(
+                        paired_key, str(child.get("id") or f"child-{i}")
+                    ),
                 }
                 for i, child in enumerate(nodes)
                 if isinstance(child, dict)
@@ -748,6 +858,15 @@ class TemplateService:
                 for link in links
                 if isinstance(link, dict)
             ]
+            invalid_reason = validate_paired_template(data)
+            if invalid_reason is not None:
+                _logger.warning(
+                    "Paired template %s pre-flight failed: %s — instantiation "
+                    "via /from-paired-template will return 422 until the "
+                    "template is updated.",
+                    path.stem,
+                    invalid_reason,
+                )
             result.append(
                 {
                     "key": path.stem,
@@ -757,6 +876,11 @@ class TemplateService:
                     "link_count": len(link_summary),
                     "children": child_summary,
                     "links": link_summary,
+                    # #207 — pre-flighted at catalog-load time so old imports
+                    # surface a banner-friendly reason. Endpoint converts this
+                    # to a 422 if the operator tries to instantiate.
+                    "valid": invalid_reason is None,
+                    "invalid_reason": invalid_reason,
                 }
             )
         return result
@@ -894,7 +1018,66 @@ class TemplateService:
                     capabilities=capabilities,
                 )
             )
+
+        # #206 — append synthetic per-child entries for every paired template so
+        # node.template lookups (edit, capability gates, image validation) resolve
+        # cleanly. These entries advertise paired_parent so frontends can hide
+        # them from the standalone create-flow type-tab picker.
+        templates.extend(self._load_synthetic_paired_child_templates())
         return templates
+
+    def _load_synthetic_paired_child_templates(self) -> list[TemplateDefinition]:
+        """Synthesize per-child :class:`TemplateDefinition` entries from paired
+        user templates (``USER_TEMPLATES_DIR/*.json`` with ``kind="paired"``).
+
+        Each child becomes a first-class catalog entry keyed
+        ``<paired_key>__<child_id>``. Capability/interface_naming blocks on the
+        child are validated via the same helpers used for real templates so a
+        broken child raises :class:`TemplateError` at load time rather than
+        silently flowing through to runtime. The child's ``image`` is recorded
+        on the synthetic ``raw`` so :meth:`list_images` can surface it (see
+        the override in that method).
+        """
+        synthetic: list[TemplateDefinition] = []
+        for path, data in self._iter_paired_user_templates():
+            nodes = data["nodes"]
+            paired_key = path.stem
+            for index, child in enumerate(nodes):
+                if not isinstance(child, dict):
+                    continue
+                child_id = str(child.get("id") or f"child-{index}")
+                child_kind = str(child.get("kind") or "qemu").strip().lower()
+                if child_kind not in SUPPORTED_TEMPLATE_TYPES:
+                    child_kind = "qemu"
+                synthetic_key = synthetic_paired_child_key(paired_key, child_id)
+                source = f"{path}::nodes[{index}]"
+                child_iface = child.get("interface_naming")
+                if child_iface is not None:
+                    child_iface = _validate_interface_naming(child_iface, source=source)
+                child_caps = _validate_capabilities(
+                    child.get("capabilities"), child_kind, source=source
+                )
+                yaml_extras = dict(child.get("extras") or {}) if isinstance(child.get("extras"), dict) else {}
+                synthetic.append(
+                    TemplateDefinition(
+                        key=synthetic_key,
+                        type=child_kind,
+                        name=str(child.get("name") or synthetic_key),
+                        description=f"Paired child of {paired_key} (auto-synthesized).",
+                        icon_type=str(child.get("icon_type") or self._default_icon_type(child_kind)),
+                        cpu=int(child.get("cpu", 1)),
+                        ram=int(child.get("ram", 1024)),
+                        ethernet=int(child.get("ethernet", 1)),
+                        console_type=str(child.get("console") or self._default_console_type(child_kind)),
+                        cpulimit=int(child.get("cpulimit", 1)),
+                        extras=yaml_extras,
+                        raw=dict(child),
+                        interface_naming=child_iface,
+                        capabilities=child_caps,
+                        paired_parent=paired_key,
+                    )
+                )
+        return synthetic
 
     def _normalize_type(self, template_type: str) -> str:
         normalized = template_type.strip().lower()

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -99,12 +99,57 @@ def _paired_child_iface_names(child: dict[str, Any]) -> list[str]:
     return base
 
 
+_PAIRED_CHILD_INT_FIELDS: tuple[tuple[str, int], ...] = (
+    ("cpu", 1),
+    ("ram", 1024),
+    ("ethernet", 1),
+    ("cpulimit", 1),
+)
+
+
+def _paired_child_scalar_problem(child: dict[str, Any]) -> str | None:
+    """Return a reason string if any of the int-typed scalar fields on a
+    paired-child block can't be cast to int, else ``None``. Centralizes the
+    scalar-shape check so :func:`validate_paired_template`,
+    :meth:`TemplateService._build_paired_catalog`, and
+    :meth:`TemplateService._load_synthetic_paired_child_templates` agree on
+    what counts as a valid child without each having to defensively cast at
+    consumption time (#208 codex-iter3).
+    """
+    for field_name, _default in _PAIRED_CHILD_INT_FIELDS:
+        if field_name not in child:
+            continue
+        raw = child[field_name]
+        try:
+            int(raw)
+        except (TypeError, ValueError):
+            return (
+                f"field {field_name!r} must be an integer "
+                f"(got {raw!r} of type {type(raw).__name__})"
+            )
+    return None
+
+
+def _safe_paired_child_int(child: dict[str, Any], field: str, default: int) -> int:
+    """Cast a paired-child scalar to int with a fallback default. Used by the
+    catalog/synthetic loaders so a malformed scalar doesn't crash the whole
+    catalog response — :func:`validate_paired_template` already flags the
+    template as ``valid:false`` so the operator sees the real reason."""
+    if field not in child:
+        return default
+    try:
+        return int(child[field])
+    except (TypeError, ValueError):
+        return default
+
+
 def validate_paired_template(data: dict[str, Any]) -> str | None:
     """Pre-flight a paired template (#207). Returns ``None`` when the template
     can be instantiated end-to-end, or a human-readable reason string when a
-    link references an interface name that no child will expose. Used by the
-    catalog builder to flag old imports + by the from-paired-template endpoint
-    to return 422 instead of 500.
+    link references an interface name that no child will expose, or a child
+    has a malformed scalar field (#208). Used by the catalog builder to flag
+    old imports + by the from-paired-template endpoint to return 422 instead
+    of 500.
     """
     nodes = data.get("nodes") or []
     links = data.get("links") or []
@@ -112,6 +157,16 @@ def validate_paired_template(data: dict[str, Any]) -> str | None:
     for child in nodes:
         if isinstance(child, dict):
             children_by_id[str(child.get("id") or "")] = child
+
+    # #208 codex-iter3 — scalar-shape check up front so a bad cpu/ram/etc
+    # fails pre-flight with a meaningful reason instead of crashing at
+    # instantiation. Predictor only consumes ``ethernet`` so this also
+    # covers the cpu/ram/cpulimit gap that previously slipped past
+    # pre-flight to the node-creation handler.
+    for child_id, child in children_by_id.items():
+        scalar_reason = _paired_child_scalar_problem(child)
+        if scalar_reason is not None:
+            return f"child {child_id!r} {scalar_reason}"
 
     for link in links:
         if not isinstance(link, dict):
@@ -869,15 +924,19 @@ class TemplateService:
             nodes = data["nodes"]
             links = data["links"]
             paired_key = path.stem
+            # #208 codex-iter3 — int casts are scoped to ``_safe_paired_child_int``
+            # so a malformed scalar can't crash the whole node-catalog response;
+            # ``validate_paired_template`` below sets ``valid:false`` so the
+            # operator still sees the real reason in the catalog payload.
             child_summary = [
                 {
                     "id": str(child.get("id") or f"child-{i}"),
                     "name": str(child.get("name") or child.get("id") or f"child-{i}"),
                     "kind": str(child.get("kind") or "qemu"),
                     "image": str(child.get("image") or ""),
-                    "cpu": int(child.get("cpu", 1)),
-                    "ram": int(child.get("ram", 1024)),
-                    "ethernet": int(child.get("ethernet", 1)),
+                    "cpu": _safe_paired_child_int(child, "cpu", 1),
+                    "ram": _safe_paired_child_int(child, "ram", 1024),
+                    "ethernet": _safe_paired_child_int(child, "ethernet", 1),
                     # #206 — synthetic template key the child node carries on
                     # its ``template`` field once instantiated; lets the frontend
                     # cross-reference the matching catalog entry for capabilities,
@@ -1092,32 +1151,57 @@ class TemplateService:
                     child_kind = "qemu"
                 synthetic_key = synthetic_paired_child_key(paired_key, child_id)
                 source = f"{path}::nodes[{index}]"
-                child_iface = child.get("interface_naming")
-                if child_iface is not None:
-                    child_iface = _validate_interface_naming(child_iface, source=source)
-                child_caps = _validate_capabilities(
-                    child.get("capabilities"), child_kind, source=source
-                )
-                yaml_extras = dict(child.get("extras") or {}) if isinstance(child.get("extras"), dict) else {}
-                synthetic.append(
-                    TemplateDefinition(
-                        key=synthetic_key,
-                        type=child_kind,
-                        name=str(child.get("name") or synthetic_key),
-                        description=f"Paired child of {paired_key} (auto-synthesized).",
-                        icon_type=str(child.get("icon_type") or self._default_icon_type(child_kind)),
-                        cpu=int(child.get("cpu", 1)),
-                        ram=int(child.get("ram", 1024)),
-                        ethernet=int(child.get("ethernet", 1)),
-                        console_type=str(child.get("console") or self._default_console_type(child_kind)),
-                        cpulimit=int(child.get("cpulimit", 1)),
-                        extras=yaml_extras,
-                        raw=dict(child),
-                        interface_naming=child_iface,
-                        capabilities=child_caps,
-                        paired_parent=paired_key,
+                # #208 codex-iter3 — paired imports may be malformed (bad
+                # scalars, busted interface_naming/capabilities). Don't take
+                # down the entire template catalog because of one broken
+                # child; the parent paired entry already gets ``valid:false``
+                # in ``_build_paired_catalog`` via ``validate_paired_template``
+                # so the operator sees the real reason. Skip-but-log the
+                # synthetic child instead.
+                try:
+                    child_iface = child.get("interface_naming")
+                    if child_iface is not None:
+                        child_iface = _validate_interface_naming(child_iface, source=source)
+                    child_caps = _validate_capabilities(
+                        child.get("capabilities"), child_kind, source=source
                     )
-                )
+                    yaml_extras = (
+                        dict(child.get("extras") or {})
+                        if isinstance(child.get("extras"), dict)
+                        else {}
+                    )
+                    synthetic.append(
+                        TemplateDefinition(
+                            key=synthetic_key,
+                            type=child_kind,
+                            name=str(child.get("name") or synthetic_key),
+                            description=f"Paired child of {paired_key} (auto-synthesized).",
+                            icon_type=str(
+                                child.get("icon_type") or self._default_icon_type(child_kind)
+                            ),
+                            cpu=_safe_paired_child_int(child, "cpu", 1),
+                            ram=_safe_paired_child_int(child, "ram", 1024),
+                            ethernet=_safe_paired_child_int(child, "ethernet", 1),
+                            console_type=str(
+                                child.get("console") or self._default_console_type(child_kind)
+                            ),
+                            cpulimit=_safe_paired_child_int(child, "cpulimit", 1),
+                            extras=yaml_extras,
+                            raw=dict(child),
+                            interface_naming=child_iface,
+                            capabilities=child_caps,
+                            paired_parent=paired_key,
+                        )
+                    )
+                except (TemplateError, ValueError, TypeError) as exc:
+                    _logger.warning(
+                        "Synthetic paired-child template skipped at load time: "
+                        "paired=%s child=%s reason=%s",
+                        paired_key,
+                        child_id,
+                        exc,
+                    )
+                    continue
         return synthetic
 
     def _normalize_type(self, template_type: str) -> str:

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -30,6 +30,22 @@ def synthetic_paired_child_key(paired_key: str, child_id: str) -> str:
     return f"{paired_key}{SYNTHETIC_PAIRED_CHILD_SEP}{child_id}"
 
 
+def _normalize_paired_child_kind(raw: Any) -> str:
+    """Mirror the runtime kind coercion in
+    ``backend/app/routers/labs.py::_build_paired_child_payload``: any kind
+    outside the supported set falls back to ``qemu``. Predictor and runtime
+    must agree on this — Codex iter-2 finding: predictor was treating any
+    non-qemu kind as ``eth*``, but runtime coerces unsupported kinds to
+    qemu and uses ``Gi*`` fallback naming. Result: a child with
+    ``kind:"weirdkind"`` and link reference ``Gi1`` was wrongly flagged
+    invalid by pre-flight while runtime built ``Gi1`` cleanly.
+    """
+    kind = str(raw or "qemu").strip().lower()
+    if kind not in {"qemu", "docker", "iol", "dynamips"}:
+        return "qemu"
+    return kind
+
+
 def _kind_default_iface_names(kind: str, ethernet: int) -> list[str]:
     """Hardcoded fallback interface names by node kind. Mirrors the qemu
     branch and ``eth{n}`` else-branch in ``_default_interfaces``."""
@@ -61,7 +77,11 @@ def _paired_child_iface_names(child: dict[str, Any]) -> list[str]:
     full-length base, so the predictor must too.
     """
     ethernet = int(child.get("ethernet", 1))
-    kind = str(child.get("kind") or "qemu").strip().lower()
+    # #207 codex-iter3 — must mirror runtime kind coercion exactly. Runtime
+    # coerces any unsupported kind to ``qemu`` (→ ``Gi*`` naming); pre-fix
+    # predictor treated every non-qemu kind as ``eth*``, so a link to
+    # ``Gi1`` on a ``kind:"weirdkind"`` child was wrongly flagged invalid.
+    kind = _normalize_paired_child_kind(child.get("kind"))
     iface_naming = child.get("interface_naming") if isinstance(child.get("interface_naming"), dict) else None
 
     # Step 1 — base list (format if present, else kind-default).

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -362,3 +362,759 @@ async def test_single_template_endpoint_redirects_paired_to_new_endpoint(patched
     assert response["code"] == 400
     assert "from-paired-template" in response["message"]
     assert "#202" in response["message"]
+
+
+# ---- #206 synthetic per-child template identity -------------------------
+
+
+def test_206_synthetic_paired_child_templates_appear_in_listing(patched_split):
+    """Each child of a paired template surfaces as a real entry in
+    list_templates(<child_kind>) keyed ``<paired_key>__<child_id>`` with
+    ``paired_parent`` set to the originating paired template key."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+
+    listed = TemplateService().list_templates("qemu")
+    assert "juniper-vmx__vcp" in listed
+    assert "juniper-vmx__vfp" in listed
+    vcp_entry = listed["juniper-vmx__vcp"]
+    assert vcp_entry["name"] == "vMX VCP"
+    assert vcp_entry["cpu"] == 1
+    assert vcp_entry["ram"] == 2048
+    assert vcp_entry["ethernet"] == 1
+
+
+def test_206_synthetic_entries_carry_paired_parent_in_catalog(patched_split):
+    """Catalog ``templates: [...]`` carries paired_parent on synthetic entries
+    so the frontend can hide them from the standalone create-flow type tabs."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+
+    catalog = TemplateService().build_node_catalog()
+    by_key = {t["key"]: t for t in catalog["templates"]}
+    assert by_key["juniper-vmx__vcp"]["paired_parent"] == "juniper-vmx"
+    assert by_key["juniper-vmx__vfp"]["paired_parent"] == "juniper-vmx"
+
+
+def test_206_real_templates_have_paired_parent_none(patched_split):
+    """Non-synthetic (regular) catalog entries surface paired_parent: None."""
+    settings = patched_split
+    (settings.TEMPLATES_DIR / "qemu").mkdir()
+    (settings.TEMPLATES_DIR / "qemu" / "csr.yml").write_text(
+        "type: qemu\nname: CSR1000v\ncpu: 2\nram: 4096\nethernet: 2\nconsole_type: telnet\nicon_type: router\ncpulimit: 1\n"
+    )
+    catalog = TemplateService().build_node_catalog()
+    by_key = {t["key"]: t for t in catalog["templates"]}
+    assert by_key["csr"]["paired_parent"] is None
+
+
+def test_206_get_template_resolves_synthetic_paired_child(patched_split):
+    """get_template lookup must succeed for the synthetic key — required by
+    edit-mode image validation in update_node."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+
+    svc = TemplateService()
+    vcp = svc.get_template("qemu", "juniper-vmx__vcp")
+    assert vcp.key == "juniper-vmx__vcp"
+    assert vcp.paired_parent == "juniper-vmx"
+    # The synthetic template surfaces the child's declared image (single-entry).
+    images = svc.list_images("qemu", "juniper-vmx__vcp")
+    assert "vmx-vcp-22.4.qcow2" in images
+
+
+def test_206_validate_node_request_passes_for_synthetic_child(patched_split):
+    """validate_node_request — used by node creation/edit flows for image
+    validation against node.template — must accept the synthetic key + the
+    child's declared image. This is the path that broke pre-#206 when child
+    nodes carried the paired template key as ``template`` and image
+    validation 400'd because the paired template wasn't in the catalog."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+
+    svc = TemplateService()
+    template = svc.validate_node_request("qemu", "juniper-vmx__vcp", "vmx-vcp-22.4.qcow2")
+    assert template.paired_parent == "juniper-vmx"
+
+
+@pytest.mark.asyncio
+async def test_206_paired_create_writes_synthetic_template_key_on_children(patched_split):
+    """End-to-end: paired-create on the endpoint must store the synthetic
+    per-child template key on every child node, not the paired template key."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 200
+    nodes = response["data"]["nodes"]
+    by_name = {n["name"]: n for n in nodes}
+    assert by_name["vMX VCP"]["template"] == "juniper-vmx__vcp"
+    assert by_name["vMX VFP"]["template"] == "juniper-vmx__vfp"
+
+
+def test_206_synthetic_key_helper_is_stable(patched_split):
+    """synthetic_paired_child_key must produce the documented format and be
+    importable from app.services.template_service so callers (including
+    routers/labs.py and tests) can construct keys consistently."""
+    from app.services.template_service import synthetic_paired_child_key
+
+    assert synthetic_paired_child_key("juniper-vmx", "vcp") == "juniper-vmx__vcp"
+    assert synthetic_paired_child_key("paired-with-dashes", "child-x") == "paired-with-dashes__child-x"
+
+
+def test_206_paired_catalog_children_carry_synthetic_template_key(patched_split):
+    """The catalog's paired_templates[].children entries carry the synthetic
+    template_key so the frontend's paired-template "Will create" panel can
+    cross-reference the matching catalog entry for capabilities/extras
+    schema."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+
+    catalog = TemplateService().build_node_catalog()
+    assert len(catalog["paired_templates"]) == 1
+    paired = catalog["paired_templates"][0]
+    assert paired["key"] == "juniper-vmx"
+    by_id = {c["id"]: c for c in paired["children"]}
+    assert by_id["vcp"]["template_key"] == "juniper-vmx__vcp"
+    assert by_id["vfp"]["template_key"] == "juniper-vmx__vfp"
+
+
+# ---- #207 paired-template pre-flight validation -------------------------
+
+
+# Pre-#202-shape vMX paired template: no interface_naming.explicit per child,
+# vQFX-style ethernet=1 on the RE so em1 link target is out of range. This is
+# what the original importer (before commit 6acd72c) produced. Should fail
+# pre-flight under #207 and surface valid:false in the catalog.
+LEGACY_PRE_202_VMX_TEMPLATE = {
+    "schema": 1,
+    "id": "juniper-vmx",
+    "name": "Juniper vMX (legacy import)",
+    "vendor": "juniper",
+    "kind": "paired",
+    "nodes": [
+        {
+            "id": "vcp",
+            "name": "vMX VCP (legacy)",
+            "kind": "qemu",
+            "image": "vmx-vcp-22.4.qcow2",
+            "cpu": 1,
+            "ram": 2048,
+            "ethernet": 1,
+            "console": "serial",
+            # No interface_naming.explicit — this is the bug pre-#202 importer
+            # had. Generic Gi1 naming will be used at creation; fxp0/em0 link
+            # refs won't resolve.
+        },
+        {
+            "id": "vfp",
+            "name": "vMX VFP (legacy)",
+            "kind": "qemu",
+            "image": "vmx-vfp-22.4.qcow2",
+            "cpu": 3,
+            "ram": 4096,
+            "ethernet": 4,
+            "console": "serial",
+        },
+    ],
+    "links": [
+        {"from_node": "vcp", "from_iface": "fxp0", "to_node": "vfp", "to_iface": "em0"},
+    ],
+}
+
+
+def test_207_legacy_paired_template_flagged_invalid_in_catalog(patched_split, caplog):
+    """A pre-#202-shape paired template (no interface_naming.explicit on the
+    children) appears in the catalog but with valid:false + a clear
+    invalid_reason naming the missing interface."""
+    import logging
+
+    settings = patched_split
+    _seed_paired_template(settings, LEGACY_PRE_202_VMX_TEMPLATE)
+
+    with caplog.at_level(logging.WARNING, logger="nova-ve.template_service"):
+        catalog = TemplateService().build_node_catalog()
+
+    assert len(catalog["paired_templates"]) == 1
+    entry = catalog["paired_templates"][0]
+    assert entry["valid"] is False
+    assert entry["invalid_reason"] is not None
+    # The reason should name the unresolvable interface
+    assert "fxp0" in entry["invalid_reason"]
+    # And the WARNING log fired exactly once for this template
+    pre_flight_warnings = [
+        r for r in caplog.records if "pre-flight failed" in r.message
+    ]
+    assert len(pre_flight_warnings) == 1
+
+
+def test_207_valid_paired_template_marked_valid_in_catalog(patched_split):
+    """The properly-shaped vMX template (with interface_naming.explicit) gets
+    valid:true and invalid_reason:None."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+
+    catalog = TemplateService().build_node_catalog()
+    entry = catalog["paired_templates"][0]
+    assert entry["valid"] is True
+    assert entry["invalid_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_207_endpoint_returns_422_for_invalid_template(patched_split):
+    """POST /nodes/from-paired-template against an invalid (legacy-import-shape)
+    template returns 422 (operator-correctable) with the invalid_reason in
+    the message — not 500 (server error)."""
+    settings = patched_split
+    _seed_paired_template(settings, LEGACY_PRE_202_VMX_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 422, response
+    assert "fxp0" in response["message"]
+    assert "interface_naming.explicit" in response["message"]
+
+
+@pytest.mark.asyncio
+async def test_207_endpoint_still_works_for_valid_template(patched_split):
+    """Sanity: a valid paired template still creates 2 nodes + 1 link end-to-end."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 200, response
+    assert len(response["data"]["nodes"]) == 2
+    assert len(response["data"]["links"]) == 1
+
+
+def test_207_validate_helper_returns_none_on_valid(patched_split):
+    """The validate_paired_template helper is importable and returns None
+    when the template is fully resolvable."""
+    from app.services.template_service import validate_paired_template
+
+    assert validate_paired_template(VMX_PAIRED_TEMPLATE) is None
+
+
+def test_207_validate_helper_returns_reason_on_invalid(patched_split):
+    """The validate_paired_template helper returns a clear reason string
+    when a link references an unresolvable interface."""
+    from app.services.template_service import validate_paired_template
+
+    reason = validate_paired_template(LEGACY_PRE_202_VMX_TEMPLATE)
+    assert reason is not None
+    assert "fxp0" in reason
+    assert "interface_naming.explicit" in reason
+
+
+def test_207_validate_helper_returns_reason_for_unknown_child(patched_split):
+    """Pre-flight catches link refs to non-existent child ids, not just
+    interface names."""
+    from app.services.template_service import validate_paired_template
+
+    bad = {
+        "kind": "paired",
+        "nodes": [
+            {"id": "vcp", "kind": "qemu", "ethernet": 1,
+             "interface_naming": {"explicit": ["fxp0"]}},
+        ],
+        "links": [
+            {"from_node": "vcp", "from_iface": "fxp0",
+             "to_node": "ghost", "to_iface": "em0"},
+        ],
+    }
+    reason = validate_paired_template(bad)
+    assert reason is not None
+    assert "ghost" in reason
+
+
+def test_207_predictor_handles_interface_naming_format_string(patched_split):
+    """Architect review fix: the predictor must mirror runtime
+    _default_interfaces, which honors interface_naming.format (string
+    shape) — NOT just .explicit. Otherwise a paired template using format
+    gets mis-classified as invalid even though it instantiates correctly."""
+    from app.services.template_service import validate_paired_template
+
+    template = {
+        "kind": "paired",
+        "nodes": [
+            {"id": "a", "kind": "qemu", "ethernet": 2,
+             "interface_naming": {"format": "eth{n}"}},
+            {"id": "b", "kind": "qemu", "ethernet": 2,
+             "interface_naming": {"format": "eth{n}"}},
+        ],
+        "links": [
+            {"from_node": "a", "from_iface": "eth0",
+             "to_node": "b", "to_iface": "eth1"},
+        ],
+    }
+    # Pre-#207-fix this returned an "interface 'eth0' not in [Gi1, Gi2]" reason
+    # because the predictor only honored .explicit and fell back to Gi{n+1}.
+    assert validate_paired_template(template) is None
+
+
+def test_207_predictor_handles_interface_naming_format_list(patched_split):
+    """The predictor must also handle the pre-normalization list shape from
+    #179 (e.g. ``format: [\"fxp0\", \"ge-0/0/{n}\"]``) — it should join and
+    render the same way the runtime does."""
+    from app.services.template_service import validate_paired_template
+
+    template = {
+        "kind": "paired",
+        "nodes": [
+            {"id": "a", "kind": "qemu", "ethernet": 3,
+             "interface_naming": {"format": ["fxp0", "ge-0/0/{n}"]}},
+            {"id": "b", "kind": "qemu", "ethernet": 1,
+             "interface_naming": {"explicit": ["em0"]}},
+        ],
+        "links": [
+            # Link references the FIRST trailing-format port: index 1 → ge-0/0/0
+            {"from_node": "a", "from_iface": "ge-0/0/0",
+             "to_node": "b", "to_iface": "em0"},
+        ],
+    }
+    assert validate_paired_template(template) is None
+
+
+def test_207_predictor_format_string_still_catches_unresolvable(patched_split):
+    """A format-shape template that references an interface name OUTSIDE the
+    rendered set must still be flagged invalid (not silently passed)."""
+    from app.services.template_service import validate_paired_template
+
+    template = {
+        "kind": "paired",
+        "nodes": [
+            {"id": "a", "kind": "qemu", "ethernet": 2,
+             "interface_naming": {"format": "eth{n}"}},
+            {"id": "b", "kind": "qemu", "ethernet": 1,
+             "interface_naming": {"format": "eth{n}"}},
+        ],
+        "links": [
+            # eth5 doesn't exist — only eth0/eth1 are rendered.
+            {"from_node": "a", "from_iface": "eth5",
+             "to_node": "b", "to_iface": "eth0"},
+        ],
+    }
+    reason = validate_paired_template(template)
+    assert reason is not None
+    assert "eth5" in reason
+
+
+# ---- #208a paired-create holds lab_lock end-to-end ----------------------
+
+
+@pytest.mark.asyncio
+async def test_208a_paired_create_acquires_lab_lock_around_phases(patched_split, monkeypatch):
+    """The paired-create endpoint must acquire ``lab_lock`` exactly once around
+    the snapshot+node-creation+link-creation+restore window. We instrument the
+    lab_lock context manager and assert: (a) the outer paired-create lock was
+    acquired exactly once, (b) the inner LinkService.create_link did NOT
+    re-acquire it (would deadlock on Linux fcntl flock).
+    """
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    acquire_count = {"n": 0}
+
+    from app.services import lab_lock as lab_lock_module
+    real_lab_lock = lab_lock_module.lab_lock
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def counting_lab_lock(lab_id, labs_dir, timeout_s=5.0):
+        acquire_count["n"] += 1
+        with real_lab_lock(lab_id, labs_dir, timeout_s=timeout_s):
+            yield
+
+    # Patch the symbol everywhere the routers and services import it from.
+    monkeypatch.setattr("app.routers.labs.lab_lock", counting_lab_lock)
+    monkeypatch.setattr("app.services.link_service.lab_lock", counting_lab_lock)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 200, response
+    # Exactly one lab_lock acquisition for the entire paired-create flow.
+    # (Inner LinkService.create_link receives _lab_lock_held=True and skips its
+    # own lab_lock context.)
+    assert acquire_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_208a_no_deadlock_when_link_service_called_with_lab_lock_held(patched_split):
+    """Smoke: invoking link_service.create_link with _lab_lock_held=True from
+    inside an outer lab_lock must not block. Without the kwarg this would
+    block on the inner fcntl flock acquisition (LabLockTimeout after 5s)."""
+    import json
+    from app.services.lab_lock import lab_lock
+    from app.services.link_service import LinkService
+
+    settings = patched_split
+    # Seed a 2-node lab so the link has real endpoints to attach to.
+    lab_path = settings.LABS_DIR / "demo.json"
+    lab_path.write_text(json.dumps({
+        "schema": 2,
+        "id": "lab-208a",
+        "meta": {"name": "demo"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {
+            "1": {"id": 1, "name": "n1", "type": "qemu", "template": "csr",
+                  "image": "csr", "ethernet": 1, "console": "telnet",
+                  "interfaces": [{"index": 0, "name": "Gi1", "network_id": 0}]},
+            "2": {"id": 2, "name": "n2", "type": "qemu", "template": "csr",
+                  "image": "csr", "ethernet": 1, "console": "telnet",
+                  "interfaces": [{"index": 0, "name": "Gi1", "network_id": 0}]},
+        },
+        "networks": {},
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }))
+
+    link_service = LinkService()
+    # Hold outer lab_lock and call create_link with _lab_lock_held=True.
+    with lab_lock("demo.json", settings.LABS_DIR, timeout_s=2.0):
+        link_payload, network_payload, replayed = await link_service.create_link(
+            "demo.json",
+            {"node_id": 1, "interface_index": 0},
+            {"node_id": 2, "interface_index": 0},
+            _lab_lock_held=True,
+        )
+    # If the lab_lock had not been short-circuited the call would have raised
+    # LabLockTimeout before completing, so reaching this point IS the test.
+    assert link_payload is not None
+    assert replayed is False
+
+
+# ---- #208b multi-link partial-failure compensation ----------------------
+
+
+# Three-node paired template with TWO auto-links: a→b and a→c. When the
+# second link's creation fails, the first must be torn down before snapshot
+# restore so host-side attach work + implicit bridge are released.
+THREE_NODE_TWO_LINK_TEMPLATE = {
+    "schema": 1,
+    "id": "three-node-two-link",
+    "name": "Three-Node Test (2 links)",
+    "vendor": "synthetic",
+    "kind": "paired",
+    "nodes": [
+        {"id": "a", "name": "Node A", "kind": "qemu", "image": "img.qcow2",
+         "cpu": 1, "ram": 512, "ethernet": 2,
+         "interface_naming": {"explicit": ["eth0", "eth1"]}},
+        {"id": "b", "name": "Node B", "kind": "qemu", "image": "img.qcow2",
+         "cpu": 1, "ram": 512, "ethernet": 1,
+         "interface_naming": {"explicit": ["eth0"]}},
+        {"id": "c", "name": "Node C", "kind": "qemu", "image": "img.qcow2",
+         "cpu": 1, "ram": 512, "ethernet": 1,
+         "interface_naming": {"explicit": ["eth0"]}},
+    ],
+    "links": [
+        {"from_node": "a", "from_iface": "eth0", "to_node": "b", "to_iface": "eth0"},
+        {"from_node": "a", "from_iface": "eth1", "to_node": "c", "to_iface": "eth0"},
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_208b_compensates_first_link_when_second_fails(patched_split, monkeypatch):
+    """Multi-link paired-create: if link 2 fails, link 1's delete_link must
+    be called (with _lab_lock_held=True) before snapshot restore so the
+    implicit bridge + host-side attach work get torn down. Without
+    compensation, lab.json would revert but kernel state would persist."""
+    settings = patched_split
+    _seed_paired_template(settings, THREE_NODE_TWO_LINK_TEMPLATE, key="three-node-two-link")
+    _seed_empty_lab(settings)
+
+    from app.services.link_service import LinkService
+
+    real_create = LinkService.create_link
+    real_delete = LinkService.delete_link
+
+    create_calls = {"n": 0}
+    delete_args: list[tuple] = []
+    fake_first_link_id = "fake-first-link-id"
+
+    async def flaky_create_link(self, lab_path, from_endpoint, to_endpoint,
+                                 *, style_override=None, idempotency_key=None,
+                                 _lab_lock_held=False):
+        create_calls["n"] += 1
+        if create_calls["n"] == 1:
+            # Simulate a successful link creation; return a payload but DON'T
+            # actually mutate lab.json (that's not what this test is about).
+            return ({"id": fake_first_link_id, "from": from_endpoint,
+                     "to": {"network_id": 999}}, None, False)
+        # Second call fails — should trigger compensation of the first.
+        raise RuntimeError("simulated link 2 failure")
+
+    async def spy_delete_link(self, lab_path, link_id, *, _lab_lock_held=False):
+        delete_args.append((lab_path, link_id, _lab_lock_held))
+        # No-op success — the compensation contract is "best effort".
+        return (True, None)
+
+    monkeypatch.setattr(LinkService, "create_link", flaky_create_link)
+    monkeypatch.setattr(LinkService, "delete_link", spy_delete_link)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="three-node-two-link"),
+        current_user=_admin(),
+    )
+
+    assert response["code"] == 500, response
+    assert "simulated link 2 failure" in response["message"]
+    # Compensation: delete_link called once for the first (successful) link,
+    # with _lab_lock_held=True (we're inside the outer lab_lock).
+    assert len(delete_args) == 1, delete_args
+    _, comp_link_id, comp_held = delete_args[0]
+    assert comp_link_id == fake_first_link_id
+    assert comp_held is True
+
+    # Snapshot restore: lab.json has zero nodes, networks, links.
+    import json
+    lab_data = json.loads((settings.LABS_DIR / "demo.json").read_text())
+    assert lab_data["nodes"] == {}
+    assert lab_data["networks"] == {}
+    assert lab_data["links"] == []
+
+    # Restore real methods (paranoia for downstream tests, monkeypatch will
+    # do this automatically but be explicit).
+    monkeypatch.setattr(LinkService, "create_link", real_create)
+    monkeypatch.setattr(LinkService, "delete_link", real_delete)
+
+
+@pytest.mark.asyncio
+async def test_208b_compensation_failure_logged_but_does_not_block_restore(
+    patched_split, monkeypatch, caplog
+):
+    """If delete_link itself raises during compensation, the failure is
+    logged and snapshot restore still proceeds — leaving the lab in the
+    cleanest possible state (lab.json reverted, kernel state may need
+    manual cleanup but that's surfaced in logs)."""
+    import logging
+
+    settings = patched_split
+    _seed_paired_template(settings, THREE_NODE_TWO_LINK_TEMPLATE, key="three-node-two-link")
+    _seed_empty_lab(settings)
+
+    from app.services.link_service import LinkService
+
+    create_calls = {"n": 0}
+
+    async def flaky_create_link(self, lab_path, from_endpoint, to_endpoint,
+                                 *, style_override=None, idempotency_key=None,
+                                 _lab_lock_held=False):
+        create_calls["n"] += 1
+        if create_calls["n"] == 1:
+            return ({"id": "lid1", "from": from_endpoint, "to": {"network_id": 1}}, None, False)
+        raise RuntimeError("link 2 failed")
+
+    async def angry_delete_link(self, lab_path, link_id, *, _lab_lock_held=False):
+        raise RuntimeError("delete_link blew up")
+
+    monkeypatch.setattr(LinkService, "create_link", flaky_create_link)
+    monkeypatch.setattr(LinkService, "delete_link", angry_delete_link)
+
+    with caplog.at_level(logging.WARNING):
+        response = await labs.create_nodes_from_paired_template(
+            "demo.json",
+            NodeFromPairedTemplate(template_key="three-node-two-link"),
+            current_user=_admin(),
+        )
+
+    # Endpoint still returns 500 with the original error (not the compensation error).
+    assert response["code"] == 500
+    assert "link 2 failed" in response["message"]
+    # Compensation failure was logged but did NOT prevent snapshot restore.
+    comp_warnings = [r for r in caplog.records if "compensation delete_link" in r.message]
+    assert len(comp_warnings) == 1
+    # Snapshot restore still happened.
+    import json
+    lab_data = json.loads((settings.LABS_DIR / "demo.json").read_text())
+    assert lab_data["nodes"] == {}
+
+
+# ---- #208e error code mapping ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_208e_paired_iface_lookup_error_returns_422(patched_split, monkeypatch):
+    """When _PairedIfaceLookupError raises during the link-creation phase
+    (downstream of pre-flight, e.g. template was edited concurrently), the
+    endpoint returns 422 (template defect, operator can fix) — not 500."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    from app.routers import labs as labs_module
+
+    real_resolve = labs_module._resolve_iface_index
+
+    def angry_resolve(node, iface_name):
+        raise labs_module._PairedIfaceLookupError(
+            f"Simulated post-pre-flight defect: interface {iface_name!r} on "
+            f"node {node.get('name')!r} disappeared."
+        )
+
+    monkeypatch.setattr(labs_module, "_resolve_iface_index", angry_resolve)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 422, response
+    assert "interface lookup" in response["message"].lower()
+    monkeypatch.setattr(labs_module, "_resolve_iface_index", real_resolve)
+
+
+@pytest.mark.asyncio
+async def test_208e_duplicate_link_returns_409(patched_split, monkeypatch):
+    """When LinkService.create_link raises DuplicateLinkError, the endpoint
+    returns 409 (conflict, operator can resolve by removing the existing
+    link or picking a different template)."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    from app.services.link_service import LinkService, DuplicateLinkError
+
+    async def dupe_create_link(self, lab_path, from_endpoint, to_endpoint,
+                                *, style_override=None, idempotency_key=None,
+                                _lab_lock_held=False):
+        raise DuplicateLinkError({"id": "existing-link-id"})
+
+    monkeypatch.setattr(LinkService, "create_link", dupe_create_link)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 409, response
+    assert "conflict" in response["message"].lower() or "existing" in response["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_208e_link_contention_returns_409(patched_split, monkeypatch):
+    """Bounded-wait contention timeout (LinkContentionError) → 409, signaling
+    the operator can retry."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    from app.services.link_service import LinkService, LinkContentionError
+
+    async def contended_create_link(self, lab_path, from_endpoint, to_endpoint,
+                                     *, style_override=None, idempotency_key=None,
+                                     _lab_lock_held=False):
+        raise LinkContentionError("simulated mutex contention")
+
+    monkeypatch.setattr(LinkService, "create_link", contended_create_link)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 409, response
+    assert "concurrent" in response["message"].lower() or "blocked" in response["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_208a_release_ip_does_not_deadlock_when_lab_lock_held(patched_split):
+    """Architect review fix: NetworkService._release_ip used to acquire
+    lab_lock unconditionally — that's a latent deadlock when called from
+    inside paired-create's outer lab_lock (during compensation of an
+    IPAM-bearing link). With the architect-iter1 fix, _release_ip now
+    accepts _lab_lock_held=True and skips the inner acquisition.
+
+    This test directly exercises the deadlock-prone path: hold the outer
+    lab_lock, seed a network with a used IP, call _release_ip with
+    _lab_lock_held=True, assert it returns within the lab_lock timeout
+    (~5s) instead of timing out."""
+    import json
+    from app.services.lab_lock import lab_lock
+    from app.services.network_service import NetworkService
+
+    settings = patched_split
+    # Seed a network with an IPv4 ``runtime.used_ips`` so _release_ip's
+    # mutation path (the one that acquires lab_lock) is actually entered.
+    lab_path = settings.LABS_DIR / "demo.json"
+    lab_path.write_text(json.dumps({
+        "schema": 2,
+        "id": "lab-208a-ipam",
+        "meta": {"name": "demo"},
+        "viewport": {"x": 0, "y": 0, "zoom": 1.0},
+        "nodes": {},
+        "networks": {
+            "1": {
+                "id": 1,
+                "name": "n1",
+                "type": "linux_bridge",
+                "left": 0, "top": 0, "icon": "Bridge.png",
+                "width": 0, "style": "", "linkstyle": "", "color": "",
+                "label": "", "visibility": True, "implicit": False,
+                "smart": 0, "config": {"cidr": "10.0.0.0/24"},
+                "runtime": {"used_ips": ["10.0.0.5", "10.0.0.6"]},
+            },
+        },
+        "links": [],
+        "defaults": {"link_style": "orthogonal"},
+    }))
+
+    # Hold outer lab_lock and call _release_ip with _lab_lock_held=True.
+    # If the kwarg isn't honored the call would block on inner fcntl flock
+    # and hit LabLockTimeout (default 5s) raising LabLockTimeout.
+    with lab_lock("demo.json", settings.LABS_DIR, timeout_s=2.0):
+        removed = NetworkService()._release_ip(
+            "demo.json", 1, "10.0.0.5", _lab_lock_held=True
+        )
+    assert removed is True
+    # The IP was actually removed.
+    after = json.loads(lab_path.read_text())
+    assert after["networks"]["1"]["runtime"]["used_ips"] == ["10.0.0.6"]
+
+
+@pytest.mark.asyncio
+async def test_208e_unexpected_exception_still_returns_500(patched_split, monkeypatch):
+    """Exception classes outside the documented mapping (operator-meaningful
+    error subset) keep returning 500 so they show up in error monitoring as
+    actual server errors needing investigation."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    from app.services.link_service import LinkService
+
+    async def angry_create_link(self, lab_path, from_endpoint, to_endpoint,
+                                 *, style_override=None, idempotency_key=None,
+                                 _lab_lock_held=False):
+        raise RuntimeError("filesystem went on holiday")
+
+    monkeypatch.setattr(LinkService, "create_link", angry_create_link)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 500, response
+    assert "filesystem" in response["message"]
+

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -467,6 +467,34 @@ def test_206_synthetic_key_helper_is_stable(patched_split):
     assert synthetic_paired_child_key("paired-with-dashes", "child-x") == "paired-with-dashes__child-x"
 
 
+@pytest.mark.asyncio
+async def test_206_synthetic_child_key_rejected_by_single_node_endpoint(patched_split):
+    """Codex-iter2 fix: POST /nodes/from-template must reject synthetic
+    per-child keys (paired_parent set) with 400 + a pointer to the paired
+    endpoint. Pre-fix the route fell through to NodeCreate construction and
+    raised an uncaught Pydantic ValidationError when the child's console_type
+    (e.g. ``serial`` for Juniper) violated NodeCreate.console's Literal.
+    """
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_node_from_template(
+        "demo.json",
+        NodeFromTemplate(
+            template_type="qemu",
+            template_key="juniper-vmx__vcp",  # synthetic child key
+            name="x",
+            image="vmx-vcp-22.4.qcow2",
+        ),
+        current_user=_admin(),
+    )
+    assert response["code"] == 400, response
+    assert "synthetic" in response["message"].lower()
+    assert "juniper-vmx" in response["message"]
+    assert "from-paired-template" in response["message"]
+
+
 def test_206_paired_catalog_children_carry_synthetic_template_key(patched_split):
     """The catalog's paired_templates[].children entries carry the synthetic
     template_key so the frontend's paired-template "Will create" panel can

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -1185,6 +1185,63 @@ async def test_208a_release_ip_does_not_deadlock_when_lab_lock_held(patched_spli
 
 
 @pytest.mark.asyncio
+async def test_208iter3_node_runtime_error_returns_422(patched_split, monkeypatch):
+    """``LinkService.create_link`` re-raises ``NodeRuntimeError`` from
+    ``_hot_attach_running_endpoints`` when the runtime refuses a hot-attach.
+    The single-node /links route maps that to 422; this test enforces that
+    the paired route does the same so the two routes don't drift (Codex
+    re-review finding)."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    from app.services.link_service import LinkService
+    from app.services.node_runtime_service import NodeRuntimeError
+
+    async def attach_refused(self, lab_path, from_endpoint, to_endpoint,
+                              *, style_override=None, idempotency_key=None,
+                              _lab_lock_held=False):
+        raise NodeRuntimeError("hot-attach refused: node not running")
+
+    monkeypatch.setattr(LinkService, "create_link", attach_refused)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 422, response
+    assert "hot-attach" in response["message"]
+
+
+@pytest.mark.asyncio
+async def test_208iter3_host_net_error_returns_422(patched_split, monkeypatch):
+    """Same path for ``host_net.HostNetError`` (kernel-side bridge/veth/TAP
+    failure during hot-attach)."""
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    from app.services import host_net
+    from app.services.link_service import LinkService
+
+    async def host_net_failed(self, lab_path, from_endpoint, to_endpoint,
+                               *, style_override=None, idempotency_key=None,
+                               _lab_lock_held=False):
+        raise host_net.HostNetError("bridge_add: permission denied")
+
+    monkeypatch.setattr(LinkService, "create_link", host_net_failed)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 422, response
+    assert "host-net" in response["message"]
+
+
+@pytest.mark.asyncio
 async def test_208e_unexpected_exception_still_returns_500(patched_split, monkeypatch):
     """Exception classes outside the documented mapping (operator-meaningful
     error subset) keep returning 500 so they show up in error monitoring as
@@ -1368,6 +1425,37 @@ def test_208iter3_validate_paired_template_flags_bad_cpu(patched_split):
     reason_cpulimit = validate_paired_template(bad_cpulimit)
     assert reason_cpulimit is not None
     assert "cpulimit" in reason_cpulimit
+
+
+# ---- #206 codex-iter3: NodeUpdate.console accepts "serial" -------------
+
+
+def test_206iter3_node_update_accepts_serial_console():
+    """Paired-template Juniper children persist ``console: "serial"``. The
+    edit modal always re-submits ``console`` along with the rest of the form,
+    so before this fix saving an unchanged paired child would 422 on
+    ``NodeUpdate.console`` Literal validation. Verify ``serial`` round-trips
+    cleanly through the schema now."""
+    from app.schemas.node import NodeUpdate
+
+    update = NodeUpdate(console="serial")
+    assert update.console == "serial"
+
+    # Other valid values still accepted.
+    for v in ("telnet", "vnc", "rdp"):
+        assert NodeUpdate(console=v).console == v
+
+
+def test_206iter3_node_update_rejects_unknown_console():
+    """Widening NodeUpdate.console to allow ``serial`` must NOT open the
+    door to arbitrary console types — anything outside the four-value enum
+    still 422s."""
+    import pydantic
+
+    from app.schemas.node import NodeUpdate
+
+    with pytest.raises(pydantic.ValidationError):
+        NodeUpdate(console="ssh")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -717,6 +717,70 @@ def test_207_predictor_handles_interface_naming_format_list(patched_split):
     assert validate_paired_template(template) is None
 
 
+def test_207_predictor_overlays_explicit_onto_kind_default_base(patched_split):
+    """Codex-iter2 fix: when interface_naming.explicit is shorter than
+    ethernet count, runtime overlays explicit onto a kind-default base
+    (qemu→Gi{n+1}, others→eth{n}) at positions 0..len(explicit)-1. The
+    predictor must mirror this — pre-fix it returned just the explicit
+    list and wrongly rejected links to the un-overlaid trailing
+    interfaces.
+    """
+    from app.services.template_service import validate_paired_template
+
+    # qemu child: ethernet=2, explicit=["mgmt0"] → ["mgmt0", "Gi2"]
+    template = {
+        "kind": "paired",
+        "nodes": [
+            {"id": "a", "kind": "qemu", "ethernet": 2,
+             "interface_naming": {"explicit": ["mgmt0"]}},
+            {"id": "b", "kind": "qemu", "ethernet": 1,
+             "interface_naming": {"explicit": ["mgmt0"]}},
+        ],
+        "links": [
+            # Link references the runtime-overlaid trailing iface "Gi2"
+            {"from_node": "a", "from_iface": "Gi2",
+             "to_node": "b", "to_iface": "mgmt0"},
+        ],
+    }
+    assert validate_paired_template(template) is None
+
+
+def test_207_predictor_overlay_matches_runtime_for_docker_kind(patched_split):
+    """Same overlay semantics for non-qemu kinds (eth{n} base)."""
+    from app.services.template_service import validate_paired_template
+
+    template = {
+        "kind": "paired",
+        "nodes": [
+            {"id": "a", "kind": "docker", "ethernet": 3,
+             "interface_naming": {"explicit": ["mgmt0", "data0"]}},
+            {"id": "b", "kind": "docker", "ethernet": 1,
+             "interface_naming": {"explicit": ["mgmt0"]}},
+        ],
+        "links": [
+            # Links target overlaid name (mgmt0), explicit-name (data0),
+            # and the un-overlaid base (eth2).
+            {"from_node": "a", "from_iface": "data0", "to_node": "b", "to_iface": "mgmt0"},
+        ],
+    }
+    assert validate_paired_template(template) is None
+    # And eth2 (the un-overlaid trailing index) should also resolve:
+    template2 = dict(template)
+    template2["links"] = [
+        {"from_node": "a", "from_iface": "eth2", "to_node": "b", "to_iface": "mgmt0"},
+    ]
+    assert validate_paired_template(template2) is None
+
+
+def test_207_predictor_overlay_preserves_runtime_match_for_full_explicit(patched_split):
+    """Sanity: when explicit covers the full ethernet count (the existing
+    juniper-vmx shape), the overlay produces the explicit list verbatim."""
+    from app.services.template_service import validate_paired_template
+
+    # Same as VMX_PAIRED_TEMPLATE shape (vfp explicit = 4 names, ethernet=4)
+    assert validate_paired_template(VMX_PAIRED_TEMPLATE) is None
+
+
 def test_207_predictor_format_string_still_catches_unresolvable(patched_split):
     """A format-shape template that references an interface name OUTSIDE the
     rendered set must still be flagged invalid (not silently passed)."""

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -1210,3 +1210,94 @@ async def test_208e_unexpected_exception_still_returns_500(patched_split, monkey
     assert response["code"] == 500, response
     assert "filesystem" in response["message"]
 
+
+# ---- #208-MEDIUM: bad child scalars surface as 422 (template defect) ----
+
+
+@pytest.mark.asyncio
+async def test_208medium_bad_ethernet_scalar_returns_422_via_preflight(patched_split):
+    """``ethernet: "not-an-int"`` is a template defect, not a server bug.
+    The pre-flight predictor casts ethernet to int; without the #208-MEDIUM
+    guard, the resulting ValueError propagates uncaught from
+    validate_paired_template back to the FastAPI handler → 500. Now it
+    surfaces as a reason string and the endpoint returns 422 with a
+    fix-the-template message."""
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad["nodes"][1]["ethernet"] = "not-an-int"
+    _seed_paired_template(settings, bad)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 422, response
+    assert "malformed scalar" in response["message"]
+    assert "ethernet" in response["message"]
+
+
+@pytest.mark.asyncio
+async def test_208medium_bad_cpu_scalar_returns_422_via_node_phase(patched_split):
+    """``cpu``/``ram``/``cpulimit`` are not consulted by the pre-flight
+    predictor — they only blow up in ``_build_paired_child_payload`` during
+    the node-creation phase. The new ``(ValueError, TemplateError)`` handler
+    in that phase maps the failure to 422 instead of 500."""
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad["nodes"][0]["cpu"] = "not-an-int"
+    _seed_paired_template(settings, bad)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 422, response
+    assert "malformed child data" in response["message"]
+
+
+@pytest.mark.asyncio
+async def test_208medium_bad_ram_scalar_returns_422_via_node_phase(patched_split):
+    """Same path as bad cpu — verifies ram is also covered by the
+    node-creation phase exception mapping."""
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad["nodes"][0]["ram"] = "huge"
+    _seed_paired_template(settings, bad)
+    _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 422, response
+    assert "malformed child data" in response["message"]
+
+
+@pytest.mark.asyncio
+async def test_208medium_node_phase_422_path_rolls_back_lab(patched_split):
+    """Bad-scalar 422 must still trigger snapshot restore — partial node
+    payloads written before the failing child must not survive in lab.json."""
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    # Make the SECOND child fail so the first has already been written into
+    # the in-memory ``nodes_map`` before the ValueError fires.
+    bad["nodes"][1]["cpu"] = "not-an-int"
+    _seed_paired_template(settings, bad)
+    lab_path = _seed_empty_lab(settings)
+
+    response = await labs.create_nodes_from_paired_template(
+        "demo.json",
+        NodeFromPairedTemplate(template_key="juniper-vmx"),
+        current_user=_admin(),
+    )
+    assert response["code"] == 422, response
+
+    # Snapshot restore: lab.json must be back to empty nodes/links.
+    restored = json.loads(lab_path.read_text())
+    assert restored.get("nodes") == {}, restored
+    assert restored.get("links") == [], restored

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -1217,11 +1217,8 @@ async def test_208e_unexpected_exception_still_returns_500(patched_split, monkey
 @pytest.mark.asyncio
 async def test_208medium_bad_ethernet_scalar_returns_422_via_preflight(patched_split):
     """``ethernet: "not-an-int"`` is a template defect, not a server bug.
-    The pre-flight predictor casts ethernet to int; without the #208-MEDIUM
-    guard, the resulting ValueError propagates uncaught from
-    validate_paired_template back to the FastAPI handler → 500. Now it
-    surfaces as a reason string and the endpoint returns 422 with a
-    fix-the-template message."""
+    The pre-flight scalar check (#208 codex-iter3) returns a reason string
+    so the endpoint returns 422 with a fix-the-template message."""
     settings = patched_split
     bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
     bad["nodes"][1]["ethernet"] = "not-an-int"
@@ -1234,16 +1231,15 @@ async def test_208medium_bad_ethernet_scalar_returns_422_via_preflight(patched_s
         current_user=_admin(),
     )
     assert response["code"] == 422, response
-    assert "malformed scalar" in response["message"]
     assert "ethernet" in response["message"]
+    assert "integer" in response["message"]
 
 
 @pytest.mark.asyncio
-async def test_208medium_bad_cpu_scalar_returns_422_via_node_phase(patched_split):
-    """``cpu``/``ram``/``cpulimit`` are not consulted by the pre-flight
-    predictor — they only blow up in ``_build_paired_child_payload`` during
-    the node-creation phase. The new ``(ValueError, TemplateError)`` handler
-    in that phase maps the failure to 422 instead of 500."""
+async def test_208medium_bad_cpu_scalar_returns_422_via_preflight(patched_split):
+    """``cpu`` is now scalar-validated by ``validate_paired_template`` at
+    pre-flight (#208 codex-iter3); endpoint returns 422 before the node
+    phase even runs."""
     settings = patched_split
     bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
     bad["nodes"][0]["cpu"] = "not-an-int"
@@ -1256,13 +1252,13 @@ async def test_208medium_bad_cpu_scalar_returns_422_via_node_phase(patched_split
         current_user=_admin(),
     )
     assert response["code"] == 422, response
-    assert "malformed child data" in response["message"]
+    assert "cpu" in response["message"]
+    assert "integer" in response["message"]
 
 
 @pytest.mark.asyncio
-async def test_208medium_bad_ram_scalar_returns_422_via_node_phase(patched_split):
-    """Same path as bad cpu — verifies ram is also covered by the
-    node-creation phase exception mapping."""
+async def test_208medium_bad_ram_scalar_returns_422_via_preflight(patched_split):
+    """Same path as bad cpu — covers the ram scalar."""
     settings = patched_split
     bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
     bad["nodes"][0]["ram"] = "huge"
@@ -1275,7 +1271,103 @@ async def test_208medium_bad_ram_scalar_returns_422_via_node_phase(patched_split
         current_user=_admin(),
     )
     assert response["code"] == 422, response
-    assert "malformed child data" in response["message"]
+    assert "ram" in response["message"]
+    assert "integer" in response["message"]
+
+
+# ---- #208 codex-iter3: catalog-build paths fault-tolerate bad scalars --
+
+
+def test_208iter3_node_catalog_survives_bad_paired_child_scalar(patched_split):
+    """A paired template with ``cpu: "not-an-int"`` on one child must not
+    crash ``build_node_catalog()`` — Codex re-review showed the int casts in
+    ``_build_paired_catalog`` and ``_load_synthetic_paired_child_templates``
+    propagated ValueError out of the catalog endpoint, taking the modal down
+    before the new ``valid:false`` banner ever rendered."""
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad["nodes"][0]["cpu"] = "not-an-int"
+    _seed_paired_template(settings, bad)
+
+    service = TemplateService()
+    catalog = service.build_node_catalog()
+    paired_entries = catalog["paired_templates"]
+    assert len(paired_entries) == 1
+    entry = paired_entries[0]
+    assert entry["valid"] is False
+    assert entry["invalid_reason"] is not None
+    assert "cpu" in entry["invalid_reason"]
+
+
+def test_208iter3_synthetic_child_load_skips_broken_child(patched_split, caplog):
+    """A child with a busted ``interface_naming`` block (raises TemplateError
+    via ``_validate_interface_naming``) must not crash the catalog load. The
+    other children still appear; only the broken child is skipped with a
+    warning log."""
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    # ``interface_naming`` must be an object — handing it a list trips
+    # _validate_interface_naming → TemplateError, which the new try/except
+    # catches and converts into skip-but-log.
+    bad["nodes"][0]["interface_naming"] = ["this", "shape", "is", "wrong"]
+    _seed_paired_template(settings, bad)
+
+    service = TemplateService()
+    with caplog.at_level("WARNING"):
+        templates = service._load_synthetic_paired_child_templates()
+
+    keys = {t.key for t in templates}
+    assert "juniper-vmx__vfp" in keys
+    assert "juniper-vmx__vcp" not in keys
+    assert any(
+        "Synthetic paired-child template skipped" in rec.message for rec in caplog.records
+    )
+
+
+def test_208iter3_synthetic_child_load_uses_safe_default_for_bad_scalar(patched_split):
+    """Bad scalars on a synthetic child don't take the catalog down — the
+    template's parent paired entry already gets ``valid:false`` (via
+    ``validate_paired_template``), and the synthetic child loads with a
+    safe default. Together they keep the catalog endpoint serving while
+    surfacing the real defect to the operator."""
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad["nodes"][0]["cpu"] = "not-an-int"
+    _seed_paired_template(settings, bad)
+
+    service = TemplateService()
+    templates = service._load_synthetic_paired_child_templates()
+    by_key = {t.key: t for t in templates}
+    # Both children still load — the bad scalar defaults to 1, but the
+    # operator-facing signal is the parent paired entry's valid:false.
+    assert "juniper-vmx__vcp" in by_key
+    assert by_key["juniper-vmx__vcp"].cpu == 1
+
+
+def test_208iter3_validate_paired_template_flags_bad_cpu(patched_split):
+    """``validate_paired_template`` returns a reason for any non-int scalar
+    field on any child — covers cpu/ram/ethernet/cpulimit, not just the
+    ethernet that was already covered via the predictor crash path."""
+    from app.services.template_service import validate_paired_template
+
+    bad_cpu = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad_cpu["nodes"][1]["cpu"] = "huge"
+    reason_cpu = validate_paired_template(bad_cpu)
+    assert reason_cpu is not None
+    assert "cpu" in reason_cpu
+    assert "integer" in reason_cpu
+
+    bad_ram = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad_ram["nodes"][0]["ram"] = "lots"
+    reason_ram = validate_paired_template(bad_ram)
+    assert reason_ram is not None
+    assert "ram" in reason_ram
+
+    bad_cpulimit = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad_cpulimit["nodes"][0]["cpulimit"] = "max"
+    reason_cpulimit = validate_paired_template(bad_cpulimit)
+    assert reason_cpulimit is not None
+    assert "cpulimit" in reason_cpulimit
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -1401,6 +1401,50 @@ def test_208iter3_synthetic_child_load_uses_safe_default_for_bad_scalar(patched_
     assert by_key["juniper-vmx__vcp"].cpu == 1
 
 
+def test_207iter3_predictor_normalizes_unsupported_kind_to_qemu(patched_split):
+    """Codex re-review caught predictor/runtime drift on unsupported child
+    kinds. Runtime ``_build_paired_child_payload`` coerces any kind outside
+    ``{qemu, docker, iol, dynamips}`` to ``qemu`` (→ ``Gi{n+1}`` fallback
+    naming). Pre-fix predictor treated every non-qemu kind as ``eth{n}``,
+    so a ``kind:"weirdkind"`` child linked via ``Gi1`` was rejected by
+    pre-flight while runtime would have built ``Gi1`` cleanly. Verify the
+    pre-flight reason matches runtime now."""
+    from app.services.template_service import validate_paired_template
+
+    weird_template = {
+        "schema": 1,
+        "id": "weird-paired",
+        "name": "Weird paired",
+        "vendor": "test",
+        "kind": "paired",
+        "nodes": [
+            {"id": "a", "name": "A", "kind": "weirdkind", "image": "x.qcow2",
+             "ethernet": 2, "console": "telnet"},
+            {"id": "b", "name": "B", "kind": "qemu", "image": "y.qcow2",
+             "ethernet": 1, "console": "telnet"},
+        ],
+        "links": [
+            # ``Gi1`` is the qemu-fallback name for ethernet index 0 on a
+            # weirdkind child (which runtime coerces to qemu).
+            {"from_node": "a", "from_iface": "Gi1", "to_node": "b", "to_iface": "Gi1"},
+        ],
+    }
+
+    reason = validate_paired_template(weird_template)
+    assert reason is None, f"Predictor drifted from runtime — got reason: {reason}"
+
+
+def test_207iter3_predictor_blank_kind_falls_back_to_qemu():
+    """Empty/None kind also normalizes to qemu (→ Gi*), same as runtime."""
+    from app.services.template_service import _paired_child_iface_names
+
+    blank = {"ethernet": 2, "kind": ""}
+    assert _paired_child_iface_names(blank) == ["Gi1", "Gi2"]
+
+    missing = {"ethernet": 1}
+    assert _paired_child_iface_names(missing) == ["Gi1"]
+
+
 def test_208iter3_validate_paired_template_flags_bad_cpu(patched_split):
     """``validate_paired_template`` returns a reason for any non-int scalar
     field on any child — covers cpu/ram/ethernet/cpulimit, not just the

--- a/frontend/src/lib/components/canvas/NodeConfigModal.svelte
+++ b/frontend/src/lib/components/canvas/NodeConfigModal.svelte
@@ -725,6 +725,9 @@
                   <option value="telnet">telnet</option>
                   <option value="vnc">vnc</option>
                   <option value="rdp">rdp</option>
+                  {#if consoleMode === 'serial'}
+                    <option value="serial">serial (paired-template)</option>
+                  {/if}
                 </select>
               </label>
             </div>

--- a/frontend/src/lib/components/canvas/NodeConfigModal.svelte
+++ b/frontend/src/lib/components/canvas/NodeConfigModal.svelte
@@ -125,7 +125,14 @@
   }
 
   function templatesForType(type: NodeTypeKey): NodeCatalogTemplate[] {
-    return (catalog?.templates ?? []).filter((template) => template.type === type);
+    // #206 — exclude synthetic paired-child entries (paired_parent set). They
+    // exist in the catalog so node.template lookups in edit mode + capability
+    // gates can resolve them, but they must not surface as standalone choices
+    // in the create-flow type tabs (operators reach paired children only via
+    // the paired-template panel).
+    return (catalog?.templates ?? []).filter(
+      (template) => template.type === type && !template.paired_parent
+    );
   }
 
   function pairedTemplates(): NodeCatalogPairedTemplate[] {
@@ -361,7 +368,10 @@
   }
 
   function submitForm() {
-    if (interfaceNamingError) return;
+    // #208c — interfaceNamingError gates only the single-node form. The
+    // paired-template path doesn't surface the freeform interface-naming
+    // input, so a stale validation error there must NOT block submission.
+    if (!pairedActive && interfaceNamingError) return;
     if (mode === 'edit' && node) {
       dispatch('submit', {
         mode: 'edit',
@@ -551,8 +561,8 @@
               <div class="rounded-2xl border border-purple-500/30 bg-purple-500/5 p-4">
                 <div class="flex flex-wrap items-center justify-between gap-2">
                   <div>
-                    <div class="text-[10px] uppercase tracking-[0.06em] text-purple-300">Paired vendor templates</div>
-                    <div class="mt-0.5 text-xs text-slate-400">Multi-VM appliances (vMX, vQFX) instantiated as a group with auto-links.</div>
+                    <div class="text-[10px] uppercase tracking-[0.06em] text-purple-300">Multi-node templates</div>
+                    <div class="mt-0.5 text-xs text-slate-400">Templates that instantiate multiple nodes plus auto-links as a single group.</div>
                   </div>
                   <label class="flex items-center gap-2 text-xs text-slate-300">
                     <select
@@ -985,7 +995,7 @@
             </button>
             <button
               type="submit"
-              disabled={submitting || (!pairedActive && (!selectedTemplate || !image)) || !!interfaceNamingError}
+              disabled={submitting || (!pairedActive && (!selectedTemplate || !image)) || (!pairedActive && !!interfaceNamingError)}
               class="rounded-full border border-blue-500/40 bg-blue-500/15 px-4 py-2 text-sm text-blue-100 transition hover:bg-blue-500/25 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {#if submitting}

--- a/frontend/src/lib/components/canvas/NodeConfigModal.svelte
+++ b/frontend/src/lib/components/canvas/NodeConfigModal.svelte
@@ -571,8 +571,9 @@
                     >
                       <option value="">— Single node —</option>
                       {#each visiblePairedTemplates as paired}
-                        <option value={paired.key}>
-                          {paired.name} [{paired.child_count} nodes / {paired.link_count} link{paired.link_count === 1 ? '' : 's'}]
+                        {@const invalid = paired.valid === false}
+                        <option value={paired.key} disabled={invalid}>
+                          {paired.name} [{paired.child_count} nodes / {paired.link_count} link{paired.link_count === 1 ? '' : 's'}]{invalid ? ' — invalid (needs re-import)' : ''}
                         </option>
                       {/each}
                     </select>
@@ -581,6 +582,12 @@
 
                 {#if selectedPairedTemplate}
                   <div class="mt-4 space-y-3">
+                    {#if selectedPairedTemplate.valid === false}
+                      <div class="rounded-xl border border-red-500/40 bg-red-500/10 p-3">
+                        <div class="text-[10px] uppercase tracking-[0.06em] text-red-300">Template invalid — cannot instantiate</div>
+                        <div class="mt-1 text-xs text-red-200">{selectedPairedTemplate.invalid_reason ?? 'Template failed pre-flight validation; re-import the source.'}</div>
+                      </div>
+                    {/if}
                     <div class="rounded-xl border border-slate-800 bg-slate-950/60 p-3">
                       <div class="text-[10px] uppercase tracking-[0.06em] text-slate-500">Will create</div>
                       <ul class="mt-2 space-y-1.5 text-xs text-slate-200">
@@ -995,7 +1002,7 @@
             </button>
             <button
               type="submit"
-              disabled={submitting || (!pairedActive && (!selectedTemplate || !image)) || (!pairedActive && !!interfaceNamingError)}
+              disabled={submitting || (!pairedActive && (!selectedTemplate || !image)) || (!pairedActive && !!interfaceNamingError) || (pairedActive && selectedPairedTemplate?.valid === false)}
               class="rounded-full border border-blue-500/40 bg-blue-500/15 px-4 py-2 text-sm text-blue-100 transition hover:bg-blue-500/25 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {#if submitting}

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -292,6 +292,13 @@ export interface NodeCatalogTemplate {
   icon_options: string[];
   extras_schema?: NodeCatalogExtraField[];
   capabilities?: TemplateCapabilities;
+  /**
+   * #206 — when set, this template entry was synthesized from a paired
+   * template's child block (key shape ``<paired_parent>__<child_id>``).
+   * Frontends should hide these from the standalone create-flow type-tab
+   * picker but still resolve them by key for edit-mode + capability lookups.
+   */
+  paired_parent?: string | null;
 }
 
 export interface NodeCatalogPairedChild {
@@ -302,6 +309,10 @@ export interface NodeCatalogPairedChild {
   cpu: number;
   ram: number;
   ethernet: number;
+  /** #206 — synthetic template key (`<paired_parent>__<child_id>`) the child
+   *  node carries on its `template` field once instantiated. Lets callers
+   *  cross-reference the matching catalog entry for capabilities / extras. */
+  template_key?: string;
 }
 
 export interface NodeCatalogPairedLink {
@@ -319,6 +330,12 @@ export interface NodeCatalogPairedTemplate {
   link_count: number;
   children: NodeCatalogPairedChild[];
   links: NodeCatalogPairedLink[];
+  /** #207 — false when the template fails pre-flight (link references an
+   *  interface name no child will expose, e.g. pre-#202 imports without
+   *  ``interface_naming.explicit``). Endpoint returns 422 in that case. */
+  valid?: boolean;
+  /** #207 — human-readable reason when valid is false. */
+  invalid_reason?: string | null;
 }
 
 export interface NodeCatalog {

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -212,7 +212,7 @@ export interface NodeData {
   type: 'qemu' | 'docker' | 'iol' | 'dynamips';
   template: string;
   image: string;
-  console: 'telnet' | 'vnc' | 'rdp';
+  console: 'telnet' | 'vnc' | 'rdp' | 'serial';
   status: 0 | 2;
   transientStatus?: 'starting' | 'stopping';
   delay: number;
@@ -252,7 +252,7 @@ export interface NodeCatalogDefaults {
   cpu: number;
   ram: number;
   ethernet: number;
-  console_type: 'telnet' | 'vnc' | 'rdp';
+  console_type: 'telnet' | 'vnc' | 'rdp' | 'serial';
   delay: number;
   cpulimit: number;
   extras?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Closes **#206**, **#207**, **#208** — addresses every Codex critic finding against the paired vMX/vQFX picker shipped in #204.

PRD lived at \`.omc/prd.json\` (7 user stories, all \`passes: true\`); progress log at \`.omc/progress.txt\`. Reviewer pass: architect (opus) returned ITERATE; both critical fixes landed on this branch.

## What's in the PR

### #206 — Real per-child template identity (priority:high)

\`TemplateService\` now synthesises one \`TemplateDefinition\` per paired-template child, keyed \`<paired_key>__<child_id>\` (e.g. \`juniper-vmx__vcp\`). Surfaced through \`_load_templates\` → \`list_templates\` / \`get_template\` / \`build_node_catalog\` with a \`paired_parent\` flag. \`list_images\` short-circuits for paired_parent entries to return the child's declared image (the substring-match scan would not match e.g. \`vmx-vcp-22.4.qcow2\` against template name \"vMX VCP\").

\`_build_paired_child_payload\` writes the synthetic key on each child node so edit-mode image validation, capability gates, and the frontend modal \`templateForId\` lookup all resolve cleanly. Frontend \`templatesForType\` filters paired-parent entries out of the standalone create-flow type tabs while leaving them resolvable for edit + capability gates.

### #207 — Pre-flight validation for paired imports (priority:high)

New \`validate_paired_template(data) -> str | None\` predicts each child's runtime interface name set (mirrors \`_default_interfaces\` priority order: \`interface_naming.explicit\` → \`format\` string → \`format\` list (#179 pre-normalization) → kind-based \`Gi{n+1}\`/\`eth{n}\` fallback) and resolves every link's \`from_iface\`/\`to_iface\` against it. \`_build_paired_catalog\` calls the validator and surfaces \`valid: bool\` + \`invalid_reason: str | null\` per entry; emits a single WARNING log per invalid template at load time.

The endpoint pre-flights before any mutation and returns 422 (operator-correctable) instead of 500 with the invalid_reason in the message.

### #208 — Robustness bundle (priority:medium)

- **208a:** \`create_nodes_from_paired_template\` wraps snapshot + node creation + link creation + restore in a single \`lab_lock\` so concurrent writers cannot be silently clobbered by snapshot restore. \`LinkService.create_link\`, \`LinkService.delete_link\`, and \`NetworkService._release_ip\` all accept \`_lab_lock_held=True\` and use \`nullcontext()\` instead of re-acquiring the (non-reentrant) per-lab fcntl flock.
- **208b:** Multi-link partial-failure compensation. The endpoint tracks every successful \`link_service.create_link\` return and walks the list in reverse calling \`delete_link(..., _lab_lock_held=True)\` before snapshot restore so host-side attach work and implicit bridges are torn down. Compensation failures are logged but do not block restore.
- **208c:** Frontend paired-template submit no longer blocked by stale single-node \`interfaceNamingError\`; \`submitForm\` and the disabled-button rule both gate that check on \`!pairedActive\`.
- **208d:** Paired-template panel heading changed from \"Paired vendor templates\" / \"vMX, vQFX...\" to \"Multi-node templates\" / generic copy. The remaining vendor name in the modal is inside the operator-facing \`INTERFACE_NAMING_PRESETS\` array (a UX preset menu), not template-data leakage.
- **208e:** Endpoint exception handler maps \`_PairedIfaceLookupError\` → 422, \`DuplicateLinkError\` → 409, \`LinkContentionError\` → 409, everything else → 500. All paths still trigger compensation + snapshot restore.

### Architect-iter1 fixes

Folded in two architect-flagged corrections:

1. \`_paired_child_iface_names\` now mirrors the runtime priority order (\`explicit\` → \`format\`-string → \`format\`-list → kind-based default) instead of only honoring \`.explicit\`. Pre-fix, any paired template using \`format:\` would be misclassified valid:false and 422'd at the endpoint despite instantiating correctly.
2. \`network_service._release_ip\` now accepts \`_lab_lock_held\` so paired-create compensation against IPAM-bearing links does not deadlock on the inner per-lab fcntl flock. Latent today (paired-create only does node↔node implicit bridges with no IPAM) but real for any future template attaching to an existing IPAM network.

### Deslop pass

Extracted \`TemplateService._iter_paired_user_templates() -> Iterator[(Path, dict)]\` shared iterator. Three call sites (\`get_paired_user_template\`, \`_build_paired_catalog\`, \`_load_synthetic_paired_child_templates\`) no longer duplicate the YAML walk + parse + structural validation block, so they cannot drift on edge cases.

## Tests

22 new tests in \`backend/tests/test_paired_template_endpoint.py\`:
- 8 covering #206 (synthetic catalog entries, \`paired_parent\` flag, \`get_template\` resolution, \`validate_node_request\` round-trip, child-node template field, child summary cross-reference, key helper)
- 7 covering #207 (legacy template flagged invalid, valid template marked valid, endpoint 422, endpoint still works for valid, helper return values, \`format\` string + list shapes, mid-list placeholder rejection)
- 4 covering #208a/b (lab_lock acquired exactly once, no deadlock when held, multi-link compensation, compensation-failure logged but non-blocking)
- 4 covering #208e (422 for iface lookup failure, 409 for duplicate, 409 for contention, 500 for unexpected)
- 1 architect-iter1 IPAM deadlock regression (\`_release_ip\` with \`_lab_lock_held=True\` from inside outer lab_lock)

Plus \`THREE_NODE_TWO_LINK_TEMPLATE\` and \`LEGACY_PRE_202_VMX_TEMPLATE\` fixtures.

## Test plan

- [x] \`pytest backend/tests/\` — 904 passed, 3 skipped
- [x] \`svelte-check\` — 0 errors / 0 warnings (1929 files)
- [x] Architect (opus) review — ITERATE → both critical fixes landed → re-verified clean
- [x] Deslop pass on changed files — duplicate iterator extracted; post-deslop regression 904/904
- [ ] Manual e2e on 192.168.100.140: drop a vMX-shaped paired template, instantiate, edit a child node (PUT image), confirm no 400 on save (this is the bug #206 fixed)

## Deferred follow-ups

Filed as separate issues per architect's recommendation to keep this PR focused on the two critical correctness fixes:

- **#209** — Synthetic per-child templates leak into public \`GET /api/list/templates/{type}\` (decision needed: filter or surface \`paired_parent\` in \`as_response\`).
- **#210** — Synthetic-key collision with a hypothetical user template named \`<paired>__<child>.yml\` is unguarded (decision needed: reserve \`__\` in real template stems or skip-on-collision).

## Files changed

| File | +/− | What |
|---|---|---|
| \`backend/app/services/template_service.py\` | +213 / -34 | Synthetic per-child entries, \`validate_paired_template\`, shared paired iterator, \`paired_parent\` field on TemplateDefinition + catalog response |
| \`backend/app/services/link_service.py\` | +43 / -3 | \`_lab_lock_held\` plumbing through \`create_link\`/\`delete_link\` and inner \`_*_locked\` helpers; \`nullcontext\` substitution for outer-held lock |
| \`backend/app/services/network_service.py\` | +18 / -3 | \`_release_ip\` accepts \`_lab_lock_held\` so paired-compensation IPAM release does not deadlock |
| \`backend/app/routers/labs.py\` | +123 / -29 | Endpoint refactored to wrap snapshot + phase 1 + phase 2 + restore in \`lab_lock\`; multi-link compensation; error code mapping; \`_build_paired_child_payload\` writes synthetic key |
| \`backend/tests/test_paired_template_endpoint.py\` | +822 | 22 new tests + 2 new fixtures (THREE_NODE_TWO_LINK_TEMPLATE, LEGACY_PRE_202_VMX_TEMPLATE) |
| \`frontend/src/lib/components/canvas/NodeConfigModal.svelte\` | +20 / -8 | \`templatesForType\` filter for paired_parent; paired-active gating on submitForm + disabled button; vendor copy generic-ised |
| \`frontend/src/lib/types/index.ts\` | +17 | \`paired_parent\` on \`NodeCatalogTemplate\`; \`template_key\` on \`NodeCatalogPairedChild\`; \`valid\` + \`invalid_reason\` on \`NodeCatalogPairedTemplate\` |