### PR TITLE
PR #211 round-3 follow-ups: HTTP transport, kind helper, parent/child consistency

### DIFF
--- a/backend/app/routers/labs.py
+++ b/backend/app/routers/labs.py
@@ -7,7 +7,7 @@ import uuid
 from urllib.parse import quote
 
 from fastapi import APIRouter, Body, Depends
-from fastapi.responses import PlainTextResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -28,7 +28,13 @@ from app.services.html5_service import Html5SessionError, Html5SessionService
 from app.services.lab_lock import lab_lock
 from app.services.lab_service import LEGACY_SCHEMA_ERROR, LabService, _lab_file_path, _normalize_relative_lab_path
 from app.services.node_runtime_service import NodeRuntimeError, NodeRuntimeService
-from app.services.template_service import TemplateError, TemplateService, _icon_filename_for, render_interface_name
+from app.services.template_service import (
+    TemplateError,
+    TemplateService,
+    _icon_filename_for,
+    normalize_paired_child_kind,
+    render_interface_name,
+)
 from app.services.ws_hub import ws_hub
 
 _logger = logging.getLogger(__name__)
@@ -51,6 +57,10 @@ def _legacy_schema_response(error: LegacyLabSchemaError) -> dict:
         "message": LEGACY_SCHEMA_ERROR,
         "lab_path": error.lab_path,
     }
+
+
+def _json_error(status_code: int, content: dict) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content=content)
 
 NODE_FIELDS_EDITABLE_WHILE_RUNNING = {"name", "icon", "left", "top", "interface_naming_scheme"}
 NODE_FIELDS_EDITABLE_WHILE_STOPPED = {"image", "cpu", "ram", "ethernet", "console", "delay", "extras"}
@@ -763,9 +773,7 @@ def _build_paired_child_payload(
     ``<paired_key>__<child_id>`` so node.template lookups by edit-mode (image
     validation, capability gates, frontend modal resolution) succeed.
     """
-    child_type = str(child.get("kind") or "qemu").lower()
-    if child_type not in {"qemu", "docker", "iol", "dynamips"}:
-        child_type = "qemu"
+    child_type = normalize_paired_child_kind(child.get("kind"))
     ethernet = int(child.get("ethernet", 1))
     extras = dict(child.get("extras") or {})
 
@@ -841,14 +849,17 @@ async def create_nodes_from_paired_template(
     template_service = TemplateService()
     paired = template_service.get_paired_user_template(request.template_key)
     if paired is None:
-        return {
-            "code": 404,
-            "status": "fail",
-            "message": (
-                f"Paired template {request.template_key!r} not found in "
-                "USER_TEMPLATES_DIR or is not a valid paired-node template."
-            ),
-        }
+        return _json_error(
+            404,
+            {
+                "code": 404,
+                "status": "fail",
+                "message": (
+                    f"Paired template {request.template_key!r} not found in "
+                    "USER_TEMPLATES_DIR or is not a valid paired-node template."
+                ),
+            },
+        )
 
     # #207 — pre-flight before any mutation. Catches old (#202-pre) imports
     # whose link refs reference interfaces no child will expose (e.g. paired
@@ -856,23 +867,29 @@ async def create_nodes_from_paired_template(
     # can render a fix-the-template message instead of a generic 500.
     pre_flight_reason = validate_paired_template(paired)
     if pre_flight_reason is not None:
-        return {
-            "code": 422,
-            "status": "fail",
-            "message": (
-                f"Paired template {request.template_key!r} cannot be instantiated: "
-                f"{pre_flight_reason}"
-            ),
-        }
+        return _json_error(
+            422,
+            {
+                "code": 422,
+                "status": "fail",
+                "message": (
+                    f"Paired template {request.template_key!r} cannot be instantiated: "
+                    f"{pre_flight_reason}"
+                ),
+            },
+        )
 
     try:
         scoped_path = _scoped_lab_path(current_user, lab_path, treat_as_absolute=True)
     except PermissionError as e:
-        return {
-            "code": 403,
-            "status": "fail",
-            "message": str(e),
-        }
+        return _json_error(
+            403,
+            {
+                "code": 403,
+                "status": "fail",
+                "message": str(e),
+            },
+        )
 
     settings = get_settings()
     normalized = _normalize_relative_lab_path(scoped_path)
@@ -892,13 +909,16 @@ async def create_nodes_from_paired_template(
         try:
             data = _read_lab_data(scoped_path)
         except LegacyLabSchemaError as exc:
-            return _legacy_schema_response(exc)
+            return _json_error(422, _legacy_schema_response(exc))
         except FileNotFoundError:
-            return {
-                "code": 404,
-                "status": "fail",
-                "message": "Lab does not exist (60038).",
-            }
+            return _json_error(
+                404,
+                {
+                    "code": 404,
+                    "status": "fail",
+                    "message": "Lab does not exist (60038).",
+                },
+            )
 
         snapshot = copy.deepcopy(data)
         nodes_map = data.setdefault("nodes", {})
@@ -949,25 +969,31 @@ async def create_nodes_from_paired_template(
                 "(template defect); rolled back",
                 request.template_key,
             )
-            return {
-                "code": 422,
-                "status": "fail",
-                "message": (
-                    f"Paired template {request.template_key!r} has malformed "
-                    f"child data: {exc}"
-                ),
-            }
+            return _json_error(
+                422,
+                {
+                    "code": 422,
+                    "status": "fail",
+                    "message": (
+                        f"Paired template {request.template_key!r} has malformed "
+                        f"child data: {exc}"
+                    ),
+                },
+            )
         except Exception as exc:  # noqa: BLE001 — broad catch is the rollback contract
             LabService.write_lab_json_static(scoped_path, snapshot)
             _logger.exception(
                 "from-paired-template: node-creation phase failed for %s; rolled back",
                 request.template_key,
             )
-            return {
-                "code": 500,
-                "status": "fail",
-                "message": f"Failed to create paired nodes: {exc}",
-            }
+            return _json_error(
+                500,
+                {
+                    "code": 500,
+                    "status": "fail",
+                    "message": f"Failed to create paired nodes: {exc}",
+                },
+            )
 
         try:
             for link in paired["links"]:
@@ -1040,34 +1066,49 @@ async def create_nodes_from_paired_template(
             from app.services.node_runtime_service import NodeRuntimeError
 
             if isinstance(exc, _PairedIfaceLookupError):
-                return {
-                    "code": 422,
-                    "status": "fail",
-                    "message": f"Paired link interface lookup failed: {exc}",
-                }
+                return _json_error(
+                    422,
+                    {
+                        "code": 422,
+                        "status": "fail",
+                        "message": f"Paired link interface lookup failed: {exc}",
+                    },
+                )
             if isinstance(exc, DuplicateLinkError):
-                return {
-                    "code": 409,
-                    "status": "fail",
-                    "message": f"Paired link conflicts with an existing link: {exc}",
-                }
+                return _json_error(
+                    409,
+                    {
+                        "code": 409,
+                        "status": "fail",
+                        "message": f"Paired link conflicts with an existing link: {exc}",
+                    },
+                )
             if isinstance(exc, LinkContentionError):
-                return {
-                    "code": 409,
-                    "status": "fail",
-                    "message": f"Paired link blocked by concurrent attach/detach: {exc}",
-                }
+                return _json_error(
+                    409,
+                    {
+                        "code": 409,
+                        "status": "fail",
+                        "message": f"Paired link blocked by concurrent attach/detach: {exc}",
+                    },
+                )
             if isinstance(exc, (NodeRuntimeError, host_net.HostNetError)):
-                return {
-                    "code": 422,
+                return _json_error(
+                    422,
+                    {
+                        "code": 422,
+                        "status": "fail",
+                        "message": f"Paired link hot-attach/host-net failure: {exc}",
+                    },
+                )
+            return _json_error(
+                500,
+                {
+                    "code": 500,
                     "status": "fail",
-                    "message": f"Paired link hot-attach/host-net failure: {exc}",
-                }
-            return {
-                "code": 500,
-                "status": "fail",
-                "message": f"Failed to create paired links: {exc}",
-            }
+                    "message": f"Failed to create paired links: {exc}",
+                },
+            )
 
     return {
         "code": 200,

--- a/backend/app/services/template_service.py
+++ b/backend/app/services/template_service.py
@@ -30,15 +30,13 @@ def synthetic_paired_child_key(paired_key: str, child_id: str) -> str:
     return f"{paired_key}{SYNTHETIC_PAIRED_CHILD_SEP}{child_id}"
 
 
-def _normalize_paired_child_kind(raw: Any) -> str:
-    """Mirror the runtime kind coercion in
-    ``backend/app/routers/labs.py::_build_paired_child_payload``: any kind
-    outside the supported set falls back to ``qemu``. Predictor and runtime
-    must agree on this — Codex iter-2 finding: predictor was treating any
-    non-qemu kind as ``eth*``, but runtime coerces unsupported kinds to
-    qemu and uses ``Gi*`` fallback naming. Result: a child with
-    ``kind:"weirdkind"`` and link reference ``Gi1`` was wrongly flagged
-    invalid by pre-flight while runtime built ``Gi1`` cleanly.
+def normalize_paired_child_kind(raw: Any) -> str:
+    """Normalize paired-child kinds for both predictor and runtime.
+
+    Whitespace is stripped before the allowlist check because imported
+    template data commonly arrives human-edited, and ``" docker "`` should
+    behave like ``"docker"`` instead of silently falling back to ``qemu``.
+    Keeping this rule in one helper prevents predictor/runtime drift.
     """
     kind = str(raw or "qemu").strip().lower()
     if kind not in {"qemu", "docker", "iol", "dynamips"}:
@@ -81,7 +79,7 @@ def _paired_child_iface_names(child: dict[str, Any]) -> list[str]:
     # coerces any unsupported kind to ``qemu`` (→ ``Gi*`` naming); pre-fix
     # predictor treated every non-qemu kind as ``eth*``, so a link to
     # ``Gi1`` on a ``kind:"weirdkind"`` child was wrongly flagged invalid.
-    kind = _normalize_paired_child_kind(child.get("kind"))
+    kind = normalize_paired_child_kind(child.get("kind"))
     iface_naming = child.get("interface_naming") if isinstance(child.get("interface_naming"), dict) else None
 
     # Step 1 — base list (format if present, else kind-default).
@@ -166,10 +164,11 @@ def _safe_paired_child_int(child: dict[str, Any], field: str, default: int) -> i
 def validate_paired_template(data: dict[str, Any]) -> str | None:
     """Pre-flight a paired template (#207). Returns ``None`` when the template
     can be instantiated end-to-end, or a human-readable reason string when a
-    link references an interface name that no child will expose, or a child
-    has a malformed scalar field (#208). Used by the catalog builder to flag
-    old imports + by the from-paired-template endpoint to return 422 instead
-    of 500.
+    link references an interface name that no child will expose, a child has
+    malformed scalar data (#208), or a child carries invalid interface naming
+    / capabilities blocks that synthetic child loading would reject. Used by
+    the catalog builder to flag old imports + by the from-paired-template
+    endpoint to return 422 instead of 500.
     """
     nodes = data.get("nodes") or []
     links = data.get("links") or []
@@ -187,6 +186,17 @@ def validate_paired_template(data: dict[str, Any]) -> str | None:
         scalar_reason = _paired_child_scalar_problem(child)
         if scalar_reason is not None:
             return f"child {child_id!r} {scalar_reason}"
+        child_kind = normalize_paired_child_kind(child.get("kind"))
+        child_source = f"paired child {child_id!r}"
+        try:
+            child_iface = child.get("interface_naming")
+            if child_iface is not None:
+                _validate_interface_naming(child_iface, source=child_source)
+            _validate_capabilities(
+                child.get("capabilities"), child_kind, source=child_source
+            )
+        except TemplateError as exc:
+            return f"child {child_id!r} {exc}"
 
     for link in links:
         if not isinstance(link, dict):
@@ -1166,9 +1176,7 @@ class TemplateService:
                 if not isinstance(child, dict):
                     continue
                 child_id = str(child.get("id") or f"child-{index}")
-                child_kind = str(child.get("kind") or "qemu").strip().lower()
-                if child_kind not in SUPPORTED_TEMPLATE_TYPES:
-                    child_kind = "qemu"
+                child_kind = normalize_paired_child_kind(child.get("kind"))
                 synthetic_key = synthetic_paired_child_key(paired_key, child_id)
                 source = f"{path}::nodes[{index}]"
                 # #208 codex-iter3 — paired imports may be malformed (bad

--- a/backend/tests/test_paired_template_endpoint.py
+++ b/backend/tests/test_paired_template_endpoint.py
@@ -20,7 +20,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
+from app.dependencies import get_current_user
 from app.routers import labs
 from app.schemas.node import NodeFromPairedTemplate, NodeFromTemplate
 from app.services.template_service import TemplateService
@@ -99,6 +102,7 @@ def patched_split(monkeypatch, split_template_dirs):
     monkeypatch.setattr("app.services.lab_service.get_settings", lambda: split_template_dirs)
     monkeypatch.setattr("app.services.node_runtime_service.get_settings", lambda: split_template_dirs)
     monkeypatch.setattr("app.services.link_service.get_settings", lambda: split_template_dirs)
+    monkeypatch.setattr("app.routers.labs.get_settings", lambda: split_template_dirs)
     return split_template_dirs
 
 
@@ -123,6 +127,28 @@ def _seed_empty_lab(settings, lab_id: str = "lab-paired") -> Path:
 
 def _seed_paired_template(settings, template: dict, key: str = "juniper-vmx") -> None:
     (settings.USER_TEMPLATES_DIR / f"{key}.json").write_text(json.dumps(template))
+
+
+def _response_json(response) -> dict:
+    if isinstance(response, dict):
+        return response
+    return json.loads(response.body)
+
+
+def _response_status(response) -> int:
+    if isinstance(response, dict):
+        return int(response.get("code", 200))
+    return int(response.status_code)
+
+
+@pytest.fixture()
+def paired_route_client(patched_split):
+    test_app = FastAPI()
+    test_app.include_router(labs.router)
+    test_app.dependency_overrides[get_current_user] = _admin
+    with TestClient(test_app) as client:
+        yield client
+    test_app.dependency_overrides.clear()
 
 
 # ---- get_paired_user_template -------------------------------------------
@@ -252,8 +278,10 @@ async def test_returns_404_for_unknown_template(patched_split):
         NodeFromPairedTemplate(template_key="nonexistent"),
         current_user=_admin(),
     )
-    assert response["code"] == 404
-    assert "paired template" in response["message"].lower()
+    body = _response_json(response)
+    assert _response_status(response) == 404
+    assert body["code"] == 404
+    assert "paired template" in body["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -270,7 +298,9 @@ async def test_returns_404_for_singleton_template(patched_split):
         NodeFromPairedTemplate(template_key="csr"),
         current_user=_admin(),
     )
-    assert response["code"] == 404
+    body = _response_json(response)
+    assert _response_status(response) == 404
+    assert body["code"] == 404
 
 
 @pytest.mark.asyncio
@@ -293,13 +323,121 @@ async def test_rolls_back_when_link_creation_fails(patched_split, monkeypatch):
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 500
-    assert "simulated link creation failure" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 500
+    assert body["code"] == 500
+    assert "simulated link creation failure" in body["message"]
 
     # Lab file must be back to the pre-call state — no orphan nodes left behind.
     on_disk = json.loads(lab_file.read_text())
     assert on_disk["nodes"] == {}
     assert on_disk["links"] == []
+
+
+def test_http_transport_returns_422_for_bad_scalar_preflight(
+    paired_route_client, patched_split
+):
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad["nodes"][0]["cpu"] = "not-an-int"
+    _seed_paired_template(settings, bad)
+    _seed_empty_lab(settings)
+
+    response = paired_route_client.post(
+        "/api/labs/demo.json/nodes/from-paired-template",
+        json={"template_key": "juniper-vmx"},
+    )
+
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body["code"] == 422
+    assert "cpu" in body["message"]
+
+
+def test_http_transport_returns_422_for_node_runtime_error(
+    paired_route_client, patched_split, monkeypatch
+):
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    from app.services.link_service import LinkService
+    from app.services.node_runtime_service import NodeRuntimeError
+
+    async def attach_refused(
+        self,
+        lab_path,
+        from_endpoint,
+        to_endpoint,
+        *,
+        style_override=None,
+        idempotency_key=None,
+        _lab_lock_held=False,
+    ):
+        raise NodeRuntimeError("hot-attach refused: node not running")
+
+    monkeypatch.setattr(LinkService, "create_link", attach_refused)
+
+    response = paired_route_client.post(
+        "/api/labs/demo.json/nodes/from-paired-template",
+        json={"template_key": "juniper-vmx"},
+    )
+
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body["code"] == 422
+    assert "hot-attach" in body["message"]
+
+
+def test_http_transport_returns_409_for_duplicate_link(
+    paired_route_client, patched_split, monkeypatch
+):
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    from app.services.link_service import DuplicateLinkError, LinkService
+
+    async def dupe_create_link(
+        self,
+        lab_path,
+        from_endpoint,
+        to_endpoint,
+        *,
+        style_override=None,
+        idempotency_key=None,
+        _lab_lock_held=False,
+    ):
+        raise DuplicateLinkError({"id": "existing-link-id"})
+
+    monkeypatch.setattr(LinkService, "create_link", dupe_create_link)
+
+    response = paired_route_client.post(
+        "/api/labs/demo.json/nodes/from-paired-template",
+        json={"template_key": "juniper-vmx"},
+    )
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["code"] == 409
+    assert "existing" in body["message"].lower() or "conflict" in body["message"].lower()
+
+
+def test_http_transport_returns_200_on_success(paired_route_client, patched_split):
+    settings = patched_split
+    _seed_paired_template(settings, VMX_PAIRED_TEMPLATE)
+    _seed_empty_lab(settings)
+
+    response = paired_route_client.post(
+        "/api/labs/demo.json/nodes/from-paired-template",
+        json={"template_key": "juniper-vmx"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["code"] == 200
+    assert len(body["data"]["nodes"]) == 2
+    assert len(body["data"]["links"]) == 1
 
 
 @pytest.mark.asyncio
@@ -607,9 +745,11 @@ async def test_207_endpoint_returns_422_for_invalid_template(patched_split):
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 422, response
-    assert "fxp0" in response["message"]
-    assert "interface_naming.explicit" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 422, response
+    assert body["code"] == 422
+    assert "fxp0" in body["message"]
+    assert "interface_naming.explicit" in body["message"]
 
 
 @pytest.mark.asyncio
@@ -969,8 +1109,10 @@ async def test_208b_compensates_first_link_when_second_fails(patched_split, monk
         current_user=_admin(),
     )
 
-    assert response["code"] == 500, response
-    assert "simulated link 2 failure" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 500, response
+    assert body["code"] == 500
+    assert "simulated link 2 failure" in body["message"]
     # Compensation: delete_link called once for the first (successful) link,
     # with _lab_lock_held=True (we're inside the outer lab_lock).
     assert len(delete_args) == 1, delete_args
@@ -1031,8 +1173,10 @@ async def test_208b_compensation_failure_logged_but_does_not_block_restore(
         )
 
     # Endpoint still returns 500 with the original error (not the compensation error).
-    assert response["code"] == 500
-    assert "link 2 failed" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 500
+    assert body["code"] == 500
+    assert "link 2 failed" in body["message"]
     # Compensation failure was logged but did NOT prevent snapshot restore.
     comp_warnings = [r for r in caplog.records if "compensation delete_link" in r.message]
     assert len(comp_warnings) == 1
@@ -1071,8 +1215,10 @@ async def test_208e_paired_iface_lookup_error_returns_422(patched_split, monkeyp
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 422, response
-    assert "interface lookup" in response["message"].lower()
+    body = _response_json(response)
+    assert _response_status(response) == 422, response
+    assert body["code"] == 422
+    assert "interface lookup" in body["message"].lower()
     monkeypatch.setattr(labs_module, "_resolve_iface_index", real_resolve)
 
 
@@ -1099,8 +1245,10 @@ async def test_208e_duplicate_link_returns_409(patched_split, monkeypatch):
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 409, response
-    assert "conflict" in response["message"].lower() or "existing" in response["message"].lower()
+    body = _response_json(response)
+    assert _response_status(response) == 409, response
+    assert body["code"] == 409
+    assert "conflict" in body["message"].lower() or "existing" in body["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -1125,8 +1273,10 @@ async def test_208e_link_contention_returns_409(patched_split, monkeypatch):
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 409, response
-    assert "concurrent" in response["message"].lower() or "blocked" in response["message"].lower()
+    body = _response_json(response)
+    assert _response_status(response) == 409, response
+    assert body["code"] == 409
+    assert "concurrent" in body["message"].lower() or "blocked" in body["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -1210,8 +1360,10 @@ async def test_208iter3_node_runtime_error_returns_422(patched_split, monkeypatc
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 422, response
-    assert "hot-attach" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 422, response
+    assert body["code"] == 422
+    assert "hot-attach" in body["message"]
 
 
 @pytest.mark.asyncio
@@ -1237,8 +1389,10 @@ async def test_208iter3_host_net_error_returns_422(patched_split, monkeypatch):
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 422, response
-    assert "host-net" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 422, response
+    assert body["code"] == 422
+    assert "host-net" in body["message"]
 
 
 @pytest.mark.asyncio
@@ -1264,8 +1418,10 @@ async def test_208e_unexpected_exception_still_returns_500(patched_split, monkey
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 500, response
-    assert "filesystem" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 500, response
+    assert body["code"] == 500
+    assert "filesystem" in body["message"]
 
 
 # ---- #208-MEDIUM: bad child scalars surface as 422 (template defect) ----
@@ -1287,9 +1443,11 @@ async def test_208medium_bad_ethernet_scalar_returns_422_via_preflight(patched_s
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 422, response
-    assert "ethernet" in response["message"]
-    assert "integer" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 422, response
+    assert body["code"] == 422
+    assert "ethernet" in body["message"]
+    assert "integer" in body["message"]
 
 
 @pytest.mark.asyncio
@@ -1308,9 +1466,11 @@ async def test_208medium_bad_cpu_scalar_returns_422_via_preflight(patched_split)
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 422, response
-    assert "cpu" in response["message"]
-    assert "integer" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 422, response
+    assert body["code"] == 422
+    assert "cpu" in body["message"]
+    assert "integer" in body["message"]
 
 
 @pytest.mark.asyncio
@@ -1327,9 +1487,11 @@ async def test_208medium_bad_ram_scalar_returns_422_via_preflight(patched_split)
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 422, response
-    assert "ram" in response["message"]
-    assert "integer" in response["message"]
+    body = _response_json(response)
+    assert _response_status(response) == 422, response
+    assert body["code"] == 422
+    assert "ram" in body["message"]
+    assert "integer" in body["message"]
 
 
 # ---- #208 codex-iter3: catalog-build paths fault-tolerate bad scalars --
@@ -1372,6 +1534,33 @@ def test_208iter3_synthetic_child_load_skips_broken_child(patched_split, caplog)
     service = TemplateService()
     with caplog.at_level("WARNING"):
         templates = service._load_synthetic_paired_child_templates()
+
+    keys = {t.key for t in templates}
+    assert "juniper-vmx__vfp" in keys
+    assert "juniper-vmx__vcp" not in keys
+    assert any(
+        "Synthetic paired-child template skipped" in rec.message for rec in caplog.records
+    )
+
+
+def test_208iter3_invalid_child_marks_parent_invalid_and_skips_synthetic(
+    patched_split, caplog
+):
+    """Synthetic-child rejection and parent ``valid:false`` must stay aligned."""
+    settings = patched_split
+    bad = json.loads(json.dumps(VMX_PAIRED_TEMPLATE))
+    bad["nodes"][0]["interface_naming"] = ["wrong", "shape"]
+    _seed_paired_template(settings, bad)
+
+    service = TemplateService()
+    with caplog.at_level("WARNING"):
+        catalog = service._build_paired_catalog()
+        templates = service._load_synthetic_paired_child_templates()
+
+    entry = catalog[0]
+    assert entry["valid"] is False
+    assert entry["invalid_reason"] is not None
+    assert "interface_naming" in entry["invalid_reason"]
 
     keys = {t.key for t in templates}
     assert "juniper-vmx__vfp" in keys
@@ -1432,6 +1621,39 @@ def test_207iter3_predictor_normalizes_unsupported_kind_to_qemu(patched_split):
 
     reason = validate_paired_template(weird_template)
     assert reason is None, f"Predictor drifted from runtime — got reason: {reason}"
+
+
+def test_207iter3_predictor_and_runtime_share_kind_normalization():
+    """Whitespace-padded supported kinds must yield identical iface names."""
+    from app.services.template_service import (
+        _paired_child_iface_names,
+        normalize_paired_child_kind,
+    )
+
+    child = {
+        "id": "docker-child",
+        "name": "Docker Child",
+        "kind": " docker ",
+        "image": "alpine:latest",
+        "ethernet": 2,
+        "console": "telnet",
+    }
+
+    predictor_names = _paired_child_iface_names(child)
+    payload = labs._build_paired_child_payload(
+        node_id=7,
+        template_key="paired-docker",
+        child=child,
+        child_id="docker-child",
+        name="Docker Child",
+        left=0,
+        top=0,
+    )
+    runtime_names = [iface["name"] for iface in payload["interfaces"]]
+
+    assert normalize_paired_child_kind(child["kind"]) == "docker"
+    assert predictor_names == ["eth0", "eth1"]
+    assert runtime_names == predictor_names
 
 
 def test_207iter3_predictor_blank_kind_falls_back_to_qemu():
@@ -1519,7 +1741,9 @@ async def test_208medium_node_phase_422_path_rolls_back_lab(patched_split):
         NodeFromPairedTemplate(template_key="juniper-vmx"),
         current_user=_admin(),
     )
-    assert response["code"] == 422, response
+    body = _response_json(response)
+    assert _response_status(response) == 422, response
+    assert body["code"] == 422
 
     # Snapshot restore: lab.json must be back to empty nodes/links.
     restored = json.loads(lab_path.read_text())


### PR DESCRIPTION
## Summary

Round-3 Codex critic review of PR #211 (merged as `2eace37`) found 3 blocking issues against the iter-3 commits. All three are fixed here. Implementation done by a Codex CLI worker dispatched via `/team 1:codex`; this PR lands the worker's output on a fresh branch.

| # | Severity | Issue | Status |
|---|---|---|---|
| 1 | HIGH | Paired endpoint returns plain dicts; HTTP transport stays 200 | ✅ Fixed |
| 2 | MEDIUM | Kind-normalization predictor/runtime drift on whitespace | ✅ Fixed |
| 3 | MEDIUM | Parent-valid/child-missing inconsistency in synthetic loader skip | ✅ Fixed |

## Task #1 — HIGH: HTTP transport fix

**Defect:** `create_nodes_from_paired_template` returned plain dicts like `{"code": 422, "status": "fail"}`. FastAPI emits HTTP 200 regardless of the embedded `code` field. The single-node `/links` route at `backend/app/routers/links.py:146,198,236` correctly uses `JSONResponse(status_code=N, content=...)`. Clients branching on HTTP status saw 200-success transport for ALL the documented error codes (422/409/500/404/403). This affected every existing error path in `/nodes/from-paired-template`, not just the iter-3 additions.

**Fix:** Every error branch in `create_nodes_from_paired_template` now returns `JSONResponse(status_code=N, content=...)`. Success path stays a plain dict (FastAPI emits 200). Tests updated to assert real HTTP status via `TestClient`, and per-test helpers (`_response_json` / `_response_status`) bridge old direct-call tests to the new `JSONResponse` return type.

## Task #2 — MEDIUM: kind-normalization shared helper

**Defect:** Iter-3 commit `561a721` claimed "mirror runtime exactly" but the new `_normalize_paired_child_kind` stripped whitespace before the allowlist check, while runtime `_build_paired_child_payload` only lowercased. `kind: " docker "` → predictor said `docker` (eth*), runtime coerced to `qemu` (Gi*). Same false-invalid / false-valid drift class round-2 was supposed to close.

**Fix:** Helper renamed to public `normalize_paired_child_kind` (no underscore prefix) and called from BOTH the predictor and the runtime `_build_paired_child_payload`. Single source of truth — picked the `.strip().lower()` semantics because trailing whitespace on imported template fields is almost always a typo, and trimming once at one site is preferable to silently coercing to qemu downstream. Parity test added.

## Task #3 — MEDIUM: parent/child consistency

**Defect:** Iter-3 commit `b7a2c89` made `_load_synthetic_paired_child_templates` skip-but-log on `TemplateError`/`TypeError`/`ValueError` so the catalog endpoint stops crashing on malformed children. But `validate_paired_template` did NOT call `_validate_interface_naming` or `_validate_capabilities` per child. Result: parent paired template could show `valid:true` and instantiate while the synthetic child template entry was missing → `get_template(synthetic_key)` lookups for image validation/capabilities silently fell back to defaults.

**Fix:** `validate_paired_template` now per-child wraps `_validate_interface_naming` and `_validate_capabilities` in try/except (TemplateError) and returns the same reason string the synthetic loader logs. The parent's `valid:false` signal stays aligned with the synthetic loader's skip decision. Test added.

## Test plan

- [x] Backend pytest: 928 passed / 3 skipped (was 922 + 6 new)
- [x] `test_paired_template_endpoint.py`: 63 tests pass (was 57 + 6)
- [x] No frontend changes; svelte-check unchanged
- [ ] Codex round-4 critic review
- [ ] Deploy to nova-ve-app-01 (192.168.100.140) and nova-ve-app-02 (192.168.100.213) on merge

Closes the round-3 Codex critic findings against PR #211.