### PR TITLE
Add 73 built-in QEMU device templates from Templates-v2 pack

### DIFF
--- a/backend/templates/qemu/128T.yml
+++ b/backend/templates/qemu/128T.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Juniper Session Smart Router
+description: Juniper Session Smart Router
+icon_type: router
+cpu: 4
+ram: 8192
+ethernet: 8
+console_type: telnet
+qemu_options: -machine type=pc-1.0,accel=kvm -cpu host -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: ge-0-{n}

--- a/backend/templates/qemu/aruba.yml
+++ b/backend/templates/qemu/aruba.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Aruba Virtual Mobility Controller
+description: Aruba Virtual Mobility Controller
+icon_type: router
+cpu: 3
+ram: 4096
+ethernet: 4
+console_type: vnc
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - Not in Use
+  - GigabitEthernet0/0/{n}

--- a/backend/templates/qemu/arubacx.yml
+++ b/backend/templates/qemu/arubacx.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Aruba CX Virtual Switch
+description: Aruba CX
+icon_type: switch
+cpu: 2
+ram: 4096
+ethernet: 7
+console_type: telnet
+qemu_options: -machine type=pc-1.0,accel=kvm -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - mgmt
+  - 1/1/{port}

--- a/backend/templates/qemu/asav.yml
+++ b/backend/templates/qemu/asav.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Cisco ASAv
+description: Cisco ASAv
+icon_type: firewall
+cpu: 1
+ram: 2048
+ethernet: 8
+console_type: telnet
+qemu_options: -machine type=pc-1.0,accel=kvm -nodefconfig -nodefaults -display none -vga std -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - Management0/0
+  - GigabitEthernet0/{n}

--- a/backend/templates/qemu/bigip.yml
+++ b/backend/templates/qemu/bigip.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: F5 BIG-IP VE
+description: F5 BIG-IP VE
+icon_type: firewall
+cpu: 2
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - MGMT
+  - 1.{port}

--- a/backend/templates/qemu/c8000v.yml
+++ b/backend/templates/qemu/c8000v.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Cisco C8000V
+description: Cisco C8000V
+icon_type: router
+cpu: 2
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_nic: vmxnet3
+qemu_options: -machine type=pc,accel=kvm -cpu host -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet{port}

--- a/backend/templates/qemu/c9800cl.yml
+++ b/backend/templates/qemu/c9800cl.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Cisco Catalyst 9800-CL
+description: Cisco Catalyst 9800-CL
+icon_type: router
+cpu: 4
+ram: 4096
+ethernet: 3
+console_type: telnet
+qemu_nic: vmxnet3
+qemu_options: -machine type=pc,accel=kvm -cpu host -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet{port}

--- a/backend/templates/qemu/cat9kv.yml
+++ b/backend/templates/qemu/cat9kv.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Cisco Catalyst 9000v
+description: Cisco Catalyst 9000v
+icon_type: switch
+cpu: 4
+ram: 24576
+ethernet: 9
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - GigabitEthernet0/0
+  - GigabitEthernet1/0/{port}

--- a/backend/templates/qemu/catalyst8000v.yml
+++ b/backend/templates/qemu/catalyst8000v.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Cisco Catalyst 8000V
+description: Cisco Catalyst 8000V
+icon_type: router
+cpu: 1
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_nic: vmxnet3
+qemu_options: -machine type=pc,accel=kvm -cpu host -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet{port}

--- a/backend/templates/qemu/clearpass.yml
+++ b/backend/templates/qemu/clearpass.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Aruba ClearPass
+description: Aruba ClearPass
+icon_type: server
+cpu: 2
+ram: 4096
+ethernet: 2
+console_type: vnc
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{port}

--- a/backend/templates/qemu/cpsg.yml
+++ b/backend/templates/qemu/cpsg.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Check Point Security Gateway
+description: Check Point Security Gateway
+icon_type: firewall
+cpu: 4
+ram: 6144
+ethernet: 4
+console_type: telnet
+qemu_nic: vmxnet3
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/csr1000v.yml
+++ b/backend/templates/qemu/csr1000v.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Cisco CSR 1000V XE 3.x
+description: Cisco CSR 1000V XE 3.x
+icon_type: router
+cpu: 1
+ram: 3072
+ethernet: 4
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet{port}

--- a/backend/templates/qemu/csr1000vng.yml
+++ b/backend/templates/qemu/csr1000vng.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Cisco CSR 1000V XE 16.x
+description: Cisco CSR 1000V XE 16.x
+icon_type: router
+cpu: 1
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_nic: vmxnet3
+qemu_options: -machine type=pc,accel=kvm -cpu host -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet{port}

--- a/backend/templates/qemu/csr8000v.yml
+++ b/backend/templates/qemu/csr8000v.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Cisco Catalyst 8000V
+description: Cisco Catalyst 8000V
+icon_type: router
+cpu: 2
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_nic: vmxnet3
+qemu_options: -machine type=pc,accel=kvm -cpu host -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet{port}

--- a/backend/templates/qemu/cumulus.yml
+++ b/backend/templates/qemu/cumulus.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: NVIDIA Cumulus VX
+description: NVIDIA Cumulus VX
+icon_type: switch
+cpu: 1
+ram: 256
+ethernet: 8
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - eth0
+  - swp{port}

--- a/backend/templates/qemu/cvp.yml
+++ b/backend/templates/qemu/cvp.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Arista CloudVision Portal
+description: Arista CloudVision Portal
+icon_type: server
+cpu: 8
+ram: 22528
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/dellos10.yml
+++ b/backend/templates/qemu/dellos10.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Dell SmartFabric OS10
+description: Dell SmartFabric OS10
+icon_type: switch
+cpu: 4
+ram: 4096
+ethernet: 16
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: ethernet1/1/{port}

--- a/backend/templates/qemu/dockerserver.yml
+++ b/backend/templates/qemu/dockerserver.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Docker Server
+description: Docker Server
+icon_type: server
+cpu: 2
+ram: 2048
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=dc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/esxi.yml
+++ b/backend/templates/qemu/esxi.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: VMware ESXi
+description: VMware ESXi
+icon_type: server
+cpu: 2
+ram: 4096
+ethernet: 4
+console_type: vnc
+qemu_options: -machine pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: vmnic{n}

--- a/backend/templates/qemu/extremexos.yml
+++ b/backend/templates/qemu/extremexos.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: ExtremeXOS
+description: ExtremeXOS
+icon_type: switch
+cpu: 1
+ram: 2048
+ethernet: 3
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -cpu Nehalem -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - Mgmt
+  - port{port}

--- a/backend/templates/qemu/firepower.yml
+++ b/backend/templates/qemu/firepower.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Cisco Firepower
+description: Cisco Firepower
+icon_type: firewall
+cpu: 4
+ram: 4096
+ethernet: 4
+console_type: vnc
+qemu_options: -machine type=pc-1.0,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - eth0 / mgmt
+  - GigabitEthernet0/{n}

--- a/backend/templates/qemu/firepower6.yml
+++ b/backend/templates/qemu/firepower6.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Cisco Firepower 6
+description: Cisco Firepower 6
+icon_type: firewall
+cpu: 4
+ram: 8192
+ethernet: 5
+console_type: vnc
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - eth0 / mgmt
+  - GigabitEthernet0/{n}

--- a/backend/templates/qemu/fmc7.yml
+++ b/backend/templates/qemu/fmc7.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Cisco FMC 7
+description: Cisco Firepower Management Center 7
+icon_type: server
+cpu: 4
+ram: 28762
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/fortinet.yml
+++ b/backend/templates/qemu/fortinet.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Fortinet FortiGate
+description: Fortinet FortiGate
+icon_type: firewall
+cpu: 1
+ram: 2048
+ethernet: 4
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: port{port}

--- a/backend/templates/qemu/freebsd.yml
+++ b/backend/templates/qemu/freebsd.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: FreeBSD
+description: FreeBSD
+icon_type: server
+cpu: 2
+ram: 4092
+ethernet: 2
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: vtnet{n}

--- a/backend/templates/qemu/ftd7.yml
+++ b/backend/templates/qemu/ftd7.yml
@@ -1,0 +1,19 @@
+type: qemu
+name: Cisco FTD 7
+description: Cisco FTD 7
+icon_type: firewall
+cpu: 4
+ram: 8192
+ethernet: 6
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - Management0/0
+  - Diagnostic0/0
+  - GigabitEthernet0/{n}

--- a/backend/templates/qemu/huaweiar1k.yml
+++ b/backend/templates/qemu/huaweiar1k.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Huawei AR1000V
+description: Huawei AR1000V
+icon_type: router
+cpu: 1
+ram: 2048
+ethernet: 6
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet0/0/{n}

--- a/backend/templates/qemu/huaweice6800.yml
+++ b/backend/templates/qemu/huaweice6800.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Huawei CloudEngine 6800V
+description: Huawei CloudEngine 6800V
+icon_type: switch
+cpu: 2
+ram: 2048
+ethernet: 22
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=q35,accel=kvm -nodefaults -rtc base=utc -cpu host
+capabilities:
+  machine: q35
+  hotplug: true
+  max_nics: 8
+interface_naming:
+  format: 10GE1/0/{port}

--- a/backend/templates/qemu/huaweine40.yml
+++ b/backend/templates/qemu/huaweine40.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Huawei NE40
+description: Huawei NE40
+icon_type: router
+cpu: 2
+ram: 2048
+ethernet: 12
+console_type: telnet
+qemu_nic: vmxnet3
+qemu_options: -machine type=pc,accel=kvm -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet0/0/{n}

--- a/backend/templates/qemu/huaweiusg6kv.yml
+++ b/backend/templates/qemu/huaweiusg6kv.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Huawei USG6000V
+description: Huawei USG6000V
+icon_type: firewall
+cpu: 2
+ram: 4096
+ethernet: 6
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - GigabitEthernet0/0/0
+  - GigabitEthernet1/0/{n}

--- a/backend/templates/qemu/ise.yml
+++ b/backend/templates/qemu/ise.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Cisco ISE
+description: Cisco Identity Services Engine
+icon_type: server
+cpu: 4
+ram: 8192
+console_type: vnc
+cpulimit: 0
+qemu_options: -machine type=pc,accel=kvm -smbios type=1,product=KVM -no-user-config -nodefaults -display none -vga std -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet {n}

--- a/backend/templates/qemu/isrv.yml
+++ b/backend/templates/qemu/isrv.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Cisco ISRv
+description: Cisco ISRv
+icon_type: router
+cpu: 2
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_nic: vmxnet3
+qemu_options: -machine type=pc,accel=kvm -cpu host -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet{port}

--- a/backend/templates/qemu/junipervrr.yml
+++ b/backend/templates/qemu/junipervrr.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Juniper vRR
+description: Juniper vRR
+icon_type: router
+cpu: 1
+ram: 2048
+ethernet: 4
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: em{n}

--- a/backend/templates/qemu/kali.yml
+++ b/backend/templates/qemu/kali.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Kali Linux
+description: Kali Linux
+icon_type: server
+cpu: 2
+ram: 4096
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=dc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/linux.yml
+++ b/backend/templates/qemu/linux.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Linux
+description: Linux
+icon_type: server
+cpu: 2
+ram: 4096
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga virtio -usbdevice tablet -boot order=cd -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/mikrotik.yml
+++ b/backend/templates/qemu/mikrotik.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: MikroTik CHR
+description: MikroTik Cloud Hosted Router
+icon_type: router
+cpu: 1
+ram: 512
+ethernet: 4
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: ether{port}

--- a/backend/templates/qemu/nxosv9k.yml
+++ b/backend/templates/qemu/nxosv9k.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Cisco Nexus 9000v
+description: Cisco Nexus 9000v
+icon_type: switch
+cpu: 2
+ram: 8192
+ethernet: 8
+console_type: telnet
+cpulimit: 0
+qemu_options: -machine type=pc,accel=kvm -enable-kvm
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - mgmt0
+  - Ethernet1/{port}

--- a/backend/templates/qemu/olive.yml
+++ b/backend/templates/qemu/olive.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Juniper Olive
+description: Juniper Olive
+icon_type: router
+cpu: 1
+ram: 4096
+ethernet: 4
+console_type: telnet
+architecture: i386
+qemu_options: -machine type=pc-1.0,accel=kvm -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: em{n}

--- a/backend/templates/qemu/openwrt.yml
+++ b/backend/templates/qemu/openwrt.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: OpenWrt
+description: OpenWrt
+icon_type: router
+cpu: 1
+ram: 2048
+ethernet: 4
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/opnsense.yml
+++ b/backend/templates/qemu/opnsense.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: OPNsense
+description: OPNsense
+icon_type: firewall
+cpu: 2
+ram: 2048
+ethernet: 2
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -usbdevice tablet -boot order=dc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: vtnet{n}

--- a/backend/templates/qemu/panorama.yml
+++ b/backend/templates/qemu/panorama.yml
@@ -1,0 +1,14 @@
+type: qemu
+name: Palo Alto Panorama
+description: Palo Alto Panorama
+icon_type: server
+cpu: 4
+ram: 16384
+console_type: vnc
+qemu_options: -machine type=pc,accel=kvm -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/pfsense.yml
+++ b/backend/templates/qemu/pfsense.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: pfSense CE
+description: pfSense CE
+icon_type: firewall
+cpu: 2
+ram: 4096
+ethernet: 2
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -usbdevice tablet -boot order=dc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: vtnet{n}

--- a/backend/templates/qemu/proxmox.yml
+++ b/backend/templates/qemu/proxmox.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Proxmox VE
+description: Proxmox VE
+icon_type: server
+cpu: 4
+ram: 8192
+ethernet: 2
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/sonicwall.yml
+++ b/backend/templates/qemu/sonicwall.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: SonicWall NSv
+description: SonicWall NSv
+icon_type: firewall
+cpu: 4
+ram: 6144
+ethernet: 8
+console_type: vnc
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: X{n}

--- a/backend/templates/qemu/sophosutm.yml
+++ b/backend/templates/qemu/sophosutm.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Sophos UTM
+description: Sophos UTM
+icon_type: firewall
+cpu: 2
+ram: 4096
+ethernet: 6
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/sophosxg.yml
+++ b/backend/templates/qemu/sophosxg.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Sophos Firewall
+description: Sophos Firewall
+icon_type: firewall
+cpu: 2
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: Port{port}

--- a/backend/templates/qemu/titanium.yml
+++ b/backend/templates/qemu/titanium.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Cisco NX-OSv Titanium
+description: Cisco NX-OSv Titanium
+icon_type: switch
+cpu: 1
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - mgmt0
+  - Ethernet2/{port}

--- a/backend/templates/qemu/vcenter.yml
+++ b/backend/templates/qemu/vcenter.yml
@@ -1,0 +1,14 @@
+type: qemu
+name: VMware vCenter
+description: VMware vCenter Server
+icon_type: server
+cpu: 2
+ram: 10240
+console_type: vnc
+qemu_options: -machine pc,accel=kvm -no-user-config -nodefaults -display none -vga std -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/veloedge.yml
+++ b/backend/templates/qemu/veloedge.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: VMware SD-WAN Edge
+description: VMware SD-WAN Edge
+icon_type: router
+cpu: 2
+ram: 4096
+ethernet: 6
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=dc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GE{port}

--- a/backend/templates/qemu/velogw.yml
+++ b/backend/templates/qemu/velogw.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: VMware SD-WAN Gateway
+description: VMware SD-WAN Gateway
+icon_type: router
+cpu: 4
+ram: 8192
+ethernet: 2
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=dc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/veloorch.yml
+++ b/backend/templates/qemu/veloorch.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: VMware SD-WAN Orchestrator
+description: VMware SD-WAN Orchestrator
+icon_type: server
+cpu: 4
+ram: 16384
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=dc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/veos.yml
+++ b/backend/templates/qemu/veos.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Arista vEOS
+description: Arista vEOS
+icon_type: switch
+cpu: 1
+ram: 2048
+ethernet: 9
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -display none -no-user-config -rtc base=utc -boot order=d
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - Management1
+  - Ethernet1/{port}

--- a/backend/templates/qemu/vios.yml
+++ b/backend/templates/qemu/vios.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Cisco IOSv
+description: Cisco IOSv
+icon_type: router
+cpu: 1
+ram: 1024
+ethernet: 4
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet0/{n}

--- a/backend/templates/qemu/viosl2.yml
+++ b/backend/templates/qemu/viosl2.yml
@@ -1,0 +1,24 @@
+type: qemu
+name: Cisco IOSvL2
+description: Cisco IOSvL2
+icon_type: switch
+cpu: 1
+ram: 1024
+ethernet: 8
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -rtc base=utc -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - GigabitEthernet0/0
+  - GigabitEthernet0/1
+  - GigabitEthernet0/2
+  - GigabitEthernet0/3
+  - GigabitEthernet1/0
+  - GigabitEthernet1/1
+  - GigabitEthernet1/2
+  - GigabitEthernet1/3
+  - GigabitEthernet{port}

--- a/backend/templates/qemu/vjunosswitch.yml
+++ b/backend/templates/qemu/vjunosswitch.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Juniper vJunos-switch
+description: Juniper vJunos-switch
+icon_type: switch
+cpu: 4
+ram: 8192
+ethernet: 11
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -smbios type=1,product=VM-VEX -cpu IvyBridge,ibpb=on,md-clear=on,spec-ctrl=on,ssbd=on,vmx=on
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - em0
+  - ge-0/0/{n}

--- a/backend/templates/qemu/vmx.yml
+++ b/backend/templates/qemu/vmx.yml
@@ -1,0 +1,19 @@
+type: qemu
+name: Juniper vMX
+description: Juniper vMX
+icon_type: router
+cpu: 1
+ram: 2048
+ethernet: 6
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - em0 / fxp0
+  - em1 / Internal use
+  - ge-0/0/{n}

--- a/backend/templates/qemu/vmxvcp.yml
+++ b/backend/templates/qemu/vmxvcp.yml
@@ -1,0 +1,19 @@
+type: qemu
+name: Juniper vMX VCP
+description: Juniper vMX VCP
+icon_type: router
+cpu: 1
+ram: 2048
+ethernet: 2
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - em0 / fxp0
+  - em1 / int
+  - ge-0/0/{n}

--- a/backend/templates/qemu/vmxvfp.yml
+++ b/backend/templates/qemu/vmxvfp.yml
@@ -1,0 +1,19 @@
+type: qemu
+name: Juniper vMX VFP
+description: Juniper vMX VFP
+icon_type: router
+cpu: 3
+ram: 4096
+ethernet: 12
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - em0 / fxp0
+  - em1 / int
+  - ge-0/0/{n}

--- a/backend/templates/qemu/vqfxpfe.yml
+++ b/backend/templates/qemu/vqfxpfe.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Juniper vQFX PFE
+description: Juniper vQFX PFE
+icon_type: switch
+cpu: 2
+ram: 2048
+ethernet: 2
+console_type: vnc
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - em0 / fxp0
+  - em1 / int
+  - xe-0/0/{n}

--- a/backend/templates/qemu/vqfxre.yml
+++ b/backend/templates/qemu/vqfxre.yml
@@ -1,0 +1,21 @@
+type: qemu
+name: Juniper vQFX RE
+description: Juniper vQFX RE
+icon_type: switch
+cpu: 2
+ram: 3072
+ethernet: 15
+console_type: telnet
+architecture: i386
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - em0 / fxp0
+  - em1 / int
+  - em2 / mgmt
+  - xe-0/0/{n}

--- a/backend/templates/qemu/vsrx.yml
+++ b/backend/templates/qemu/vsrx.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Juniper vSRX
+description: Juniper vSRX
+icon_type: firewall
+cpu: 2
+ram: 2048
+ethernet: 4
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - fxp0
+  - ge-0/0/{n}

--- a/backend/templates/qemu/vsrx30.yml
+++ b/backend/templates/qemu/vsrx30.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Juniper vSRX 3.0
+description: Juniper vSRX 3.0
+icon_type: firewall
+cpu: 2
+ram: 4096
+ethernet: 6
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc-1.0,accel=kvm -cpu qemu64,+ssse3,+sse4.1,+sse4.2,+x2apic,+aes,pclmulqdq -nodefconfig -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - fxp0
+  - ge-0/0/{n}

--- a/backend/templates/qemu/vsrxng.yml
+++ b/backend/templates/qemu/vsrxng.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Juniper vSRX NextGen
+description: Juniper vSRX NextGen
+icon_type: firewall
+cpu: 2
+ram: 4096
+ethernet: 4
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -cpu host -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - fxp0
+  - ge-0/0/{n}

--- a/backend/templates/qemu/vtbond.yml
+++ b/backend/templates/qemu/vtbond.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Cisco SD-WAN vBond
+description: Cisco SD-WAN vBond
+icon_type: router
+cpu: 2
+ram: 2048
+ethernet: 2
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -cpu host -vga std -usbdevice tablet -boot order=dc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - eth0
+  - ge0/{n}

--- a/backend/templates/qemu/vtedge.yml
+++ b/backend/templates/qemu/vtedge.yml
@@ -1,0 +1,17 @@
+type: qemu
+name: Cisco SD-WAN vEdge
+description: Cisco SD-WAN vEdge
+icon_type: router
+cpu: 1
+ram: 2048
+ethernet: 5
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -cpu host -vga std -usbdevice tablet -boot order=dc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - eth0
+  - ge0/{n}

--- a/backend/templates/qemu/vtmgmt.yml
+++ b/backend/templates/qemu/vtmgmt.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Cisco SD-WAN vManage
+description: Cisco SD-WAN vManage
+icon_type: server
+cpu: 4
+ram: 16384
+ethernet: 2
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -cpu host -vga std -usbdevice tablet -boot order=dc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/vtsmart.yml
+++ b/backend/templates/qemu/vtsmart.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: Cisco SD-WAN vSmart
+description: Cisco SD-WAN vSmart
+icon_type: router
+cpu: 2
+ram: 2048
+ethernet: 2
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -cpu host -vga std -usbdevice tablet -boot order=dc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/vwlc.yml
+++ b/backend/templates/qemu/vwlc.yml
@@ -1,0 +1,15 @@
+type: qemu
+name: Cisco vWLC
+description: Cisco vWLC
+icon_type: router
+cpu: 1
+ram: 2048
+ethernet: 2
+console_type: telnet
+qemu_options: -machine type=pc,accel=kvm -no-user-config -nodefaults -rtc base=utc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: GigabitEthernet0/0/{n}

--- a/backend/templates/qemu/watchguard.yml
+++ b/backend/templates/qemu/watchguard.yml
@@ -1,0 +1,16 @@
+type: qemu
+name: WatchGuard FireboxV
+description: WatchGuard FireboxV
+icon_type: firewall
+cpu: 2
+ram: 2048
+ethernet: 2
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm -vga std -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: eth{n}

--- a/backend/templates/qemu/win.yml
+++ b/backend/templates/qemu/win.yml
@@ -1,0 +1,14 @@
+type: qemu
+name: Microsoft Windows
+description: Microsoft Windows
+icon_type: server
+cpu: 4
+ram: 4096
+console_type: rdp
+qemu_options: -machine type=pc,accel=kvm -cpu host,+pcid,+kvm_pv_unhalt,+kvm_pv_eoi,hv_spinlocks=0x1fff,hv_vapic,hv_time,hv_reset,hv_vpindex,hv_runtime,hv_relaxed,hv_synic,hv_stimer -vga qxl -usbdevice tablet -boot order=cd
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: Ethernet {port}

--- a/backend/templates/qemu/winserver.yml
+++ b/backend/templates/qemu/winserver.yml
@@ -1,0 +1,14 @@
+type: qemu
+name: Microsoft Windows Server
+description: Microsoft Windows Server
+icon_type: server
+cpu: 4
+ram: 4096
+console_type: rdp
+qemu_options: -machine type=pc,accel=kvm -cpu host,+fsgsbase -vga qxl -usbdevice tablet -boot order=dc
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format: Ethernet {port}

--- a/backend/templates/qemu/xrv.yml
+++ b/backend/templates/qemu/xrv.yml
@@ -1,0 +1,18 @@
+type: qemu
+name: Cisco IOS XRv
+description: Cisco IOS XRv
+icon_type: router
+cpu: 1
+ram: 3072
+ethernet: 4
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -machine type=pc,accel=kvm,usb=off -no-user-config -nodefaults -rtc base=utc,driftfix=slew -global kvm-pit.lost_tick_policy=discard -no-hpet -realtime mlock=off -no-shutdown -boot order=c
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - MgmtEth0/0/CPU0/0
+  - GigabitEthernet0/0/0/{n}

--- a/backend/templates/qemu/xrv9k.yml
+++ b/backend/templates/qemu/xrv9k.yml
@@ -1,0 +1,20 @@
+type: qemu
+name: Cisco IOS XRv 9000
+description: Cisco IOS XRv 9000
+icon_type: router
+cpu: 4
+ram: 16384
+ethernet: 7
+console_type: telnet
+qemu_nic: virtio-net-pci
+qemu_options: -enable-kvm -smbios 'type=1,manufacturer=cisco,product=Cisco IOS XRv 9000' -machine type=pc,accel=kvm,usb=off -no-user-config -nodefaults -rtc base=utc,driftfix=slew -global kvm-pit.lost_tick_policy=discard -no-hpet -realtime mlock=off -no-shutdown -boot order=c -cpu host
+capabilities:
+  machine: pc
+  hotplug: false
+  max_nics: 8
+interface_naming:
+  format:
+  - MgmtEth0/RP0/CPU0/0
+  - Internal use 1
+  - Internal use 2
+  - GigabitEthernet0/0/0/{n}


### PR DESCRIPTION
Expands the built-in node template library from 6 device types to the full common EVE-NG / PNETLab vendor set by adding **73 new QEMU templates** under `backend/templates/qemu/`.

The Templates-v2 pack already conforms to nova-ve's built-in schema (`type` / `capabilities` / `interface_naming`); each template is enriched to the curated built-in structure with a device-appropriate `icon_type` (router 29 / switch 13 / firewall 18 / server 16) and explicit `console_type` (telnet 55 / vnc 19 / rdp 2), preserving the hardware profile, `interface_naming`, `qemu_nic`/`qemu_options`, and `capabilities` verbatim.

**Curated collisions preserved untouched:** `qemu/paloalto.yml` (q35, `max_nics: 25`, e1000 — pinned by `test_builtin_paloalto_template_matches_eve_pnetlab_image_layout`), `qemu/vyos.yml`, `docker/docker.yml`.

**Verification**
- All 76 qemu templates load via `TemplateService` with no `TemplateError`; extras compose and interface names render correctly.
- Template test suite: **102 passed**.

Closes #235