### PR TITLE
Fix fresh-install 403: keep base data dir 0755 for Caddy webroot traversal

### DIFF
--- a/backend/tests/test_deploy_helpers.py
+++ b/backend/tests/test_deploy_helpers.py
@@ -321,6 +321,17 @@ def test_provisioner_no_longer_creates_default_database_password():
     assert 'chmod 0600 "${pw_file}"' in body
 
 
+def test_provisioner_keeps_base_data_dir_world_traversable():
+    # Regression: the credential-hardening pass set /var/lib/nova-ve to 0750,
+    # which locked the caddy user out of the webroot (${BASE_DATA_DIR}/www)
+    # and broke every fresh install with HTTP 403 on "/". The base data dir
+    # must stay 0755; secrets inside it are individually chmod 0600.
+    body = PROVISION_SH.read_text()
+    assert '-m 0750 "${base_data_dir}"' not in body
+    assert 'install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0755 "${base_data_dir}"' in body
+    assert "install -d -o \"${APP_OWNER}\" -g \"${APP_GROUP}\" -m 0755 /var/lib/nova-ve" in body
+
+
 def test_local_rancher_setup_does_not_emit_default_database_url():
     body = (DEPLOY_SCRIPTS / "setup-local-rancher.sh").read_text()
     assert "postgresql+asyncpg://nova:nova" not in body

--- a/deploy/scripts/provision-ubuntu-2604.sh
+++ b/deploy/scripts/provision-ubuntu-2604.sh
@@ -246,7 +246,10 @@ ensure_backend_env() {
   base_data_dir="$(awk -F= '/^BASE_DATA_DIR=/{print $2}' "${ENV_FILE}" | tail -n1)"
   base_data_dir="${base_data_dir:-/var/lib/nova-ve}"
   pw_file="${base_data_dir}/db_password"
-  install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0750 "${base_data_dir}"
+  # 0755 (not 0750): the caddy user must traverse this directory to reach the
+  # webroot at ${base_data_dir}/www; secrets inside (db_password, backend.env)
+  # are individually protected with mode 0600.
+  install -d -o "${APP_OWNER}" -g "${APP_GROUP}" -m 0755 "${base_data_dir}"
   if [[ ! -s "${pw_file}" ]]; then
     db_password="$(generate_urlsafe_secret 24)"
     install -m 0600 -o "${APP_OWNER}" -g "${APP_GROUP}" /dev/null "${pw_file}"


### PR DESCRIPTION
## Problem

Every fresh install since the credential-hardening merge (#234) ends with the web UI returning **HTTP 403 on `/`** while `/api/*` and `/html5/` work. The install smoke check fails its index-page loop 20/20 times.

## Root cause

`ensure_backend_env` (added in 08b2c34) runs `install -d -o nova-ve -g nova-ve -m 0750 "${base_data_dir}"` **unconditionally**, and it executes *after* the main provisioning step that creates `/var/lib/nova-ve` with 0755. `install -d` re-applies mode/ownership on an existing directory, so the base dir ends up 0750. The `caddy` user (not in the `nova-ve` group) can then no longer traverse into the webroot `/var/lib/nova-ve/www` → `file_server` returns 403 for the SPA.

## Fix

Use `-m 0755` (matching the main provisioning line) with a comment explaining why. Secrecy is unaffected: `db_password` and `/etc/nova-ve/backend.env` are individually mode 0600.

## Verification

- Reproduced on a fresh Ubuntu 26.04 install: `/` → 403, `namei -l` showed `drwxr-x--- nova-ve nova-ve nova-ve` blocking traversal at `/var/lib/nova-ve`.
- Live fix on the same host: `chmod 0755 /var/lib/nova-ve` → `/` returns 200 and the **full smoke-check passes** (`nova-ve smoke checks passed`), including admin login with the generated password.
- Added a static regression test (`test_provisioner_keeps_base_data_dir_world_traversable`); `tests/test_deploy_helpers.py` → 20 passed.