### PR TITLE
Install required QEMU/iproute2 packages; make install-time demo images alpine-only (#230)

### DIFF
--- a/backend/tests/test_deploy_helpers.py
+++ b/backend/tests/test_deploy_helpers.py
@@ -321,6 +321,28 @@ def test_provisioner_no_longer_creates_default_database_password():
     assert 'chmod 0600 "${pw_file}"' in body
 
 
+def test_provisioner_installs_required_runtime_packages():
+    # Issue #230: the backend defaults to /usr/bin/qemu-system-x86_64 and
+    # /usr/bin/qemu-img, but the provisioner never installed the packages
+    # providing them, so QEMU nodes failed on a clean install. iproute2
+    # provides the ip/bridge binaries the backend and nova-ve-net.py shell
+    # out to; pin it explicitly rather than relying on the base image.
+    body = PROVISION_SH.read_text()
+    assert "qemu-system-x86 \\" in body
+    assert "qemu-utils \\" in body
+    assert "iproute2 \\" in body
+
+
+def test_demo_image_build_excludes_heavy_images():
+    # Install-time demo images are alpine-only; the Ubuntu XFCE desktop
+    # image is documented as a manual build instead.
+    body = (DEPLOY_SCRIPTS / "build-demo-images.sh").read_text()
+    assert 'build_demo_image "nova-ve/alpine-telnet:latest"' in body
+    assert 'build_demo_image "nova-ve/alpine-vnc:latest"' in body
+    assert 'build_demo_image "nova-ve/ubuntu-2604-xfce-vnc' not in body
+    assert 'pull_if_missing "ubuntu:26.04"' not in body
+
+
 def test_provisioner_keeps_base_data_dir_world_traversable():
     # Regression: the credential-hardening pass set /var/lib/nova-ve to 0750,
     # which locked the caddy user out of the webroot (${BASE_DATA_DIR}/www)

--- a/deploy/demo-images/ubuntu-2604-xfce-vnc/Dockerfile
+++ b/deploy/demo-images/ubuntu-2604-xfce-vnc/Dockerfile
@@ -35,9 +35,7 @@ RUN set -eux; \
       xterm \
       xvfb \
       xfce4 \
-      xfce4-goodies \
-      xfce4-terminal \
-      xubuntu-desktop-minimal; \
+      xfce4-terminal; \
     rm -f /usr/sbin/policy-rc.d; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*

--- a/deploy/scripts/build-demo-images.sh
+++ b/deploy/scripts/build-demo-images.sh
@@ -9,9 +9,13 @@
 #                                     lab option once marked)
 #   - nova-ve/alpine-telnet:latest   (telnet console demo, see #181)
 #   - nova-ve/alpine-vnc:latest      (VNC desktop demo)
-#   - nova-ve/ubuntu-2604-xfce-vnc:latest
-#                                    (Ubuntu 26.04 XFCE/VNC demo with
-#                                     NetworkManager for lab links)
+#
+# Heavier demo images (e.g. the Ubuntu 26.04 XFCE/VNC desktop under
+# deploy/demo-images/ubuntu-2604-xfce-vnc/) are intentionally NOT built at
+# install time. Build one manually when needed:
+#   docker build -t nova-ve/ubuntu-2604-xfce-vnc:latest \
+#     deploy/demo-images/ubuntu-2604-xfce-vnc
+# then mark it for lab use from the admin UI (or tag it under nova-ve-lab/).
 #
 # Marker convention: every image listed above also gets a
 # ``nova-ve-lab/<sanitized>:<tag>`` reverse tag. The backend's image catalog
@@ -113,12 +117,10 @@ build_demo_image() {
 
 # 1. Base images.
 pull_if_missing "alpine:3.22"
-pull_if_missing "ubuntu:26.04"
 
 # 2. Demo images.
 build_demo_image "nova-ve/alpine-telnet:latest" "${REPO_ROOT}/deploy/demo-images/alpine-telnet"
 build_demo_image "nova-ve/alpine-vnc:latest"    "${REPO_ROOT}/deploy/demo-images/alpine-vnc"
-build_demo_image "nova-ve/ubuntu-2604-xfce-vnc:latest" "${REPO_ROOT}/deploy/demo-images/ubuntu-2604-xfce-vnc"
 
 # 3. Mark everything for lab availability so the add-node modal sees them by
 # default. Operators can ``Unmark`` from the admin UI if they want a cleaner
@@ -126,6 +128,5 @@ build_demo_image "nova-ve/ubuntu-2604-xfce-vnc:latest" "${REPO_ROOT}/deploy/demo
 mark_for_lab "alpine:3.22"
 mark_for_lab "nova-ve/alpine-telnet:latest"
 mark_for_lab "nova-ve/alpine-vnc:latest"
-mark_for_lab "nova-ve/ubuntu-2604-xfce-vnc:latest"
 
 echo "build-demo-images: done." >&2

--- a/deploy/scripts/provision-ubuntu-2604.sh
+++ b/deploy/scripts/provision-ubuntu-2604.sh
@@ -505,10 +505,13 @@ run apt-get install -y --no-install-recommends \
   docker-compose-v2 \
   dnsmasq \
   nftables \
+  iproute2 \
   python3 \
   python3-venv \
   nodejs \
   npm \
+  qemu-system-x86 \
+  qemu-utils \
   cmake \
   libelf-dev \
   libpcap-dev

--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,7 @@
 #   3. Runs deploy/scripts/provision-ubuntu-2604.sh which:
 #        - installs all OS packages: docker.io, docker-compose-v2, postgresql,
 #          caddy, nodejs+npm, python3+venv, build-essential, libpq-dev, jq,
-#          openssl, dnsmasq, nftables, qemu/kvm tooling (pulled in
-#          transitively by the helper);
+#          openssl, dnsmasq, nftables, iproute2, qemu-system-x86, qemu-utils;
 #        - creates /var/lib/nova-ve/{labs,images,tmp,guacamole,runtime,www};
 #        - generates random secrets into /etc/nova-ve/backend.env;
 #        - bootstraps the host postgres role/db (nova/nova/novadb);


### PR DESCRIPTION
Fixes #230.

## QEMU packages (the actual #230 bug)

The backend defaults to `/usr/bin/qemu-system-x86_64` and `/usr/bin/qemu-img`, but `provision-ubuntu-2604.sh` never installed the packages providing them — QEMU nodes failed after a clean install. Added to the apt list:

- `qemu-system-x86` (also provides `qemu-system-i386`, used by the i386 built-in templates)
- `qemu-utils`

`qemu-system-arm` (for the optional `aarch64` template arch) is intentionally not bundled; `_resolve_qemu_binary` falls back gracefully and operators can install it when needed.

## Explicit runtime utilities, no junk

- Pinned `iproute2` explicitly: the backend resolves `ip`/`bridge` via `shutil.which` and `nova-ve-net.py` shells out to `ip` — installs must not depend on the base image including it.
- Audited every host binary the system invokes (docker, dnsmasq, nft, ip/bridge, psql/pg_isready, openssl, jq, caddy, node/npm, dynamips build deps) against the apt list: nothing else missing, nothing superfluous. All host `apt-get install` calls already use `--no-install-recommends`.
- Fixed install.sh's package-list comment which falsely claimed qemu/kvm tooling was "pulled in transitively".

## Demo images: alpine-only at install time

The "full XFCE install" seen during installs was the `nova-ve/ubuntu-2604-xfce-vnc` Docker image build (`xubuntu-desktop-minimal` etc. inside the container, not on the host). Per review:

- `build-demo-images.sh` now builds/marks only `alpine:3.22`, `nova-ve/alpine-telnet`, `nova-ve/alpine-vnc`; it no longer pulls `ubuntu:26.04`.
- The XFCE Dockerfile stays in-repo as a documented manual build, and is trimmed of `xfce4-goodies`/`xubuntu-desktop-minimal` (the entrypoint only needs `startxfce4` from the `xfce4` meta plus `xfce4-terminal`).

## Tests

- `test_provisioner_installs_required_runtime_packages` and `test_demo_image_build_excludes_heavy_images` added.
- Full backend suite: 1123 passed, 3 skipped.