### PR TITLE
Defer bridge-cloud reboot so the install summary is always written

### DIFF
--- a/backend/tests/test_deploy_helpers.py
+++ b/backend/tests/test_deploy_helpers.py
@@ -343,6 +343,34 @@ def test_demo_image_build_excludes_heavy_images():
     assert 'pull_if_missing "ubuntu:26.04"' not in body
 
 
+def test_provisioner_defers_bridge_cloud_reboot_to_installer():
+    # Regression: the bridge-cloud naming flip used to reboot inline at the end
+    # of provisioning, killing install.sh before it wrote the install summary
+    # (the only on-disk copy of the generated admin password). Under
+    # NOVA_VE_BRIDGE_CLOUD_DEFER_REBOOT=1 the provisioner must drop a sentinel
+    # and return instead of rebooting, leaving the reboot to install.sh.
+    body = PROVISION_SH.read_text()
+    assert '"${NOVA_VE_BRIDGE_CLOUD_DEFER_REBOOT:-0}" == "1"' in body
+    assert ': > "${BRIDGE_CLOUD_REBOOT_SENTINEL}"' in body
+    # The actual reboot lives in a helper the defer branch does NOT call.
+    assert "bridge_cloud_reboot_now()" in body
+    assert "BRIDGE_CLOUD_REBOOT_SENTINEL=" in body
+
+
+def test_installer_reboots_after_writing_summary():
+    # install.sh must request the deferred reboot and only perform it after the
+    # summary file (and credentials banner) are written, using the same tmpfs
+    # sentinel path the provisioner drops.
+    body = INSTALL_SH.read_text()
+    assert "NOVA_VE_BRIDGE_CLOUD_DEFER_REBOOT=1" in body
+    assert 'REBOOT_SENTINEL="/run/nova-ve-bridge-cloud-reboot-pending"' in body
+    # The reboot guard must appear AFTER the summary is written to disk.
+    summary_pos = body.index('chmod 0600 "${SUMMARY_PATH}"')
+    reboot_pos = body.index('if [[ -e "${REBOOT_SENTINEL}" ]]; then')
+    assert summary_pos < reboot_pos
+    assert "systemctl reboot --ignore-inhibitors --no-block" in body
+
+
 def test_provisioner_keeps_base_data_dir_world_traversable():
     # Regression: the credential-hardening pass set /var/lib/nova-ve to 0750,
     # which locked the caddy user out of the webroot (${BASE_DATA_DIR}/www)

--- a/deploy/scripts/provision-ubuntu-2604.sh
+++ b/deploy/scripts/provision-ubuntu-2604.sh
@@ -17,6 +17,10 @@ CADDY_TEMPLATE="${REPO_ROOT}/deploy/templates/Caddyfile.tpl"
 BACKEND_SERVICE_TEMPLATE="${REPO_ROOT}/deploy/templates/nova-ve-backend.service.tpl"
 PYTHON_BIN="${NOVA_VE_PYTHON_BIN:-python3}"
 GUACAMOLE_COMPOSE_SCRIPT="${REPO_ROOT}/deploy/scripts/run-guacamole.sh"
+# tmpfs sentinel the bridge-cloud flip drops when it defers its reboot to the
+# installer wrapper (see bridge_cloud_flip / install.sh).  On /run so it is
+# cleared automatically on the next boot.  install.sh must use the same path.
+BRIDGE_CLOUD_REBOOT_SENTINEL="${NOVA_VE_BRIDGE_CLOUD_REBOOT_SENTINEL:-/run/nova-ve-bridge-cloud-reboot-pending}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -930,6 +934,26 @@ bridge_cloud_flip() {
   source /opt/nova-ve/bin/nova-ve-marker.sh
   _write_marker_atomic naming-flipped
 
+  # When invoked by install.sh (NOVA_VE_BRIDGE_CLOUD_DEFER_REBOOT=1) we do NOT
+  # reboot here: the wrapper still has to write nova-ve-install-summary.md (the
+  # only on-disk record of the generated admin password) and print the
+  # credentials banner.  Rebooting inline races that work and usually wins, so
+  # fresh installs ended up with no summary on disk.  Instead we drop a tmpfs
+  # sentinel (auto-cleared on the next boot) and let install.sh run the
+  # countdown + reboot as its very last step.  Standalone provisioner runs
+  # leave the flag unset and reboot inline exactly as before.
+  if [[ "${NOVA_VE_BRIDGE_CLOUD_DEFER_REBOOT:-0}" == "1" ]]; then
+    : > "${BRIDGE_CLOUD_REBOOT_SENTINEL}"
+    echo "bridge-cloud: naming flip staged; reboot deferred to installer."
+    return 0
+  fi
+
+  bridge_cloud_reboot_now
+}
+
+# Print the abort banner, count down, then reboot.  Shared by the standalone
+# provisioner path and by install.sh's deferred-reboot path.
+bridge_cloud_reboot_now() {
   echo
   echo "==============================================================="
   echo "  bridge-cloud: reboot required to apply the iface naming flip"
@@ -1038,4 +1062,7 @@ fi
 # Bridge-Cloud naming flip + post-boot scaffolding.  Always-on with a
 # 30-second Ctrl-C abort window per plan §2 D4.  Re-runs on already-
 # migrated hosts log "already migrated" and return without rebooting.
+# When run under install.sh the actual reboot is deferred to the wrapper
+# (NOVA_VE_BRIDGE_CLOUD_DEFER_REBOOT=1) so the install summary is written
+# first; standalone runs reboot inline.
 bridge_cloud_flip

--- a/install.sh
+++ b/install.sh
@@ -162,9 +162,16 @@ if [[ ! -x "${PROVISIONER}" ]]; then
 fi
 
 log "Running ${PROVISIONER} (this can take 10-20 min on a fresh box)..."
+# Defer the bridge-cloud naming-flip reboot back to us: the provisioner stages
+# the flip and drops ${REBOOT_SENTINEL} instead of rebooting inline, so we can
+# write the install summary (the only on-disk copy of the generated admin
+# password) and print the credentials banner before the host goes down.
+REBOOT_SENTINEL="/run/nova-ve-bridge-cloud-reboot-pending"
 NOVA_VE_SERVICE_USER="${APP_OWNER}" \
 NOVA_VE_OWNER="${APP_OWNER}" \
 NOVA_VE_REPO_DIR="${REPO_DIR}" \
+NOVA_VE_BRIDGE_CLOUD_DEFER_REBOOT=1 \
+NOVA_VE_BRIDGE_CLOUD_REBOOT_SENTINEL="${REBOOT_SENTINEL}" \
 SUDO_USER="${APP_OWNER}" \
 bash "${PROVISIONER}"
 
@@ -336,3 +343,26 @@ cat <<EOF
  Admin:   ${NOVA_VE_ADMIN_USERNAME} / ${NOVA_VE_ADMIN_PASSWORD}
 ==========================================================================
 EOF
+
+# Deferred bridge-cloud reboot. The provisioner staged the iface naming flip
+# and asked us to reboot (sentinel on tmpfs, cleared on the next boot). We do
+# it now -- AFTER the summary is on disk and the credentials are printed -- so
+# the operator never loses the generated admin password to a premature reboot.
+if [[ -e "${REBOOT_SENTINEL}" ]]; then
+  rm -f "${REBOOT_SENTINEL}"
+  cat <<EOF
+
+==========================================================================
+ A reboot is required to apply the bridge-cloud interface naming flip.
+ Your credentials are saved at ${SUMMARY_PATH} and in ${ENV_FILE}.
+ Press Ctrl-C within 30 seconds to abort the reboot.
+==========================================================================
+EOF
+  for i in $(seq 30 -1 1); do
+    printf '[install.sh] reboot in %ss -- Ctrl-C to abort\n' "${i}"
+    sleep 1
+  done
+  # --ignore-inhibitors overrides block-mode inhibitors (e.g. the
+  # unattended-upgrades-shutdown lock); --no-block lets systemd-shutdown run.
+  systemctl reboot --ignore-inhibitors --no-block || systemctl --force --force reboot
+fi


### PR DESCRIPTION
## Problem

On a fresh install the bridge-cloud naming flip reboots the host inline at the very end of `provision-ubuntu-2604.sh`. But `install.sh` writes `nova-ve-install-summary.md` — the only on-disk record of the generated admin password — **after** the provisioner returns. The inline reboot raced that step and usually won, so fresh installs ended up with **no summary on disk** and the operator lost the printed credentials on reboot. Confirmed on a fresh `.215` install: no summary file anywhere, host already rebooted (`bridge-cloud.state: complete`).

## Fix

- Provisioner honours `NOVA_VE_BRIDGE_CLOUD_DEFER_REBOOT=1`: stages the flip, drops a tmpfs sentinel (`/run/nova-ve-bridge-cloud-reboot-pending`, auto-cleared next boot) and returns instead of rebooting. The reboot moved into a `bridge_cloud_reboot_now` helper.
- `install.sh` sets that flag, writes the summary + prints the credentials banner, then runs the 30s-countdown reboot as its **final** step when the sentinel is present.
- Standalone provisioner runs (operator re-runs without install.sh) leave the flag unset and reboot inline exactly as before. Already-migrated re-runs never reach the flip, so no sentinel is dropped and install.sh doesn't reboot them.

## Verification

- Simulated both paths (defer=1 → sentinel written, install.sh writes summary first then reboots, sentinel cleared; defer unset → inline reboot, no sentinel).
- `bash -n` clean on both scripts.
- Regression tests added pinning the defer branch and the summary-before-reboot ordering; `tests/test_deploy_helpers.py` → 24 passed.